### PR TITLE
Fix P0 security findings: header inspection + base64 evasion

### DIFF
--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -452,7 +452,7 @@ class Agentcage:
             url=flow.request.url,
             host=host,
             method="WEBSOCKET",
-            headers=dict(flow.request.headers),
+            headers=list(flow.request.headers.items(multi=True)),
             content_type="application/x-websocket-frame",
             body_bytes=body_bytes,
             body_text=body_text,
@@ -529,12 +529,12 @@ class Agentcage:
             body_bytes = flow.response.content
             body_text = flow.response.get_text(strict=False)
             content_type = flow.response.headers.get("content-type", "")
-            headers = dict(flow.response.headers)
+            headers = list(flow.response.headers.items(multi=True))
         else:
             body_bytes = flow.request.content
             body_text = flow.request.get_text(strict=False)
             content_type = flow.request.headers.get("content-type", "")
-            headers = dict(flow.request.headers)
+            headers = list(flow.request.headers.items(multi=True))
 
         body_size = len(body_bytes) if body_bytes else 0
         body_ent = shannon_entropy(body_bytes) if body_bytes else None

--- a/src/agentcage/data/proxy/inspectors/base.py
+++ b/src/agentcage/data/proxy/inspectors/base.py
@@ -25,7 +25,7 @@ class InspectionContext:
     url: str
     host: str
     method: str
-    headers: dict[str, str]
+    headers: list[tuple[str, str]]
     content_type: str
     body_bytes: Optional[bytes]
     body_text: Optional[str]

--- a/src/agentcage/data/proxy/inspectors/content_type.py
+++ b/src/agentcage/data/proxy/inspectors/content_type.py
@@ -24,7 +24,7 @@ _TEXT_CT_PREFIXES = (
 )
 
 # Base64: almost exclusively [A-Za-z0-9+/=\s]
-_BASE64_RE = re.compile(r"^[A-Za-z0-9+/=\s]{64,}$", re.MULTILINE)
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/=\-_\s]{64,}$", re.MULTILINE)
 
 
 class ContentTypeInspector(Inspector):

--- a/src/agentcage/data/proxy/inspectors/secrets.py
+++ b/src/agentcage/data/proxy/inspectors/secrets.py
@@ -93,7 +93,7 @@ class SecretsInspector(Inspector):
     ) -> Optional[InspectionResult]:
         if not self.enabled:
             return None
-        targets = [ctx.url, str(ctx.headers)]
+        targets = [ctx.url] + [v for _, v in ctx.headers]
         if ctx.body_text:
             targets.append(ctx.body_text)
         host = ctx.host.lower()

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -78,7 +78,7 @@ class TestLoadInspectorFromFile:
             url="https://example.com",
             host="example.com",
             method="POST",
-            headers={},
+            headers=[],
             content_type="text/plain",
             body_bytes=b"contains SECRET data",
             body_text="contains SECRET data",

--- a/tests/test_inspectors.py
+++ b/tests/test_inspectors.py
@@ -30,7 +30,7 @@ def _ctx(
         url=url,
         host=host,
         method=method,
-        headers=headers or {},
+        headers=headers or [],
         content_type=content_type,
         body_bytes=body_bytes,
         body_text=body_text,
@@ -398,6 +398,37 @@ class TestSecretsInspector:
         assert s.allow_to_domains["anthropic_key"] == ["my-proxy.example.com"]
         # No built-in entries for keys the user didn't specify
         assert "openai_key" not in s.allow_to_domains
+
+    def test_detects_secret_in_duplicate_header(self):
+        """Multi-value headers: secret in a later value must still be caught."""
+        s = SecretsInspector()
+        s.configure({"enabled": True})
+        ctx = _ctx(
+            headers=[
+                ("authorization", "Bearer safe-token"),
+                ("x-custom", "sk-ant-abcdefghijklmnopqrstuvwxyz"),
+            ],
+            host="evil.com",
+        )
+        r = s.inspect_request(ctx)
+        assert r is not None
+        assert r.action == "block"
+        assert "anthropic_key" in r.reason
+
+    def test_detects_secret_in_repeated_header_value(self):
+        """When the same header appears twice, both values are scanned."""
+        s = SecretsInspector()
+        s.configure({"enabled": True})
+        ctx = _ctx(
+            headers=[
+                ("x-data", "harmless"),
+                ("x-data", "sk-ant-abcdefghijklmnopqrstuvwxyz"),
+            ],
+            host="evil.com",
+        )
+        r = s.inspect_request(ctx)
+        assert r is not None
+        assert "anthropic_key" in r.reason
 
 
 # ── BodySizeInspector ────────────────────────────────────
@@ -829,6 +860,27 @@ class TestContentTypeInspector:
             body_entropy=4.0,
         )
         assert ct.inspect_request(ctx) is None
+
+    def test_detects_url_safe_base64_blob(self):
+        """URL-safe base64 uses -_ instead of +/ — must still be caught."""
+        ct = ContentTypeInspector()
+        ct.configure({
+            "entropy_ceiling": 6.5,
+            "detect_base64": True,
+            "base64_min_len": 64,
+            "action": "flag",
+        })
+        # URL-safe base64 with - and _ characters
+        b64_line = "ABCDEFgh-_ABCDEFgh-_" * 20  # 400 chars
+        body = f"preamble\n{b64_line}\npostamble"
+        ctx = _ctx(
+            content_type="text/plain",
+            body_text=body,
+            body_entropy=4.0,
+        )
+        r = ct.inspect_request(ctx)
+        assert r is not None
+        assert "base64" in r.reason
 
     def test_no_body(self):
         ct = ContentTypeInspector()


### PR DESCRIPTION
## Summary

- **N1+M4**: `InspectionContext.headers` was `dict[str, str]`, which silently dropped duplicate HTTP header values (e.g. multiple `Set-Cookie` or `X-Forwarded-For`). An attacker could hide secrets in the second value of a repeated header to bypass inspection. Additionally, the secrets inspector scanned headers via `str(ctx.headers)` which produced a Python repr string — fragile for regex matching. Changed headers to `list[tuple[str, str]]` using `items(multi=True)` and scan each header value individually.
- **M1**: The base64 blob detection regex only matched standard base64 (`+/=`), missing URL-safe base64 (`-_`). Exfiltrated data encoded with `urlsafe_b64encode` bypassed the content-type mismatch inspector. Extended the regex character class to include `-_`.

## Test plan

- [x] All 522 existing tests pass
- [x] New test: secret detection in duplicate/repeated headers
- [x] New test: URL-safe base64 blob detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)