### PR TITLE
Fix cage verify false egress failure on images without curl or node

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -592,6 +592,7 @@ def cage_verify(name: str):
 
     passed = 0
     failed = 0
+    warned = 0
 
     def _pass(msg: str):
         nonlocal passed
@@ -602,6 +603,11 @@ def cage_verify(name: str):
         nonlocal failed
         click.echo(f"  [FAIL] {msg}")
         failed += 1
+
+    def _warn(msg: str):
+        nonlocal warned
+        click.echo(f"  [WARN] {msg}")
+        warned += 1
 
     click.echo(f"=== agentcage verify: {name} ({cfg.isolation}) ===")
     click.echo()
@@ -616,19 +622,19 @@ def cage_verify(name: str):
             _fail(f"{name}-{svc} is NOT running")
 
     if cfg.isolation == "container":
-        _verify_container(name, _pass, _fail)
+        _verify_container(name, _pass, _fail, _warn)
     else:
         _verify_firecracker(name, _pass, _fail)
 
     # Summary
     click.echo()
-    click.echo(f"=== Results: {passed} passed, {failed} failed, 0 warnings ===")
+    click.echo(f"=== Results: {passed} passed, {failed} failed, {warned} warnings ===")
     if failed > 0:
         click.echo("    Review failures above.")
         sys.exit(1)
 
 
-def _verify_container(name: str, _pass, _fail):
+def _verify_container(name: str, _pass, _fail, _warn):
     """Container-specific health checks (exec into host containers)."""
     podman = Podman()
 
@@ -669,7 +675,8 @@ def _verify_container(name: str, _pass, _fail):
     click.echo()
     click.echo("-- Egress Filtering --")
     try:
-        # Try curl first, fall back to node's fetch if curl isn't available
+        # Try curl first, fall back to node, then python3 urllib
+        status = ""
         exit_code, output = podman.container_exec(
             f"{name}-cage", ["which", "curl"]
         )
@@ -689,8 +696,27 @@ def _verify_container(name: str, _pass, _fail):
                  ".then(r=>console.log(r.status))"
                  ".catch(()=>console.log('000'))"],
             )
-            status = output.strip()
-        if status in ("403", "000"):
+            if exit_code == 0 and output.strip():
+                status = output.strip()
+            else:
+                # Use python3 urllib as last resort
+                exit_code, output = podman.container_exec(
+                    f"{name}-cage",
+                    ["python3", "-c",
+                     "import urllib.request, urllib.error\n"
+                     "try:\n"
+                     "    urllib.request.urlopen('https://evil-exfil-server.io', timeout=5)\n"
+                     "    print('200')\n"
+                     "except urllib.error.HTTPError as e:\n"
+                     "    print(e.code)\n"
+                     "except Exception:\n"
+                     "    print('000')"],
+                )
+                if exit_code == 0 and output.strip():
+                    status = output.strip()
+        if not status:
+            _warn("No HTTP client (curl/node/python3) in cage — cannot verify egress filtering")
+        elif status in ("403", "000"):
             _pass(f"Blocked domain (evil-exfil-server.io) is denied (HTTP {status})")
         else:
             _fail(f"Blocked domain returned HTTP {status} — egress filtering may be broken")

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -367,6 +367,61 @@ class TestCageVerify:
         assert result.exit_code != 0
         assert "FAIL" in result.output
 
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_verify_egress_python_fallback(self, mock_state, mock_get_backend, MockPodman):
+        """When curl and node are missing, python3 urllib fallback works."""
+        mock_state.load_deployment_config.return_value = _mock_config("container")
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        podman = MockPodman.return_value
+        podman.container_exec.side_effect = [
+            (0, ""),            # test -f /certs/...
+            (1, ""),            # which curl → not found
+            (1, ""),            # node fallback → fails
+            (0, "403\n"),       # python3 urllib → 403
+        ]
+        podman.container_inspect.return_value = {
+            "Config": {"Env": ["HTTP_PROXY=http://x", "HTTPS_PROXY=http://x"]}
+        }
+        podman.info.return_value = {
+            "host": {"security": {"rootless": True}}
+        }
+        result = _runner().invoke(main, ["cage", "verify", "test"])
+        assert result.exit_code == 0
+        assert "PASS" in result.output
+        assert "403" in result.output
+
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_verify_egress_no_client_warns(self, mock_state, mock_get_backend, MockPodman):
+        """When no HTTP client is available, verify warns instead of failing."""
+        mock_state.load_deployment_config.return_value = _mock_config("container")
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        podman = MockPodman.return_value
+        podman.container_exec.side_effect = [
+            (0, ""),            # test -f /certs/...
+            (1, ""),            # which curl → not found
+            (1, ""),            # node fallback → fails
+            (1, ""),            # python3 fallback → fails
+        ]
+        podman.container_inspect.return_value = {
+            "Config": {"Env": ["HTTP_PROXY=http://x", "HTTPS_PROXY=http://x"]}
+        }
+        podman.info.return_value = {
+            "host": {"security": {"rootless": True}}
+        }
+        result = _runner().invoke(main, ["cage", "verify", "test"])
+        assert result.exit_code == 0  # warnings don't fail verify
+        assert "WARN" in result.output
+        assert "No HTTP client" in result.output
+        assert "1 warnings" in result.output
+
 
 def _mock_config(isolation="container"):
     cfg = MagicMock()


### PR DESCRIPTION
## Summary
- Adds python3 `urllib` as a third fallback in the egress check chain (`curl` → `node` → `python3`) so images like `python:3.12-slim` that lack curl and node can still verify egress filtering
- Reports `[WARN]` instead of a misleading `[FAIL]` when no HTTP client is available at all
- Adds `_warn` helper and shows actual warning count in the verify summary line

Fixes #16

## Test plan
- [x] `test_verify_egress_python_fallback` — curl missing, node fails, python3 returns 403 → PASS
- [x] `test_verify_egress_no_client_warns` — all three fail → WARN, exit code 0
- [x] Existing `test_verify_container_all_running` still passes (curl path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)