### PR TITLE
Add github.com to allow_to_domains for GitHub token patterns

### DIFF
--- a/src/agentcage/data/proxy/inspectors/secrets.py
+++ b/src/agentcage/data/proxy/inspectors/secrets.py
@@ -34,6 +34,8 @@ BUILTIN_ALLOW_TO_DOMAINS = {
     "openai_key": ["openai.com"],
     "anthropic_key": ["anthropic.com"],
     "aws_access_key": ["amazonaws.com"],
+    "github_token": ["github.com"],
+    "github_pat": ["github.com"],
     "google_api_key": ["googleapis.com", "google.com"],
     "slack_token": ["slack.com"],
     "stripe_key": ["stripe.com"],


### PR DESCRIPTION
## Summary

- `github_token` (`ghp_`/`ghs_`) and `github_pat` (`github_pat_`) are correctly detected by the secrets inspector, but `BUILTIN_ALLOW_TO_DOMAINS` has no entries for either pattern
- This means legitimate GitHub API calls (e.g. `ghp_` token sent to `api.github.com`) are blocked by the inspector even though the token is going to its intended destination
- Adds `"github.com"` as an allowed domain for both patterns, matching the convention used by other providers (`openai_key` → `openai.com`, `stripe_key` → `stripe.com`, etc.)

## Test

Tested on v0.6.0 (Ubuntu 24.04, Podman 4.9.3):

1. Created a cage with `api.github.com` in the domain allowlist
2. Sent a real-length `ghp_` token to `https://api.github.com/user` via POST body
3. **Before fix:** Request blocked with `secret detected: github_token` (HTTP 403)
4. **After fix:** Request allowed through to `api.github.com` (token is going to its legitimate destination)

Non-GitHub destinations are still blocked as expected.