### PR TITLE
fix: prevent API key exposure in cage environment variables

### DIFF
--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -220,8 +220,12 @@ def load_config(path: str) -> Config:
                 inject_to=list(entry.get("inject_to") or []),
             ))
 
-    # Remove injected secrets from podman_secrets (they're handled separately)
+    # Remove injected secrets from podman_secrets and env — they are handled
+    # separately via placeholder substitution in the proxy.  Leaving them in
+    # env would expose the real value inside the cage (os.path.expandvars
+    # expands ${VAR} references during quadlet generation).
     cc.podman_secrets = [s for s in cc.podman_secrets if s not in injected_names]
+    cc.env = {k: v for k, v in cc.env.items() if k not in injected_names}
 
     # DNS servers (default to host resolvers if not specified)
     cfg.dns_servers = list(raw.get("dns_servers") or _host_dns_servers())

--- a/src/agentcage/data/firecracker/vm-init.sh
+++ b/src/agentcage/data/firecracker/vm-init.sh
@@ -116,6 +116,12 @@ if [[ -n "$SECRETS_DEV" ]]; then
         podman secret create "$local_name" "$f" || true
         echo "agentcage-vm: loaded secret $local_name"
     done
+
+    # Unmount and remove the secrets drive — secrets are now in the Podman
+    # secret store; keeping the mount would expose plain-text values on disk.
+    umount /mnt/secrets
+    rm -rf /mnt/secrets
+    echo "agentcage-vm: secrets drive unmounted"
 else
     echo "agentcage-vm: no secrets drive found"
 fi

--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -33,10 +33,10 @@ Secret={{ deploy_name }}.{{ secret }},type=env,target={{ secret }}
 Secret={{ secret }},type=env
 {% endif %}
 {% endfor %}
-{% for key, val in cage_placeholders %}
+{% for key, val in env.items() %}
 Environment="{{ key }}={{ val }}"
 {% endfor %}
-{% for key, val in env.items() %}
+{% for key, val in cage_placeholders %}
 Environment="{{ key }}={{ val }}"
 {% endfor %}
 {% if user %}


### PR DESCRIPTION
Three security fixes for secret leakage into the cage:

1. config.py: Strip secret_injection env names from container.env
   (matching existing podman_secrets behavior). Previously, if the
   same key appeared in both env and secret_injection, the real value
   from os.path.expandvars() would override the placeholder.

2. cage.container.j2: Reorder so cage_placeholders render AFTER env
   (defense in depth). Later Environment= lines override earlier ones
   in systemd, so placeholders now always win over any env overlap.

3. vm-init.sh: Unmount and remove the secrets drive after loading
   secrets into the Podman store. Previously the drive stayed mounted
   at /mnt/secrets, leaving plain-text secret values on disk.

https://claude.ai/code/session_017GwWsVw4qJk6QuKwDFn9Ne