### PR TITLE
Fix GitHub tokens blocked when sent to github.com

### DIFF
--- a/src/agentcage/data/proxy/inspectors/secrets.py
+++ b/src/agentcage/data/proxy/inspectors/secrets.py
@@ -34,6 +34,8 @@ BUILTIN_ALLOW_TO_DOMAINS = {
     "openai_key": ["openai.com"],
     "anthropic_key": ["anthropic.com"],
     "aws_access_key": ["amazonaws.com"],
+    "github_token": ["github.com", "githubusercontent.com"],
+    "github_pat": ["github.com", "githubusercontent.com"],
     "google_api_key": ["googleapis.com", "google.com"],
     "slack_token": ["slack.com"],
     "stripe_key": ["stripe.com"],

--- a/tests/test_inspectors.py
+++ b/tests/test_inspectors.py
@@ -399,6 +399,42 @@ class TestSecretsInspector:
         # No built-in entries for keys the user didn't specify
         assert "openai_key" not in s.allow_to_domains
 
+    def test_builtin_allow_lets_github_token_through(self):
+        """ghp_ token to api.github.com should be allowed."""
+        s = SecretsInspector()
+        s.configure({"enabled": True})
+        token = "ghp_" + "A" * 36
+        ctx = _ctx(
+            headers=[("authorization", f"Bearer {token}")],
+            host="api.github.com",
+        )
+        assert s.inspect_request(ctx) is None
+
+    def test_builtin_allow_lets_github_pat_through(self):
+        """github_pat_ token to api.github.com should be allowed."""
+        s = SecretsInspector()
+        s.configure({"enabled": True})
+        token = "github_pat_" + "A" * 22
+        ctx = _ctx(
+            headers=[("authorization", f"Bearer {token}")],
+            host="api.github.com",
+        )
+        assert s.inspect_request(ctx) is None
+
+    def test_builtin_allow_blocks_github_token_to_wrong_domain(self):
+        """ghp_ token to evil.com should be blocked."""
+        s = SecretsInspector()
+        s.configure({"enabled": True})
+        token = "ghp_" + "A" * 36
+        ctx = _ctx(
+            headers=[("authorization", f"Bearer {token}")],
+            host="evil.com",
+        )
+        r = s.inspect_request(ctx)
+        assert r is not None
+        assert r.action == "block"
+        assert "github_token" in r.reason
+
     def test_detects_secret_in_duplicate_header(self):
         """Multi-value headers: secret in a later value must still be caught."""
         s = SecretsInspector()


### PR DESCRIPTION
## Summary
- Add `github_token` and `github_pat` entries to `BUILTIN_ALLOW_TO_DOMAINS` so `ghp_`/`ghs_`/`github_pat_` tokens are allowed through to `github.com` and `githubusercontent.com`
- Add 3 tests covering allowed and blocked scenarios

Fixes #15

## Test plan
- [x] `ghp_` token to `api.github.com` → allowed
- [x] `github_pat_` token to `api.github.com` → allowed
- [x] `ghp_` token to `evil.com` → blocked
- [x] All 78 tests pass (`uv run pytest tests/test_inspectors.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)