### PR TITLE
feat: coding agent scaffolds, agentcage run, and polished CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-03-21
+
+### Added
+- Polished `agentcage run` CLI output: box-drawn banner, spinner during builds, ✓/✗ status lines, compact info summary
+- `agentcage run -v/--verbose` flag to show full build output
+- Version banner on `agentcage` and `agentcage --help`
+
 ## [0.9.2] - 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Don't let your agent phone home.
 
 > :warning: **Warning:** This is an experimental project. It has not been audited by security professionals. Use it at your own risk. See [Security & Threat Model](docs/security.md) for details and known limitations.
 
-> **Setup guides:** [OpenClaw](src/agentcage/scaffolds/openclaw/README.md) · [PicoClaw](src/agentcage/scaffolds/picoclaw/README.md) · [NanoClaw](src/agentcage/scaffolds/nanoclaw/README.md)
+> **Coding agents:** [Claude Code](src/agentcage/scaffolds/claude-code/README.md) · [Codex](src/agentcage/scaffolds/codex/README.md) &nbsp;|&nbsp; **Agent platforms:** [OpenClaw](src/agentcage/scaffolds/openclaw/README.md) · [PicoClaw](src/agentcage/scaffolds/picoclaw/README.md) · [NanoClaw](src/agentcage/scaffolds/nanoclaw/README.md)
 
 <p align="center">
   <a href="https://asciinema.org/a/838890"><img src="https://asciinema.org/a/838890.svg" alt="agentcage demo" width="700"></a>
@@ -37,7 +37,10 @@ Both container mode (rootless Podman) and VM mode (Lima KVM) are supported -- se
 # Install
 curl -fsSL https://raw.githubusercontent.com/agentcage/agentcage/master/install.sh | sh
 
-# Scaffold a config (or use --scaffold openclaw)
+# Run Claude Code in a sandbox (one command)
+agentcage run claude-code
+
+# Or scaffold a config for a custom agent
 agentcage init myapp --image node:22-slim
 
 # Create and start the cage
@@ -125,8 +128,9 @@ agentcage cage destroy myapp
 
 | Command / Group | Commands |
 |---|---|
+| `run` | *(top-level)* -- run a coding agent in a sandbox (`agentcage run claude-code`) |
 | `init` | *(top-level)* -- scaffold a config file |
-| `cage` | `create`, `update`, `edit`, `list`, `destroy`, `verify`, `restart`, `logs`, `exec`, `audit`, `har`, `backup`, `restore` (aliases: `ls`/`ps`/`status` → `list`, `rm` → `destroy`, `reload` → `restart`) |
+| `cage` | `create`, `update`, `edit`, `list`, `destroy`, `prune`, `verify`, `restart`, `logs`, `exec`, `audit`, `har`, `backup`, `restore` (aliases: `ls`/`ps`/`status` → `list`, `rm` → `destroy`, `reload` → `restart`) |
 | `secret` | `set`, `list`, `rm` (alias: `ls` → `list`) |
 | `domain` | `list`, `add`, `rm` (alias: `ls` → `list`) |
 | `completions` | *(top-level)* -- print shell completion script (`bash`/`zsh`/`fish`) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,8 +1,9 @@
 # CLI Reference
 
-The CLI has a top-level **`init`** command for scaffolding configs, and three command groups: **`cage`** (manage cages), **`secret`** (manage cage-scoped secrets), and **`domain`** (manage cage domain filters).
+The CLI has top-level **`run`** and **`init`** commands, and three command groups: **`cage`** (manage cages), **`secret`** (manage cage-scoped secrets), and **`domain`** (manage cage domain filters).
 
 ```
+agentcage run SCAFFOLD [options]
 agentcage init [NAME] [options]
 agentcage <group> <command> [options]
 ```
@@ -23,7 +24,7 @@ Generates a starter `cage.yaml` for a new cage. With `--scaffold`, uses a curate
 | `--image` | string | `node:22-slim` | Container image |
 | `--isolation` | choice: `container`/`vm` | `container` | Isolation backend |
 | `--force` | flag | | Overwrite existing file |
-| `--scaffold` | string | | Use a scaffold template (e.g. `openclaw`, `picoclaw`) |
+| `--scaffold` | string | | Use a scaffold template (e.g. `claude-code`, `codex`, `openclaw`) |
 | `--list-scaffolds` | flag | | List available scaffolds and exit |
 | `--port` | int | | Host port to publish (scaffold-specific) |
 
@@ -39,8 +40,41 @@ agentcage init myclaw --scaffold openclaw
 # NanoClaw scaffold (nested containers)
 agentcage init myapp --scaffold nanoclaw
 
+# Claude Code scaffold
+agentcage init mycc --scaffold claude-code
+
 # List available scaffolds
 agentcage init --list-scaffolds
+```
+
+---
+
+## `run` -- Run a coding agent in a sandbox
+
+```
+agentcage run SCAFFOLD [options] [-- EXTRA_ARGS...]
+```
+
+Creates a sandboxed cage from a scaffold, opens an interactive session, and stops the cage on exit. Auto-generates a unique cage name (e.g. `claude-code-bold-fox`). The cage state is preserved after exit for auditing — use `cage prune` to clean up.
+
+### Options
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--project` | path | current directory | Project directory to mount as `/workspace` |
+| `--name` | string | auto-generated | Override the auto-generated cage name |
+
+### Examples
+
+```bash
+# Run Claude Code in the current project
+agentcage run claude-code
+
+# Run Codex with a specific project
+agentcage run codex --project /path/to/repo
+
+# Run with a custom name
+agentcage run claude-code --name my-session
 ```
 
 ---
@@ -53,6 +87,7 @@ agentcage init --list-scaffolds
 | `cage update NAME [-c CONFIG]` | Rebuild images and restart an existing cage |
 | `cage list` | List all cages with status |
 | `cage destroy NAME [-y] [--keep-secrets]` | Stop containers, remove quadlets, state, and scoped secrets |
+| `cage prune [-y]` | Remove all exited interactive and ephemeral cages |
 | `cage show NAME` | Show cage configuration and status |
 | `cage verify NAME` | Health checks (containers, certs, proxy, egress, rootless) |
 | `cage edit NAME` | Open stored config in `$EDITOR`, validate, and reload if running |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,8 @@ Example configs: [`basic/cage.yaml`](../examples/basic/) | [`openclaw/cage.yaml`
 |---------|------|---------|-------------|
 | `name` | `string` | *(required)* | Project name — used as the prefix for container names, network name, and quadlet filenames (e.g. `myapp` produces `myapp-cage`, `myapp-proxy`, etc.) |
 | `isolation` | `string` | `"container"` | Isolation backend: `"container"` (rootless Podman, default) or `"vm"` (Lima VM). Old `"firecracker"` configs are silently upgraded to `"vm"`. |
+| `lifecycle` | `string` | `"service"` | Cage lifecycle mode: `"service"` (always running, auto-restart), `"interactive"` (on-demand, stops on exit, state preserved), or `"ephemeral"` (stops on exit, destroyed by `cage prune`). |
+| `scaffold` | `string` | `""` | Scaffold name used to generate this config (shown in `cage list` output). |
 | `log_allowed` | `bool` | `true` | Log allowed requests to the proxy journal |
 | `max_request_body` | `int` | `10485760` (10 MB) | Max request body size in bytes. Set to `0` to disable the body-size limit |
 | `dns_servers` | `list[string]` | *(from host `/etc/resolv.conf`)* | Upstream DNS servers used by both the dnsmasq sidecar and the proxy container |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.9.2"
+version = "0.10.0"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -15,7 +15,7 @@ class Backend(Protocol):
         """Return list of unmet prerequisite descriptions (empty = all OK)."""
         ...
 
-    def build_artifacts(self, config: Config, deploy_name: str) -> None:
+    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
         """Build container images or VM rootfs as needed."""
         ...
 
@@ -34,11 +34,11 @@ class Backend(Protocol):
         """Return the directory where unit files should be installed."""
         ...
 
-    def install_units(self, units: dict[str, str]) -> None:
+    def install_units(self, units: dict[str, str], *, quiet: bool = False) -> None:
         """Write unit files to unit_dir() and reload systemd."""
         ...
 
-    def start(self, name: str) -> None:
+    def start(self, name: str, *, quiet: bool = False) -> None:
         """Start a cage by name."""
         ...
 

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -42,7 +42,6 @@ class ContainerBackend:
             "agentcage-proxy",
             os.path.join(containers_dir, "Containerfile.proxy"),
             build_context,
-            no_cache=True,
             cap_add=["CAP_CHOWN", "CAP_FOWNER", "CAP_SETUID", "CAP_SETGID", "CAP_DAC_OVERRIDE"],
             quiet=quiet,
         )

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -31,25 +31,29 @@ class ContainerBackend:
             issues.append("Podman is not available")
         return issues
 
-    def build_artifacts(self, config: Config, deploy_name: str) -> None:
+    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
         data_dir = Path(__file__).resolve().parent.parent / "data"
         containers_dir = str(data_dir / "containers")
         build_context = str(data_dir)
 
-        click.echo("Building proxy image...")
+        if not quiet:
+            click.echo("Building proxy image...")
         self._podman.build_image(
             "agentcage-proxy",
             os.path.join(containers_dir, "Containerfile.proxy"),
             build_context,
             no_cache=True,
             cap_add=["CAP_CHOWN", "CAP_FOWNER", "CAP_SETUID", "CAP_SETGID", "CAP_DAC_OVERRIDE"],
+            quiet=quiet,
         )
-        click.echo("Building DNS image...")
+        if not quiet:
+            click.echo("Building DNS image...")
         self._podman.build_image(
             "agentcage-dns",
             os.path.join(containers_dir, "Containerfile.dns"),
             build_context,
             cap_add=["CAP_SETFCAP"],
+            quiet=quiet,
         )
 
     def generate_units(
@@ -66,33 +70,37 @@ class ContainerBackend:
     def unit_dir(self) -> Path:
         return Path(os.path.expanduser("~/.config/containers/systemd"))
 
-    def install_units(self, units: dict[str, str]) -> None:
+    def install_units(self, units: dict[str, str], *, quiet: bool = False) -> None:
         dest = self.unit_dir()
         dest.mkdir(parents=True, exist_ok=True)
         for filename, content in units.items():
             (dest / filename).write_text(content)
-        click.echo(f"Installed quadlet files to {dest}/")
+        if not quiet:
+            click.echo(f"Installed quadlet files to {dest}/")
         systemd.daemon_reload()
 
-    def start(self, name: str) -> None:
+    def start(self, name: str, *, quiet: bool = False) -> None:
         # Restart network/volume first so they're recreated
         # (systemd may think they're still active from a previous run even if
         # podman resources were removed by 'cage destroy')
         try:
             systemd.restart_unit(f"{name}-net-network.service")
         except Exception as e:
-            click.echo(f"warning: failed to restart network service: {e}", err=True)
+            if not quiet:
+                click.echo(f"warning: failed to restart network service: {e}", err=True)
         try:
             systemd.restart_unit(f"{name}-certs-volume.service")
         except Exception as e:
-            click.echo(f"warning: failed to restart volume service: {e}", err=True)
+            if not quiet:
+                click.echo(f"warning: failed to restart volume service: {e}", err=True)
         if (self.unit_dir() / f"{name}-podman-storage.volume").exists():
             try:
                 systemd.restart_unit(f"{name}-podman-storage-volume.service")
             except Exception:
                 pass
         systemd.start_unit(f"{name}-cage.service")
-        click.echo(f"Started {name}-cage")
+        if not quiet:
+            click.echo(f"Started {name}-cage")
 
     def stop(self, name: str) -> None:
         for svc in self.service_names(name):

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -36,7 +36,7 @@ class VmBackend:
     def check_prerequisites(self, config: Config) -> list[str]:
         return lima_prerequisites.check_prerequisites()
 
-    def build_artifacts(self, config: Config, deploy_name: str) -> None:
+    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
         """Build proxy and DNS images inside the VM.
 
         The build context (package data directory) is copied into the VM
@@ -112,16 +112,17 @@ class VmBackend:
     def unit_dir(self) -> Path:
         return Path(os.path.expanduser("~/.config/agentcage/lima"))
 
-    def install_units(self, units: dict[str, str]) -> None:
+    def install_units(self, units: dict[str, str], *, quiet: bool = False) -> None:
         dest = self.unit_dir()
         dest.mkdir(parents=True, exist_ok=True)
         for filename, content in units.items():
             fpath = dest / filename
             fpath.parent.mkdir(parents=True, exist_ok=True)
             fpath.write_text(content)
-        click.echo(f"Installed Lima config to {dest}/")
+        if not quiet:
+            click.echo(f"Installed Lima config to {dest}/")
 
-    def start(self, name: str) -> None:
+    def start(self, name: str, *, quiet: bool = False) -> None:
         inst = self._instance(name)
         config_path = self.unit_dir() / "lima.yaml"
 

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -66,7 +66,7 @@ class VmBackend:
 
         click.echo("Building proxy image inside VM...")
         inst.exec([
-            "podman", "build", "--no-cache",
+            "podman", "build",
             "--cap-add=CAP_CHOWN", "--cap-add=CAP_FOWNER",
             "--cap-add=CAP_SETUID", "--cap-add=CAP_SETGID",
             "--cap-add=CAP_DAC_OVERRIDE",

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -211,9 +211,10 @@ def init(name: str | None, output: str, image: str, isolation: str,
               help="Cage name (default: auto-generated).")
 @click.option("-s", "--set-secret", "secrets", multiple=True,
               help="Set a secret (KEY=VALUE or KEY to prompt). Repeatable.")
+@click.option("-v", "--verbose", is_flag=True, help="Show full build output.")
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 def run(scaffold: str, project_dir: str | None, name: str | None,
-        secrets: tuple[str, ...], extra_args: tuple[str, ...]):
+        secrets: tuple[str, ...], verbose: bool, extra_args: tuple[str, ...]):
     """Run a coding agent in a sandboxed cage.
 
     \b
@@ -226,7 +227,7 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
     from agentcage.run import execute
     exit_code = execute(
         scaffold, project_dir=project_dir, name=name,
-        secrets=secrets, extra_args=extra_args,
+        secrets=secrets, extra_args=extra_args, verbose=verbose,
     )
     sys.exit(exit_code)
 

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -41,6 +41,7 @@ from agentcage.services import (
     ensure_patches as _ensure_patches,
     build_container_image as _build_container_image_svc,
     build_and_deploy as _build_and_deploy,
+    destroy_cage as _destroy_cage,
 )
 
 
@@ -197,6 +198,37 @@ def init(name: str | None, output: str, image: str, isolation: str,
         click.echo(f"  2. agentcage cage create -c {dest}")
 
 
+
+
+# ── run ──────────────────────────────────────────────────
+
+
+@main.command(context_settings={"ignore_unknown_options": True})
+@click.argument("scaffold")
+@click.option("--project", "project_dir", default=None, type=click.Path(exists=True),
+              help="Project directory to mount (default: current directory).")
+@click.option("--name", default=None,
+              help="Cage name (default: auto-generated).")
+@click.option("-s", "--set-secret", "secrets", multiple=True,
+              help="Set a secret (KEY=VALUE or KEY to prompt). Repeatable.")
+@click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
+def run(scaffold: str, project_dir: str | None, name: str | None,
+        secrets: tuple[str, ...], extra_args: tuple[str, ...]):
+    """Run a coding agent in a sandboxed cage.
+
+    \b
+    Examples:
+      agentcage run claude-code
+      agentcage run codex --project /path/to/repo
+      agentcage run claude-code -s ANTHROPIC_API_KEY=sk-...
+      agentcage run claude-code --name my-session -- claude --help
+    """
+    from agentcage.run import execute
+    exit_code = execute(
+        scaffold, project_dir=project_dir, name=name,
+        secrets=secrets, extra_args=extra_args,
+    )
+    sys.exit(exit_code)
 
 
 # ── cage group ────────────────────────────────────────────
@@ -510,17 +542,19 @@ def cage_list():
         click.echo("No cages found.")
         return
 
-    click.echo(f"{'NAME':<20} {'ISOLATION':<14} {'VERSION':<12} STATUS")
+    click.echo(f"{'NAME':<25} {'LIFECYCLE':<14} {'ISOLATION':<12} {'SCAFFOLD':<15} STATUS")
     for name in names:
         try:
             cfg = state.load_deployment_config(name)
             backend = get_backend(cfg)
         except Exception:
-            click.echo(f"{name:<20} {'?':<14} {'-':<12} unknown (config error)")
+            click.echo(f"{name:<25} {'?':<14} {'?':<12} {'-':<15} unknown (config error)")
             continue
 
         isolation = cfg.isolation
-        ver = state.load_metadata(name).get("agentcage_version", "-")
+        meta = state.load_metadata(name)
+        lifecycle = meta.get("lifecycle", cfg.lifecycle)
+        scaffold_name = meta.get("scaffold", cfg.scaffold) or "-"
         services = backend.service_names(name)
         total = len(services)
         running = sum(
@@ -530,10 +564,13 @@ def cage_list():
         if running == total:
             status = f"running ({running}/{total})"
         elif running == 0:
-            status = f"stopped (0/{total})"
+            if lifecycle in ("interactive", "ephemeral"):
+                status = "exited"
+            else:
+                status = f"stopped (0/{total})"
         else:
             status = f"degraded ({running}/{total})"
-        click.echo(f"{name:<20} {isolation:<14} {ver:<12} {status}")
+        click.echo(f"{name:<25} {lifecycle:<14} {isolation:<12} {scaffold_name:<15} {status}")
 
 
 @cage.command("destroy")
@@ -554,26 +591,7 @@ def cage_destroy(name: str, yes: bool, keep_secrets: bool):
             abort=True,
         )
 
-    # Load config to determine backend, fall back to container backend
-    try:
-        cfg = state.load_deployment_config(name)
-        backend = get_backend(cfg)
-    except Exception:
-        from agentcage.backends.container import ContainerBackend
-        backend = ContainerBackend()
-
-    click.echo("Stopping services...")
-    backend.stop(name)
-
-    click.echo("Removing quadlet files...")
-    removed = backend.destroy_resources(name, keep_secrets=keep_secrets)
-
-    click.echo("Removing Podman resources...")
-
-    # Remove state
-    if state.deployment_exists(name):
-        state.remove_deployment(name)
-        removed.append("state")
+    removed = _destroy_cage(name, keep_secrets=keep_secrets, echo=click.echo)
 
     click.echo()
     if removed:
@@ -582,6 +600,48 @@ def cage_destroy(name: str, yes: bool, keep_secrets: bool):
             click.echo(f"  {item}")
     else:
         click.echo(f'Nothing to remove (cage "{name}" not found).')
+
+
+@cage.command("prune")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+def cage_prune(yes: bool):
+    """Remove all exited interactive and ephemeral cages."""
+    names = state.list_deployments()
+    candidates = []
+    for name in names:
+        try:
+            cfg = state.load_deployment_config(name)
+            backend = get_backend(cfg)
+        except Exception:
+            continue
+        meta = state.load_metadata(name)
+        lifecycle = meta.get("lifecycle", cfg.lifecycle)
+        if lifecycle not in ("interactive", "ephemeral"):
+            continue
+        services = backend.service_names(name)
+        running = sum(1 for svc in services if backend.is_running(name, svc))
+        if running == 0:
+            candidates.append(name)
+
+    if not candidates:
+        click.echo("Nothing to prune.")
+        return
+
+    click.echo(f"The following exited cages will be removed:")
+    for name in candidates:
+        click.echo(f"  {name}")
+
+    if not yes:
+        click.confirm(f"\nRemove {len(candidates)} cage(s)?", abort=True)
+
+    for name in candidates:
+        click.echo(f"Removing {name}...")
+        try:
+            _destroy_cage(name, keep_secrets=False)
+        except Exception as e:
+            click.echo(f"  warning: failed to remove {name}: {e}", err=True)
+            continue
+    click.echo(f"Pruned {len(candidates)} cage(s).")
 
 
 @cage.command("verify")

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -95,7 +95,15 @@ class AliasGroup(click.Group):
                     formatter.write_text(f"{alias} → {target}")
 
 
-@click.group()
+class _BannerGroup(click.Group):
+    """Show the agentcage banner before help text."""
+
+    def get_help(self, ctx: click.Context) -> str:
+        from agentcage.output import banner_text
+        return banner_text(version("agentcage")) + "\n" + super().get_help(ctx)
+
+
+@click.group(cls=_BannerGroup)
 @click.version_option(version=version("agentcage"), prog_name="agentcage")
 def main():
     """Defense-in-depth proxy sandbox for AI agents."""
@@ -246,6 +254,9 @@ def cage():
               help="Set a secret (KEY=VALUE or KEY to prompt). Repeatable.")
 def cage_create(config_path: str, secrets: tuple):
     """Build images, generate quadlets, install, and start a new cage."""
+    from agentcage import output as _out
+    _out.banner(version("agentcage"))
+
     cfg = load_config(config_path)
     try:
         warnings = validate_config(cfg)

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -105,10 +105,14 @@ class VmConfig:
     mem_mb: int = 4096
 
 
+_VALID_LIFECYCLES = ("service", "interactive", "ephemeral")
+
+
 @dataclass
 class Config:
     name: str = ""
     isolation: str = "container"  # "container" | "vm"
+    lifecycle: str = "service"  # "service" | "interactive" | "ephemeral"
     container: ContainerConfig = field(default_factory=ContainerConfig)
     secret_injection: list[SecretInjectionRule] = field(default_factory=list)
     dns_servers: list[str] = field(default_factory=list)
@@ -118,6 +122,7 @@ class Config:
     vm: VmConfig = field(default_factory=VmConfig)
     help: str = ""
     exec_aliases: dict[str, list[str]] = field(default_factory=dict)
+    scaffold: str = ""  # scaffold name, stored in metadata for cage ls
 
 
 def _is_loopback(addr: str) -> bool:
@@ -186,6 +191,8 @@ def load_config(path: str) -> Config:
     cfg = Config()
     cfg.name = raw.get("name", "")
     cfg.isolation = raw.get("isolation", "container")
+    cfg.lifecycle = raw.get("lifecycle", "service")
+    cfg.scaffold = raw.get("scaffold", "")
 
     # Silently migrate "firecracker" isolation to "vm"
     if cfg.isolation == "firecracker":
@@ -358,6 +365,12 @@ def validate_config(config: Config) -> list[str]:
     if config.isolation not in ("container", "vm"):
         raise ValueError(
             f"isolation must be 'container' or 'vm' (got: {config.isolation!r})"
+        )
+
+    if config.lifecycle not in _VALID_LIFECYCLES:
+        raise ValueError(
+            f"lifecycle must be one of {_VALID_LIFECYCLES} "
+            f"(got: {config.lifecycle!r})"
         )
 
     if config.isolation == "container" and platform.system() == "Darwin":

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -43,6 +43,7 @@ class ContainerConfig:
     no_new_privileges: bool = True
     nested_containers: bool = False
     security_label_disable: bool = True
+    userns: str = ""  # e.g. "keep-id" to map host UID into container
     build: BuildConfig = field(default_factory=BuildConfig)
     restart: str = "on-failure"
     restart_sec: int = 10
@@ -230,6 +231,7 @@ def load_config(path: str) -> Config:
     cc.no_new_privileges = c.get("no_new_privileges", True)
     cc.nested_containers = bool(c.get("nested_containers", False))
     cc.security_label_disable = c.get("security_label_disable", True)
+    cc.userns = str(c.get("userns", "") or "")
 
     # drop_capabilities: default "ALL" (string or list)
     drop = c.get("drop_capabilities", "ALL")

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -105,7 +105,9 @@ def load_scaffold_meta(scaffold: str) -> dict | None:
         return yaml.safe_load(f) or {}
 
 
-def run_scaffold_setup(scaffold: str, name: str, dest: str, *, image_tag: str | None = None) -> None:
+def run_scaffold_setup(
+    scaffold: str, name: str, dest: str, *, image_tag: str | None = None, quiet: bool = False,
+) -> None:
     """Execute build/provision steps from scaffold.yaml."""
     meta = load_scaffold_meta(scaffold)
     if meta is None:
@@ -116,11 +118,15 @@ def run_scaffold_setup(scaffold: str, name: str, dest: str, *, image_tag: str | 
     podman = Podman()
     scaffold_dir = _SCAFFOLDS_DIR / scaffold
 
+    def _echo(msg: str) -> None:
+        if not quiet:
+            click.echo(msg)
+
     # 1. Process build entries
     for entry in meta.get("build", []):
         image = entry["image"]
         if podman.image_exists(image):
-            click.echo(f"Image {image} already exists, skipping build.")
+            _echo(f"Image {image} already exists, skipping build.")
             continue
 
         # Resolve build_args — append resolved tag for scaffold images
@@ -131,22 +137,27 @@ def run_scaffold_setup(scaffold: str, name: str, dest: str, *, image_tag: str | 
 
         if "containerfile" in entry:
             containerfile = str(scaffold_dir / entry["containerfile"])
-            click.echo(f"Building {image}...")
+            _echo(f"Building {image}...")
             podman.build_image(
                 image, containerfile, str(scaffold_dir),
                 cap_add=entry.get("cap_add"), build_args=build_args,
+                quiet=quiet,
             )
         elif "git" in entry:
             git_url = entry["git"]
             depth = entry.get("depth", 1)
             with tempfile.TemporaryDirectory() as tmpdir:
-                click.echo(f"Cloning {git_url}...")
+                _echo(f"Cloning {git_url}...")
                 cmd = ["git", "clone", f"--depth={depth}", git_url, tmpdir]
-                subprocess.run(cmd, check=True)
-                click.echo(f"Building {image}...")
+                if quiet:
+                    subprocess.run(cmd, check=True, capture_output=True)
+                else:
+                    subprocess.run(cmd, check=True)
+                _echo(f"Building {image}...")
                 podman.build_image(
                     image, None, tmpdir,
                     cap_add=entry.get("cap_add"), build_args=build_args,
+                    quiet=quiet,
                 )
 
     # 2. Process provision entries
@@ -154,8 +165,8 @@ def run_scaffold_setup(scaffold: str, name: str, dest: str, *, image_tag: str | 
         src = scaffold_dir / entry["src"]
         dest_path = Path(entry["dest"]).expanduser()
         if dest_path.exists():
-            click.echo(f"{dest_path} already exists, skipping.")
+            _echo(f"{dest_path} already exists, skipping.")
             continue
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(src), str(dest_path))
-        click.echo(f"Created {dest_path}")
+        _echo(f"Created {dest_path}")

--- a/src/agentcage/output.py
+++ b/src/agentcage/output.py
@@ -14,15 +14,23 @@ import time
 import click
 
 
-def header(scaffold: str) -> None:
-    """Print the ╭─╮ header box."""
-    title = f" \u273b agentcage run \u00b7 {scaffold} "
+def banner_text(ver: str) -> str:
+    """Return the ╭─╮ banner with version as a string."""
+    title = f" \u273b agentcage v{ver} "
     width = max(len(title) + 2, 44)
     padding = width - len(title)
-    click.echo(dim(f"\u256d{'\u2500' * width}\u256e"))
-    click.echo(dim("\u2502") + click.style(title, bold=True) + " " * padding + dim("\u2502"))
-    click.echo(dim(f"\u2570{'\u2500' * width}\u256f"))
-    click.echo()
+    lines = [
+        dim(f"\u256d{'\u2500' * width}\u256e"),
+        dim("\u2502") + click.style(title, bold=True) + " " * padding + dim("\u2502"),
+        dim(f"\u2570{'\u2500' * width}\u256f"),
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def banner(ver: str) -> None:
+    """Print the ╭─╮ banner with version."""
+    click.echo(banner_text(ver))
 
 
 def step_done(msg: str) -> None:

--- a/src/agentcage/output.py
+++ b/src/agentcage/output.py
@@ -1,0 +1,93 @@
+"""Styled terminal output helpers for agentcage CLI.
+
+Provides a consistent visual style: dim borders, green/red status marks,
+compact info lines, and a braille-dot spinner for in-progress steps.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import threading
+import time
+
+import click
+
+
+def header(scaffold: str) -> None:
+    """Print the ╭─╮ header box."""
+    title = f" \u273b agentcage run \u00b7 {scaffold} "
+    width = max(len(title) + 2, 44)
+    padding = width - len(title)
+    click.echo(dim(f"\u256d{'\u2500' * width}\u256e"))
+    click.echo(dim("\u2502") + click.style(title, bold=True) + " " * padding + dim("\u2502"))
+    click.echo(dim(f"\u2570{'\u2500' * width}\u256f"))
+    click.echo()
+
+
+def step_done(msg: str) -> None:
+    """Print a green ✓ status line."""
+    click.echo(f"  {green('\u2713')} {msg}")
+
+
+def step_fail(msg: str) -> None:
+    """Print a red ✗ status line to stderr."""
+    click.echo(f"  {red('\u2717')} {msg}", err=True)
+
+
+def info(label: str, value: str) -> None:
+    """Print a dim label + value info line."""
+    click.echo(f"  {dim(label.ljust(9))}{value}")
+
+
+def separator() -> None:
+    """Print a dim horizontal rule."""
+    click.echo(dim("\u2500" * 44))
+
+
+def dim(text: str) -> str:
+    return click.style(text, dim=True)
+
+
+def green(text: str) -> str:
+    return click.style(text, fg="green")
+
+
+def red(text: str) -> str:
+    return click.style(text, fg="red")
+
+
+class Spinner:
+    """Context manager that shows a braille spinner on the current line.
+
+    Falls back to a static ``…`` prefix when stderr is not a TTY.
+    """
+
+    _FRAMES = "\u280b\u2819\u2839\u2838\u283c\u2834\u2826\u2827\u2807\u280f"
+
+    def __init__(self, msg: str) -> None:
+        self.msg = msg
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> Spinner:
+        if not sys.stderr.isatty():
+            click.echo(f"  \u2026 {self.msg}", err=True)
+            return self
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+        if sys.stderr.isatty():
+            click.echo("\r\033[K", nl=False, err=True)
+
+    def _spin(self) -> None:
+        for frame in itertools.cycle(self._FRAMES):
+            if self._stop.is_set():
+                break
+            click.echo(f"\r  {frame} {self.msg}", nl=False, err=True)
+            time.sleep(0.08)

--- a/src/agentcage/podman.py
+++ b/src/agentcage/podman.py
@@ -43,6 +43,7 @@ class Podman:
         cap_add: list[str] | None = None,
         no_cache: bool = False,
         build_args: dict[str, str] | None = None,
+        quiet: bool = False,
     ) -> None:
         cmd = [*_podman_cmd(), "build", "-t", tag]
         if containerfile is not None:
@@ -54,7 +55,15 @@ class Podman:
         for k, v in (build_args or {}).items():
             cmd.extend(["--build-arg", f"{k}={v}"])
         cmd.append(context_dir)
-        subprocess.run(cmd, check=True)
+        if quiet:
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    result.returncode, cmd,
+                    output=result.stdout, stderr=result.stderr,
+                )
+        else:
+            subprocess.run(cmd, check=True)
 
     def run_and_remove(
         self,

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -348,6 +348,7 @@ def generate_quadlets(
         podman_secrets=cc.podman_secrets,
         cage_placeholders=cage_placeholders,
         env=expanded_env,
+        userns=cc.userns,
         user=cage_user,
         read_only=cc.read_only,
         security_label_disable=cc.security_label_disable,

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -330,6 +330,12 @@ def generate_quadlets(
             volume_name=f"agentcage-podman-{name}",
         )
 
+    # Map lifecycle to systemd restart policy
+    lifecycle = config.lifecycle
+    restart = cc.restart
+    if lifecycle in ("interactive", "ephemeral"):
+        restart = "no"
+
     # Cage container — no published ports (traffic arrives via proxy reverse mode)
     files[f"{name}-cage.container"] = env.get_template("cage.container.j2").render(
         **common,
@@ -351,12 +357,13 @@ def generate_quadlets(
         memory=cc.memory,
         cpus=cc.cpus,
         command=cc.command,
-        restart=cc.restart,
+        restart=restart,
         restart_sec=cc.restart_sec,
         timeout_start_sec=cc.timeout_start_sec,
         timeout_stop_sec=cc.timeout_stop_sec,
         deploy_name=deploy_name,
         nested_containers=nested_containers,
+        lifecycle=lifecycle,
     )
 
     return files

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -16,6 +16,7 @@ Architecture:
 
 from __future__ import annotations
 
+import json
 import os
 import random
 import shutil
@@ -23,6 +24,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 import click
@@ -48,11 +50,13 @@ _ADJECTIVES = [
 # Short aliases for scaffold names
 _SCAFFOLD_ALIASES: dict[str, str] = {
     "claude": "claude-code",
+    "alpine": "alpine-curl",
 }
 
 # Short prefixes for auto-generated cage names
 _NAME_PREFIXES: dict[str, str] = {
     "claude-code": "claude",
+    "alpine-curl": "alpine",
 }
 
 _NOUNS = [
@@ -77,6 +81,65 @@ def generate_name(scaffold: str) -> str:
         if name not in existing:
             return name
     raise RuntimeError("Could not generate a unique cage name after 100 attempts")
+
+
+def _monitor_proxy(proxy_container: str, stop_event: threading.Event) -> None:
+    """Tail proxy logs and print blocked-request notifications to the terminal.
+
+    Runs as a daemon thread alongside the interactive session.  Writes
+    directly to ``/dev/tty`` so output appears even while podman exec
+    owns stdout/stderr.
+    """
+    try:
+        tty = open("/dev/tty", "w")
+    except OSError:
+        return
+
+    try:
+        proc = subprocess.Popen(
+            ["podman", "logs", "-f", proxy_container],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError:
+        tty.close()
+        return
+
+    dim = "\x1b[2m"
+    red = "\x1b[31m"
+    reset = "\x1b[0m"
+
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            if stop_event.is_set():
+                break
+            line = line.strip()
+            if not line or '"decision"' not in line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if entry.get("decision") != "blocked":
+                continue
+            host = entry.get("host", "?")
+            reason = entry.get("reason", "blocked")
+            tty.write(
+                f"\r{dim}[agentcage]{reset} {red}blocked{reset}"
+                f" {dim}→{reset} {host} {dim}({reason}){reset}\n"
+            )
+            tty.flush()
+    except (OSError, ValueError):
+        pass
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        tty.close()
 
 
 def execute(
@@ -131,7 +194,8 @@ def execute(
         return 1
 
     # Print header
-    output.header(scaffold)
+    from importlib.metadata import version
+    output.banner(version("agentcage"))
 
     # Render config from scaffold template
     os.environ["PROJECT_DIR"] = project_dir
@@ -174,19 +238,6 @@ def execute(
 
     # Run scaffold setup (build images) and deploy
     try:
-        if verbose:
-            run_scaffold_setup(
-                scaffold, cage_name, str(config_path),
-                image_tag=image_tag,
-            )
-        else:
-            with output.Spinner("Building image..."):
-                run_scaffold_setup(
-                    scaffold, cage_name, str(config_path),
-                    image_tag=image_tag, quiet=True,
-                )
-        output.step_done("Image ready")
-
         podman = Podman()
 
         # Set secrets passed via --set-secret
@@ -219,6 +270,10 @@ def execute(
         config_host_path = state.save_proxy_config(cage_name)
 
         if verbose:
+            run_scaffold_setup(
+                scaffold, cage_name, str(config_path),
+                image_tag=image_tag,
+            )
             build_and_deploy(
                 cfg,
                 config_host_path=config_host_path,
@@ -227,7 +282,11 @@ def execute(
                 used_octets=used_octets,
             )
         else:
-            with output.Spinner("Building proxy..."):
+            with output.Spinner("Starting cage..."):
+                run_scaffold_setup(
+                    scaffold, cage_name, str(config_path),
+                    image_tag=image_tag, quiet=True,
+                )
                 build_and_deploy(
                     cfg,
                     config_host_path=config_host_path,
@@ -236,9 +295,7 @@ def execute(
                     used_octets=used_octets,
                     quiet=True,
                 )
-        output.step_done("Proxy built")
-        output.step_done("DNS ready")
-        output.step_done(f"Cage {click.style(cage_name, bold=True)} started")
+        output.step_done(output.dim(cage_name))
     except subprocess.CalledProcessError as e:
         output.step_fail("Build failed")
         # Dump captured build output for debugging
@@ -258,20 +315,10 @@ def execute(
         shutil.rmtree(str(config_dir), ignore_errors=True)
         return 1
 
-    # Summary info
+    # Summary
     click.echo()
-    output.info("Project", project_dir)
-
-    # Detect mounted auth
-    claude_dir = Path.home() / ".claude"
-    if claude_dir.is_dir():
-        output.info("Auth", "~/.claude (mounted)")
-    else:
-        output.info("Auth", output.dim("not configured"))
-
-    click.echo()
-    output.info("Ctrl+D", "to exit")
-    output.info("Audit", f"agentcage cage audit {cage_name}")
+    click.echo(f"  {output.dim(project_dir)}")
+    click.echo(f"  {output.dim('Ctrl+D to exit')} {output.dim('·')} {output.dim('agentcage cage audit ' + cage_name)}")
     click.echo()
     output.separator()
 
@@ -287,7 +334,15 @@ def execute(
     # Run interactive session
     exit_code = 0
     container_name = f"{cfg.name}-cage"
+    proxy_container = f"{cfg.name}-proxy"
     exec_flags = ["-it"] if sys.stdin.isatty() else []
+
+    # Monitor proxy logs for blocked requests
+    monitor_stop = threading.Event()
+    monitor_thread = threading.Thread(
+        target=_monitor_proxy, args=(proxy_container, monitor_stop), daemon=True,
+    )
+    monitor_thread.start()
 
     try:
         result = subprocess.run(
@@ -298,6 +353,8 @@ def execute(
         click.echo("\nSession interrupted.")
         exit_code = 130
     finally:
+        monitor_stop.set()
+        monitor_thread.join(timeout=3)
         click.echo()
         output.separator()
         with output.Spinner("Stopping cage..."):
@@ -306,8 +363,8 @@ def execute(
                 backend.stop(cfg.name)
             except Exception as e:
                 click.echo(f"warning: failed to stop cage: {e}", err=True)
-        output.step_done(f"Cage {click.style(cage_name, bold=True)} stopped")
-        output.info("Audit", f"agentcage cage audit {cage_name}")
+        click.echo(f"  {output.dim(cage_name + ' stopped')}")
+        click.echo(f"  {output.dim('agentcage cage audit ' + cage_name)}")
 
     # Clean up temp config dir
     shutil.rmtree(str(config_dir), ignore_errors=True)

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -1,0 +1,266 @@
+"""Lifecycle orchestration for interactive and ephemeral cages.
+
+The ``execute()`` function creates a cage from a scaffold, opens an
+interactive session, and cleans up on exit.  Signal handling ensures
+the cage is stopped even if the user hits Ctrl+C.
+
+Architecture:
+  agentcage run <scaffold> [--project DIR] [--name NAME]
+       │
+       ├─ resolve scaffold → render config
+       ├─ auto-generate name if needed
+       ├─ build image + deploy cage
+       ├─ subprocess.run(podman exec -it ...)  ← returns on exit
+       └─ finally: stop cage (state dir preserved)
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import click
+
+from agentcage import state
+from agentcage.backends import get_backend
+from agentcage.config import load_config, validate_config
+from agentcage.init import list_scaffolds, load_scaffold_meta, render_config, run_scaffold_setup
+from agentcage.podman import Podman
+from agentcage.services import build_and_deploy, check_port_availability, destroy_cage
+
+# Word lists for auto-generated cage names (Docker-style)
+_ADJECTIVES = [
+    "bold", "brave", "bright", "calm", "cool", "dark", "deep", "dry",
+    "fair", "fast", "firm", "free", "glad", "gold", "good", "gray",
+    "keen", "kind", "late", "lean", "long", "mild", "neat", "new",
+    "odd", "old", "pale", "pure", "rare", "raw", "red", "rich",
+    "safe", "shy", "slim", "soft", "tall", "thin", "warm", "wide",
+    "wild", "wise", "blue", "grim", "hale", "lush", "prim", "tame",
+    "true", "vast",
+]
+
+# Short aliases for scaffold names
+_SCAFFOLD_ALIASES: dict[str, str] = {
+    "claude": "claude-code",
+}
+
+_NOUNS = [
+    "ant", "bay", "bee", "cod", "cow", "dew", "doe", "elm",
+    "elk", "emu", "ewe", "fig", "fox", "gem", "gnu", "hog",
+    "ivy", "jay", "kit", "lad", "log", "mew", "nit", "oak",
+    "orb", "owl", "pea", "ram", "ray", "roe", "rue", "rye",
+    "sap", "sky", "sow", "sun", "tar", "tern", "tic", "vow",
+    "wax", "web", "yak", "yam", "yew", "zap", "ash", "birch",
+    "fern", "hawk",
+]
+
+
+def generate_name(scaffold: str) -> str:
+    """Generate a unique cage name like ``claude-code-bold-fox``."""
+    existing = set(state.list_deployments())
+    for _ in range(100):
+        adj = random.choice(_ADJECTIVES)
+        noun = random.choice(_NOUNS)
+        name = f"{scaffold}-{adj}-{noun}"
+        if name not in existing:
+            return name
+    raise RuntimeError("Could not generate a unique cage name after 100 attempts")
+
+
+def execute(
+    scaffold: str,
+    *,
+    project_dir: str | None = None,
+    name: str | None = None,
+    secrets: tuple[str, ...] = (),
+    extra_args: tuple[str, ...] = (),
+) -> int:
+    """Create a cage from a scaffold, run an interactive session, and clean up.
+
+    Returns the exit code from the interactive session.
+    """
+    # Resolve scaffold aliases
+    scaffold = _SCAFFOLD_ALIASES.get(scaffold, scaffold)
+
+    # Validate scaffold exists
+    available = list_scaffolds()
+    if scaffold not in available:
+        click.echo(
+            f"error: unknown scaffold '{scaffold}'. "
+            f"Available: {', '.join(available)}",
+            err=True,
+        )
+        return 1
+
+    # Resolve project directory
+    if project_dir is None:
+        project_dir = os.getcwd()
+    project_dir = os.path.abspath(project_dir)
+
+    # Warn if mounting home directory
+    home = os.path.expanduser("~")
+    if os.path.realpath(project_dir) == os.path.realpath(home):
+        click.echo(
+            f"warning: mounting home directory ({project_dir}) as project workspace. "
+            f"Sensitive files (e.g. .ssh, .aws) will be accessible to the agent.",
+            err=True,
+        )
+
+    # Generate or validate cage name
+    cage_name = name or generate_name(scaffold)
+
+    if state.deployment_exists(cage_name):
+        click.echo(
+            f"error: cage '{cage_name}' already exists. "
+            f"Use --name to specify a different name, or destroy it first.",
+            err=True,
+        )
+        return 1
+
+    # Render config from scaffold template
+    click.echo(f"Creating cage '{cage_name}'...")
+    os.environ["PROJECT_DIR"] = project_dir
+    config_text, image_tag = render_config(
+        cage_name, scaffold=scaffold, isolation="container",
+    )
+
+    # Write temp config file
+    config_dir = Path(tempfile.mkdtemp(prefix="agentcage-run-"))
+    config_path = config_dir / "cage.yaml"
+    config_path.write_text(config_text)
+
+    cfg = load_config(str(config_path))
+    warnings = validate_config(cfg)
+    for w in warnings:
+        click.echo(f"warning: {w}", err=True)
+
+    # Check port availability
+    unavailable = check_port_availability(cfg)
+    if unavailable:
+        for spec, _bind, port in unavailable:
+            click.echo(f"error: port {port} is already in use ({spec})", err=True)
+        return 1
+
+    # Save deployment state
+    state.save_deployment(cage_name, str(config_path))
+    meta = state.load_metadata(cage_name)
+    meta["scaffold"] = scaffold
+    meta["lifecycle"] = cfg.lifecycle
+    state.save_metadata(cage_name, meta)
+
+    # Copy scaffold Containerfile to state dir if build is configured
+    if cfg.container.build.containerfile:
+        from agentcage.init import _SCAFFOLDS_DIR
+        scaffold_dir = _SCAFFOLDS_DIR / scaffold
+        containerfile_src = scaffold_dir / cfg.container.build.containerfile
+        if containerfile_src.exists():
+            dest_cf = Path(state.stored_config_path(cage_name)).parent / "Containerfile"
+            shutil.copy2(str(containerfile_src), str(dest_cf))
+
+    # Run scaffold setup (build images) and deploy
+    try:
+        run_scaffold_setup(scaffold, cage_name, str(config_path), image_tag=image_tag)
+
+        podman = Podman()
+
+        # Set secrets passed via --set-secret
+        provided_keys: set[str] = set()
+        for spec in secrets:
+            if "=" in spec:
+                key, val = spec.split("=", 1)
+            else:
+                key = spec
+                val = click.prompt(f"Value for {key}", hide_input=True)
+            full = f"{cage_name}.{key}"
+            if podman.secret_exists(full):
+                podman.secret_remove(full)
+            podman.secret_create(full, val)
+            provided_keys.add(key)
+            click.echo(f"Secret '{key}' set.")
+
+        # Strip secret injection rules for secrets not provided —
+        # keeps only rules whose secrets were passed via --set-secret.
+        cfg.secret_injection = [
+            r for r in cfg.secret_injection if r.env in provided_keys
+        ]
+        cfg.container.podman_secrets = [
+            s for s in cfg.container.podman_secrets if s in provided_keys
+        ]
+
+        from agentcage.quadlets import collect_used_octets
+        used_octets = collect_used_octets(exclude=cage_name)
+
+        # Save proxy config and get its host path (mounted into proxy container)
+        config_host_path = state.save_proxy_config(cage_name)
+
+        build_and_deploy(
+            cfg,
+            config_host_path=config_host_path,
+            deploy_name=cage_name,
+            podman=podman,
+            used_octets=used_octets,
+        )
+    except Exception as e:
+        click.echo(f"error: failed to build/deploy cage: {e}", err=True)
+        # Clean up partial state
+        if state.deployment_exists(cage_name):
+            state.remove_deployment(cage_name)
+        shutil.rmtree(str(config_dir), ignore_errors=True)
+        return 1
+
+    click.echo(f"Cage '{cage_name}' started.")
+
+    if cfg.help:
+        click.echo("")
+        click.echo(cfg.help.rstrip())
+        click.echo("")
+
+    # Determine the exec command
+    meta_loaded = load_scaffold_meta(scaffold) or {}
+    # Use exec alias if defined, otherwise shell
+    exec_cmd: list[str] = []
+    if extra_args:
+        exec_cmd = list(extra_args)
+    elif cfg.exec_aliases:
+        # Use the first defined alias
+        first_alias = next(iter(cfg.exec_aliases.values()))
+        exec_cmd = list(first_alias)
+    else:
+        exec_cmd = ["/bin/bash"]
+
+    # Run interactive session
+    exit_code = 0
+    container_name = f"{cfg.name}-cage"
+    exec_flags = ["-it"] if sys.stdin.isatty() else []
+
+    try:
+        click.echo(f"Starting interactive session... (Ctrl+D to exit)")
+        result = subprocess.run(
+            ["podman", "exec"] + exec_flags + [container_name] + exec_cmd,
+        )
+        exit_code = result.returncode
+    except KeyboardInterrupt:
+        click.echo("\nSession interrupted.")
+        exit_code = 130
+    finally:
+        click.echo(f"Stopping cage '{cage_name}'...")
+        try:
+            backend = get_backend(cfg)
+            backend.stop(cfg.name)
+        except Exception as e:
+            click.echo(f"warning: failed to stop cage: {e}", err=True)
+        click.echo(
+            f"Cage '{cage_name}' stopped. "
+            f"Audit: agentcage cage audit {cage_name}"
+        )
+
+    # Clean up temp config dir
+    shutil.rmtree(str(config_dir), ignore_errors=True)
+
+    return exit_code

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -86,21 +86,23 @@ def execute(
     name: str | None = None,
     secrets: tuple[str, ...] = (),
     extra_args: tuple[str, ...] = (),
+    verbose: bool = False,
 ) -> int:
     """Create a cage from a scaffold, run an interactive session, and clean up.
 
     Returns the exit code from the interactive session.
     """
+    from agentcage import output
+
     # Resolve scaffold aliases
     scaffold = _SCAFFOLD_ALIASES.get(scaffold, scaffold)
 
     # Validate scaffold exists
     available = list_scaffolds()
     if scaffold not in available:
-        click.echo(
-            f"error: unknown scaffold '{scaffold}'. "
-            f"Available: {', '.join(available)}",
-            err=True,
+        output.step_fail(
+            f"Unknown scaffold '{scaffold}'. "
+            f"Available: {', '.join(available)}"
         )
         return 1
 
@@ -122,15 +124,16 @@ def execute(
     cage_name = name or generate_name(scaffold)
 
     if state.deployment_exists(cage_name):
-        click.echo(
-            f"error: cage '{cage_name}' already exists. "
-            f"Use --name to specify a different name, or destroy it first.",
-            err=True,
+        output.step_fail(
+            f"Cage '{cage_name}' already exists. "
+            f"Use --name to specify a different name, or destroy it first."
         )
         return 1
 
+    # Print header
+    output.header(scaffold)
+
     # Render config from scaffold template
-    click.echo(f"Creating cage '{cage_name}'...")
     os.environ["PROJECT_DIR"] = project_dir
     config_text, image_tag = render_config(
         cage_name, scaffold=scaffold, isolation="container",
@@ -150,7 +153,7 @@ def execute(
     unavailable = check_port_availability(cfg)
     if unavailable:
         for spec, _bind, port in unavailable:
-            click.echo(f"error: port {port} is already in use ({spec})", err=True)
+            output.step_fail(f"Port {port} is already in use ({spec})")
         return 1
 
     # Save deployment state
@@ -171,7 +174,18 @@ def execute(
 
     # Run scaffold setup (build images) and deploy
     try:
-        run_scaffold_setup(scaffold, cage_name, str(config_path), image_tag=image_tag)
+        if verbose:
+            run_scaffold_setup(
+                scaffold, cage_name, str(config_path),
+                image_tag=image_tag,
+            )
+        else:
+            with output.Spinner("Building image..."):
+                run_scaffold_setup(
+                    scaffold, cage_name, str(config_path),
+                    image_tag=image_tag, quiet=True,
+                )
+        output.step_done("Image ready")
 
         podman = Podman()
 
@@ -188,7 +202,6 @@ def execute(
                 podman.secret_remove(full)
             podman.secret_create(full, val)
             provided_keys.add(key)
-            click.echo(f"Secret '{key}' set.")
 
         # Strip secret injection rules for secrets not provided —
         # keeps only rules whose secrets were passed via --set-secret.
@@ -205,27 +218,62 @@ def execute(
         # Save proxy config and get its host path (mounted into proxy container)
         config_host_path = state.save_proxy_config(cage_name)
 
-        build_and_deploy(
-            cfg,
-            config_host_path=config_host_path,
-            deploy_name=cage_name,
-            podman=podman,
-            used_octets=used_octets,
-        )
+        if verbose:
+            build_and_deploy(
+                cfg,
+                config_host_path=config_host_path,
+                deploy_name=cage_name,
+                podman=podman,
+                used_octets=used_octets,
+            )
+        else:
+            with output.Spinner("Building proxy..."):
+                build_and_deploy(
+                    cfg,
+                    config_host_path=config_host_path,
+                    deploy_name=cage_name,
+                    podman=podman,
+                    used_octets=used_octets,
+                    quiet=True,
+                )
+        output.step_done("Proxy built")
+        output.step_done("DNS ready")
+        output.step_done(f"Cage {click.style(cage_name, bold=True)} started")
+    except subprocess.CalledProcessError as e:
+        output.step_fail("Build failed")
+        # Dump captured build output for debugging
+        if e.stderr:
+            click.echo(e.stderr, err=True)
+        if e.stdout:
+            click.echo(e.stdout, err=True)
+        if state.deployment_exists(cage_name):
+            state.remove_deployment(cage_name)
+        shutil.rmtree(str(config_dir), ignore_errors=True)
+        return 1
     except Exception as e:
-        click.echo(f"error: failed to build/deploy cage: {e}", err=True)
+        output.step_fail(f"Failed to build/deploy cage: {e}")
         # Clean up partial state
         if state.deployment_exists(cage_name):
             state.remove_deployment(cage_name)
         shutil.rmtree(str(config_dir), ignore_errors=True)
         return 1
 
-    click.echo(f"Cage '{cage_name}' started.")
+    # Summary info
+    click.echo()
+    output.info("Project", project_dir)
 
-    if cfg.help:
-        click.echo("")
-        click.echo(cfg.help.rstrip())
-        click.echo("")
+    # Detect mounted auth
+    claude_dir = Path.home() / ".claude"
+    if claude_dir.is_dir():
+        output.info("Auth", "~/.claude (mounted)")
+    else:
+        output.info("Auth", output.dim("not configured"))
+
+    click.echo()
+    output.info("Ctrl+D", "to exit")
+    output.info("Audit", f"agentcage cage audit {cage_name}")
+    click.echo()
+    output.separator()
 
     # Determine the exec command: agent binary + any extra args
     if cfg.exec_aliases:
@@ -242,7 +290,6 @@ def execute(
     exec_flags = ["-it"] if sys.stdin.isatty() else []
 
     try:
-        click.echo(f"Starting interactive session... (Ctrl+D to exit)")
         result = subprocess.run(
             ["podman", "exec"] + exec_flags + [container_name] + exec_cmd,
         )
@@ -251,16 +298,16 @@ def execute(
         click.echo("\nSession interrupted.")
         exit_code = 130
     finally:
-        click.echo(f"Stopping cage '{cage_name}'...")
-        try:
-            backend = get_backend(cfg)
-            backend.stop(cfg.name)
-        except Exception as e:
-            click.echo(f"warning: failed to stop cage: {e}", err=True)
-        click.echo(
-            f"Cage '{cage_name}' stopped. "
-            f"Audit: agentcage cage audit {cage_name}"
-        )
+        click.echo()
+        output.separator()
+        with output.Spinner("Stopping cage..."):
+            try:
+                backend = get_backend(cfg)
+                backend.stop(cfg.name)
+            except Exception as e:
+                click.echo(f"warning: failed to stop cage: {e}", err=True)
+        output.step_done(f"Cage {click.style(cage_name, bold=True)} stopped")
+        output.info("Audit", f"agentcage cage audit {cage_name}")
 
     # Clean up temp config dir
     shutil.rmtree(str(config_dir), ignore_errors=True)

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -50,6 +50,11 @@ _SCAFFOLD_ALIASES: dict[str, str] = {
     "claude": "claude-code",
 }
 
+# Short prefixes for auto-generated cage names
+_NAME_PREFIXES: dict[str, str] = {
+    "claude-code": "claude",
+}
+
 _NOUNS = [
     "ant", "bay", "bee", "cod", "cow", "dew", "doe", "elm",
     "elk", "emu", "ewe", "fig", "fox", "gem", "gnu", "hog",
@@ -62,12 +67,13 @@ _NOUNS = [
 
 
 def generate_name(scaffold: str) -> str:
-    """Generate a unique cage name like ``claude-code-bold-fox``."""
+    """Generate a unique cage name like ``claude-bold-fox``."""
+    prefix = _NAME_PREFIXES.get(scaffold, scaffold)
     existing = set(state.list_deployments())
     for _ in range(100):
         adj = random.choice(_ADJECTIVES)
         noun = random.choice(_NOUNS)
-        name = f"{scaffold}-{adj}-{noun}"
+        name = f"{prefix}-{adj}-{noun}"
         if name not in existing:
             return name
     raise RuntimeError("Could not generate a unique cage name after 100 attempts")

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -227,16 +227,12 @@ def execute(
         click.echo(cfg.help.rstrip())
         click.echo("")
 
-    # Determine the exec command
-    meta_loaded = load_scaffold_meta(scaffold) or {}
-    # Use exec alias if defined, otherwise shell
-    exec_cmd: list[str] = []
-    if extra_args:
-        exec_cmd = list(extra_args)
-    elif cfg.exec_aliases:
-        # Use the first defined alias
+    # Determine the exec command: agent binary + any extra args
+    if cfg.exec_aliases:
         first_alias = next(iter(cfg.exec_aliases.values()))
-        exec_cmd = list(first_alias)
+        exec_cmd = list(first_alias) + list(extra_args)
+    elif extra_args:
+        exec_cmd = list(extra_args)
     else:
         exec_cmd = ["/bin/bash"]
 

--- a/src/agentcage/scaffolds/alpine-curl/Containerfile
+++ b/src/agentcage/scaffolds/alpine-curl/Containerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.21
+RUN apk add --no-cache curl

--- a/src/agentcage/scaffolds/alpine-curl/cage.yaml.j2
+++ b/src/agentcage/scaffolds/alpine-curl/cage.yaml.j2
@@ -1,0 +1,60 @@
+# agentcage configuration for {{ name }} (alpine-curl scaffold)
+#
+# Minimal Alpine container with curl for interactive proxy testing.
+#
+# Quick start:
+#   agentcage run alpine-curl
+#   curl -v https://example.com
+
+name: {{ name }}
+
+lifecycle: interactive
+
+scaffold: alpine-curl
+
+container:
+  image: "localhost/agentcage-scaffold-alpine-curl:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  memory: "256m"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Domain allowlist ──
+# Open by default for testing — restrict as needed.
+domains:
+  allow:
+    - example.com
+    - httpbin.org
+    - ifconfig.me
+
+# ── Logging ──
+logging:
+  level: info
+  dns: info
+
+# ── Inspectors ──
+inspectors:
+  - name: entropy
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  sh: ["sh"]
+
+# ── Help ──
+help: |
+  Interactive Alpine shell with curl:
+    agentcage cage exec {{ name }} -- sh
+
+  Test proxy:
+    curl -v https://example.com
+    curl https://httpbin.org/get

--- a/src/agentcage/scaffolds/alpine-curl/scaffold.yaml
+++ b/src/agentcage/scaffolds/alpine-curl/scaffold.yaml
@@ -1,0 +1,3 @@
+build:
+  - image: "localhost/agentcage-scaffold-alpine-curl:latest"
+    containerfile: "Containerfile"

--- a/src/agentcage/scaffolds/claude-code/Containerfile
+++ b/src/agentcage/scaffolds/claude-code/Containerfile
@@ -1,0 +1,20 @@
+FROM docker.io/library/node:22-slim
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        curl \
+        openssh-client \
+        build-essential \
+        python3 \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI (latest stable)
+RUN npm install -g @anthropic-ai/claude-code
+
+# node:22-slim already has user node (1000:1000)
+USER node
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -40,8 +40,9 @@ container:
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
     # Auth & settings — mount host ~/.claude so login persists across sessions.
-    # Remove this line to isolate cage state from the host.
+    # Remove these lines to isolate cage state from the host.
     - "~/.claude:/home/node/.claude:rw"
+    - "~/.claude.json:/home/node/.claude.json:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -47,6 +47,10 @@ container:
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
 
+  # Map host UID into container so mounted files have correct ownership
+  userns: "keep-id"
+  user: ""
+
   # Coding agents need to write to various paths in the home directory
   read_only: false
 

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -39,13 +39,12 @@ container:
   # Project directory — mount your repo here
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+    # Auth & settings — mount host ~/.claude so login persists across sessions.
+    # Remove this line to isolate cage state from the host.
+    - "~/.claude:/home/node/.claude:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
-
-  # Persistent agent state (survives cage destroy/create)
-  named_volumes:
-    {{ name }}-claude-home: "/home/node/.claude:rw"
 
   # Coding agents need to write to various paths in the home directory
   read_only: false

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -83,6 +83,11 @@ domains:
     - anthropic.com
     - claude.com
 
+    # ── Telemetry (Claude Code hangs on startup if these are blocked) ──
+    - datadoghq.com
+    - githubusercontent.com
+    - sentry.io
+
     # ── Package registries ──
     - npmjs.org
     - npmjs.com

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -1,0 +1,124 @@
+# agentcage configuration for {{ name }} (Claude Code scaffold)
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Start a session:
+#        agentcage cage exec {{ name }} -- claude
+#   3. Or use the run command:
+#        agentcage run claude-code
+#
+# Authentication:
+#   Option A — Subscription (Claude Pro/Team/Enterprise):
+#     agentcage cage exec {{ name }} -- claude login
+#     (follow the URL to authenticate, token saved in ~/.claude volume)
+#
+#   Option B — API key:
+#     agentcage secret set {{ name }} ANTHROPIC_API_KEY
+#     agentcage cage restart {{ name }}
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 4096
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: claude-code
+
+container:
+  image: "localhost/agentcage-scaffold-claude-code:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+  #  # Git config (uncomment to enable)
+  #  - "~/.gitconfig:/home/node/.gitconfig:ro"
+  #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
+
+  # Persistent agent state (survives cage destroy/create)
+  named_volumes:
+    {{ name }}-claude-home: "/home/node/.claude:rw"
+
+  # Coding agents need to write to various paths in the home directory
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=256M"
+
+  # Resource limits
+  memory: "2g"
+  cpus: "2.0"
+
+  timeout_start_sec: 60
+
+# ── Secret injection ──
+# API keys are swapped by the proxy — the cage only sees placeholders.
+# Create each secret:  agentcage secret set {{ name }} ANTHROPIC_API_KEY
+secret_injection:
+  - env: ANTHROPIC_API_KEY
+    placeholder: "{%raw%}{{ANTHROPIC_API_KEY}}{%endraw%}"
+    inject_to:
+      - anthropic.com
+
+  # Uncomment for GitHub push via HTTPS:
+  #- env: GITHUB_TOKEN
+  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  inject_to:
+  #    - github.com
+
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "anthropic.com" also allows
+# "api.anthropic.com").
+domains:
+  allow:
+    # ── AI provider ──
+    - anthropic.com
+    - claude.com
+
+    # ── Package registries ──
+    - npmjs.org
+    - npmjs.com
+    - pypi.org
+    - files.pythonhosted.org
+    - nodejs.org
+
+    # ── Code hosting (uncomment for git push) ──
+    #- github.com
+    #- githubusercontent.com
+
+    # Add domains your agent needs access to:
+    #- example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: entropy
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  claude: ["claude"]
+
+# ── Help ──
+help: |
+  Start a Claude Code session:
+    agentcage cage exec {{ name }} -- claude
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run claude-code
+
+  Authentication:
+    Subscription: agentcage cage exec {{ name }} -- claude login
+    API key:      agentcage secret set {{ name }} ANTHROPIC_API_KEY

--- a/src/agentcage/scaffolds/claude-code/scaffold.yaml
+++ b/src/agentcage/scaffolds/claude-code/scaffold.yaml
@@ -1,0 +1,9 @@
+build:
+  - image: "localhost/agentcage-scaffold-claude-code:latest"
+    containerfile: "Containerfile"
+    cap_add: [CAP_SETFCAP, CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- claude"
+  - "Or use: agentcage run claude-code"

--- a/src/agentcage/scaffolds/codex/Containerfile
+++ b/src/agentcage/scaffolds/codex/Containerfile
@@ -1,0 +1,20 @@
+FROM docker.io/library/node:22-slim
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        curl \
+        openssh-client \
+        build-essential \
+        python3 \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install OpenAI Codex CLI (latest stable)
+RUN npm install -g @openai/codex
+
+# node:22-slim already has user node (1000:1000)
+USER node
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -1,0 +1,115 @@
+# agentcage configuration for {{ name }} (Codex scaffold)
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Start a session:
+#        agentcage cage exec {{ name }} -- codex
+#   3. Or use the run command:
+#        agentcage run codex
+#
+# Authentication:
+#   agentcage secret set {{ name }} OPENAI_API_KEY
+#   agentcage cage restart {{ name }}
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 4096
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: codex
+
+container:
+  image: "localhost/agentcage-scaffold-codex:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+  #  # Git config (uncomment to enable)
+  #  - "~/.gitconfig:/home/node/.gitconfig:ro"
+  #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
+
+  # Persistent agent state (survives cage destroy/create)
+  named_volumes:
+    {{ name }}-codex-home: "/home/node/.codex:rw"
+
+  # Coding agents need to write to various paths in the home directory
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=256M"
+
+  # Resource limits
+  memory: "2g"
+  cpus: "2.0"
+
+  timeout_start_sec: 60
+
+# ── Secret injection ──
+# API keys are swapped by the proxy — the cage only sees placeholders.
+# Create each secret:  agentcage secret set {{ name }} OPENAI_API_KEY
+secret_injection:
+  - env: OPENAI_API_KEY
+    placeholder: "{%raw%}{{OPENAI_API_KEY}}{%endraw%}"
+    inject_to:
+      - openai.com
+
+  # Uncomment for GitHub push via HTTPS:
+  #- env: GITHUB_TOKEN
+  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  inject_to:
+  #    - github.com
+
+# ── Domain allowlist ──
+domains:
+  allow:
+    # ── AI provider ──
+    - openai.com
+
+    # ── Package registries ──
+    - npmjs.org
+    - npmjs.com
+    - pypi.org
+    - files.pythonhosted.org
+    - nodejs.org
+
+    # ── Code hosting (uncomment for git push) ──
+    #- github.com
+    #- githubusercontent.com
+
+    # Add domains your agent needs access to:
+    #- example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: entropy
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  codex: ["codex"]
+
+# ── Help ──
+help: |
+  Start a Codex session:
+    agentcage cage exec {{ name }} -- codex
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run codex
+
+  Set your API key:
+    agentcage secret set {{ name }} OPENAI_API_KEY

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -34,13 +34,12 @@ container:
   # Project directory — mount your repo here
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+    # Auth & settings — mount host ~/.codex so login persists across sessions.
+    # Remove this line to isolate cage state from the host.
+    - "~/.codex:/home/node/.codex:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
-
-  # Persistent agent state (survives cage destroy/create)
-  named_volumes:
-    {{ name }}-codex-home: "/home/node/.codex:rw"
 
   # Coding agents need to write to various paths in the home directory
   read_only: false

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -41,6 +41,10 @@ container:
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
 
+  # Map host UID into container so mounted files have correct ownership
+  userns: "keep-id"
+  user: ""
+
   # Coding agents need to write to various paths in the home directory
   read_only: false
 

--- a/src/agentcage/scaffolds/codex/scaffold.yaml
+++ b/src/agentcage/scaffolds/codex/scaffold.yaml
@@ -1,0 +1,9 @@
+build:
+  - image: "localhost/agentcage-scaffold-codex:latest"
+    containerfile: "Containerfile"
+    cap_add: [CAP_SETFCAP, CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- codex"
+  - "Or use: agentcage run codex"

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -205,3 +205,35 @@ def restart_cage(name: str, cfg=None):
         cfg = state.load_deployment_config(name)
     backend = get_backend(cfg)
     backend.restart(name)
+
+
+def destroy_cage(
+    name: str,
+    *,
+    keep_secrets: bool = False,
+    echo: Callable[[str], None] | None = None,
+) -> list[str]:
+    """Stop and destroy a cage, removing all resources.
+
+    Returns a list of removed resource descriptions.
+    """
+    _echo = echo or (lambda _: None)
+
+    try:
+        cfg = state.load_deployment_config(name)
+        backend = get_backend(cfg)
+    except Exception:
+        from agentcage.backends.container import ContainerBackend
+        backend = ContainerBackend()
+
+    _echo("Stopping services...")
+    backend.stop(name)
+
+    _echo("Removing resources...")
+    removed = backend.destroy_resources(name, keep_secrets=keep_secrets)
+
+    if state.deployment_exists(name):
+        state.remove_deployment(name)
+        removed.append(f"state:{name}")
+
+    return removed

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -169,6 +169,7 @@ def build_and_deploy(
     deploy_name: str,
     podman: Podman,
     used_octets: set[int] | None = None,
+    quiet: bool = False,
 ):
     """Build images, generate quadlets, install, and start."""
     from agentcage.quadlets import cage_network_addrs
@@ -183,10 +184,10 @@ def build_and_deploy(
     with open(resolv_path, "w") as f:
         f.write(f"nameserver {addrs['ip_dns']}\n")
 
-    backend.build_artifacts(cfg, deploy_name)
+    backend.build_artifacts(cfg, deploy_name, quiet=quiet)
 
     units = backend.generate_units(cfg, config_host_path, patches_work, deploy_name, used_octets=used_octets)
-    backend.install_units(units)
+    backend.install_units(units, quiet=quiet)
 
     # Persist the actual assigned network octet so collect_used_octets()
     # can read the real value instead of recomputing the hash (which
@@ -196,7 +197,7 @@ def build_and_deploy(
     meta["network_octet"] = octet
     state.save_metadata(deploy_name, meta)
 
-    backend.start(cfg.name)
+    backend.start(cfg.name, quiet=quiet)
 
 
 def restart_cage(name: str, cfg=None):

--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -39,6 +39,9 @@ Environment="{{ key }}={{ val }}"
 {% for key, val in cage_placeholders %}
 Environment="{{ key }}={{ val }}"
 {% endfor %}
+{% if userns %}
+UserNS={{ userns }}
+{% endif %}
 {% if user %}
 User={{ user }}
 {% endif %}

--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -92,4 +92,6 @@ TimeoutStopSec={{ timeout_stop_sec }}
 {% endif %}
 
 [Install]
+{% if lifecycle == "service" %}
 WantedBy=default.target
+{% endif %}

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -33,13 +33,15 @@ else
   e2e_fail "3.2" "Placeholder in cage env" "got '$OUTPUT', expected '{{MY_API_KEY}}'"
 fi
 
-# 3.3: Injection on outbound — send placeholder, then poll audit for injection record
-curl -s -X POST -H 'Content-Type: application/json' \
-  -d '{"key":"{{MY_API_KEY}}"}' "$BASE/check-secret" >/dev/null 2>&1 || true
+# 3.3: Injection on outbound — send placeholder, then poll audit for injection record.
+# Retry the triggering curl on each iteration since the outbound proxy or
+# httpbin.org may not be ready on the first attempt.
 FOUND=false
-for _i in $(seq 1 10); do
+for _i in $(seq 1 15); do
+  curl -s -X POST -H 'Content-Type: application/json' \
+    -d '{"key":"{{MY_API_KEY}}"}' "$BASE/check-secret" >/dev/null 2>&1 || true
   sleep 2
-  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 10 2>&1) || true
+  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 20 2>&1) || true
   if echo "$OUTPUT" | grep -q "secrets_injected"; then
     FOUND=true
     break
@@ -48,7 +50,7 @@ done
 if [ "$FOUND" = true ]; then
   e2e_pass "3.3" "Injection on outbound"
 else
-  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 20s"
+  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 30s"
 fi
 
 # 3.4: Set new secret

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -6,6 +6,7 @@ import json
 import textwrap
 from unittest.mock import MagicMock, patch, call, ANY
 
+import click
 from click.testing import CliRunner
 
 from agentcage.cli import main
@@ -82,33 +83,19 @@ class TestCageUpdate:
 
 
 class TestCageDestroy:
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_destroy_with_yes(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        podman = MockPodman.return_value
-        podman.network_remove.return_value = False
-        podman.volume_remove.return_value = False
-        podman.secret_list.return_value = [{"Name": "test.API_KEY"}]
-        podman.secret_remove.return_value = True
-        mock_state.deployment_exists.return_value = True
+    @patch("agentcage.cli._destroy_cage")
+    def test_destroy_with_yes(self, mock_destroy, tmp_path):
+        mock_destroy.return_value = ["state:test"]
 
         result = _runner().invoke(main, ["cage", "destroy", "test", "-y"])
         assert result.exit_code == 0
-        mock_state.remove_deployment.assert_called_once_with("test")
+        mock_destroy.assert_called_once_with("test", keep_secrets=False, echo=click.echo)
 
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_destroy_prompts_without_yes(self, mock_state, MockPodman, mock_systemd):
-        podman = MockPodman.return_value
-        podman.network_remove.return_value = False
-        podman.volume_remove.return_value = False
-        podman.secret_list.return_value = []
-        mock_state.deployment_exists.return_value = False
-
+    @patch("agentcage.cli._destroy_cage")
+    def test_destroy_prompts_without_yes(self, mock_destroy):
         result = _runner().invoke(main, ["cage", "destroy", "test"], input="n\n")
         assert result.exit_code != 0  # aborted
+        mock_destroy.assert_not_called()
 
 
 class TestCageList:
@@ -132,7 +119,7 @@ class TestCageList:
         assert result.exit_code == 0
         assert "myapp" in result.output
         assert "container" in result.output
-        assert "1.2.3" in result.output
+        assert "service" in result.output  # default lifecycle
         assert "running (3/3)" in result.output
 
     @patch("agentcage.cli.get_backend")
@@ -148,7 +135,6 @@ class TestCageList:
         assert result.exit_code == 0
         assert "myvm" in result.output
         assert "vm" in result.output
-        assert "0.9.0" in result.output
         assert "running (1/1)" in result.output
 
     @patch("agentcage.cli.get_backend")
@@ -163,11 +149,11 @@ class TestCageList:
         result = _runner().invoke(main, ["cage", "list"])
         assert result.exit_code == 0
         assert "old" in result.output
-        # VERSION column header present, value is "-"
-        assert "VERSION" in result.output
+        # LIFECYCLE column header present
+        assert "LIFECYCLE" in result.output
         lines = result.output.strip().split("\n")
         data_line = [l for l in lines if "old" in l][0]
-        assert "-" in data_line
+        assert "service" in data_line  # default lifecycle
 
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
@@ -431,9 +417,11 @@ class TestCageVerify:
         assert "1 warnings" in result.output
 
 
-def _mock_config(isolation="container"):
+def _mock_config(isolation="container", lifecycle="service", scaffold=""):
     cfg = MagicMock()
     cfg.isolation = isolation
+    cfg.lifecycle = lifecycle
+    cfg.scaffold = scaffold
     cfg.container.nested_containers = False
     return cfg
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,201 @@
+"""Tests for lifecycle config field and its effects on quadlet generation.
+
+These tests specify the expected behavior of the lifecycle feature:
+- Config.lifecycle field with values "service", "interactive", "ephemeral"
+- validate_config() rejects invalid lifecycle values
+- Quadlet generation maps lifecycle to Restart and WantedBy settings
+"""
+
+import textwrap
+
+import pytest
+
+from agentcage.config import Config, ContainerConfig, load_config, validate_config
+
+_has_lifecycle = hasattr(Config, "lifecycle")
+_skip_reason = "lifecycle field not yet implemented on Config"
+
+
+@pytest.mark.skipif(not _has_lifecycle, reason=_skip_reason)
+class TestLifecycleConfigParsing:
+    """Verify lifecycle field is parsed from YAML config."""
+
+    def test_lifecycle_defaults_to_service(self, tmp_path):
+        """When lifecycle is omitted, it defaults to 'service'."""
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        assert cfg.lifecycle == "service"
+
+    def test_lifecycle_service(self, tmp_path):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            lifecycle: service
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        assert cfg.lifecycle == "service"
+
+    def test_lifecycle_interactive(self, tmp_path):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            lifecycle: interactive
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        assert cfg.lifecycle == "interactive"
+
+    def test_lifecycle_ephemeral(self, tmp_path):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            lifecycle: ephemeral
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        assert cfg.lifecycle == "ephemeral"
+
+
+@pytest.mark.skipif(not _has_lifecycle, reason=_skip_reason)
+class TestLifecycleValidation:
+    """Verify validate_config rejects invalid lifecycle values."""
+
+    def test_invalid_lifecycle_raises(self, tmp_path):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            lifecycle: invalid
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        with pytest.raises(ValueError, match="lifecycle"):
+            validate_config(cfg)
+
+    def test_valid_lifecycles_pass_validation(self, tmp_path):
+        for lifecycle in ("service", "interactive", "ephemeral"):
+            p = tmp_path / "cage.yaml"
+            p.write_text(textwrap.dedent(f"""\
+                name: test
+                lifecycle: {lifecycle}
+                container:
+                  image: localhost/test:latest
+            """))
+            cfg = load_config(str(p))
+            # Should not raise
+            validate_config(cfg)
+
+
+@pytest.mark.skipif(not _has_lifecycle, reason=_skip_reason)
+class TestLifecycleQuadletMapping:
+    """Verify lifecycle affects Restart and WantedBy in generated quadlets."""
+
+    def _generate(self, tmp_path, lifecycle):
+        from agentcage.quadlets import generate_quadlets
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent(f"""\
+            name: test
+            lifecycle: {lifecycle}
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        return generate_quadlets(cfg, str(p), "/patches")
+
+    def test_service_lifecycle_has_restart_on_failure(self, tmp_path):
+        files = self._generate(tmp_path, "service")
+        cage = files["test-cage.container"]
+        assert "Restart=on-failure" in cage
+
+    def test_service_lifecycle_has_wantedby(self, tmp_path):
+        files = self._generate(tmp_path, "service")
+        cage = files["test-cage.container"]
+        assert "WantedBy=default.target" in cage
+
+    def test_interactive_lifecycle_has_restart_no(self, tmp_path):
+        files = self._generate(tmp_path, "interactive")
+        cage = files["test-cage.container"]
+        assert "Restart=no" in cage
+
+    def test_interactive_lifecycle_no_wantedby(self, tmp_path):
+        files = self._generate(tmp_path, "interactive")
+        cage = files["test-cage.container"]
+        assert "WantedBy" not in cage
+
+    def test_ephemeral_lifecycle_has_restart_no(self, tmp_path):
+        files = self._generate(tmp_path, "ephemeral")
+        cage = files["test-cage.container"]
+        assert "Restart=no" in cage
+
+    def test_ephemeral_lifecycle_no_wantedby(self, tmp_path):
+        files = self._generate(tmp_path, "ephemeral")
+        cage = files["test-cage.container"]
+        assert "WantedBy" not in cage
+
+
+class TestExistingRestartConfig:
+    """Verify the existing restart config field works correctly with quadlets.
+
+    These tests verify current behavior which lifecycle will build upon.
+    """
+
+    def test_default_restart_is_on_failure(self, tmp_path):
+        """Default restart policy is on-failure."""
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        assert cfg.container.restart == "on-failure"
+
+    def test_restart_no_in_config(self, tmp_path):
+        """Setting restart: no disables automatic restarts."""
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: localhost/test:latest
+              restart: "no"
+        """))
+        cfg = load_config(str(p))
+        assert cfg.container.restart == "no"
+
+    def test_restart_appears_in_quadlet(self, tmp_path):
+        """Restart policy is propagated to the cage quadlet."""
+        from agentcage.quadlets import generate_quadlets
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: localhost/test:latest
+              restart: "no"
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, str(p), "/patches")
+        cage = files["test-cage.container"]
+        assert "Restart=no" in cage
+
+    def test_wantedby_present_by_default(self, tmp_path):
+        """By default, WantedBy=default.target enables auto-start."""
+        from agentcage.quadlets import generate_quadlets
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: localhost/test:latest
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, str(p), "/patches")
+        cage = files["test-cage.container"]
+        assert "WantedBy=default.target" in cage

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -15,7 +15,9 @@ class TestGenerateName:
     def test_produces_valid_cage_name(self, _mock):
         name = generate_name("claude-code")
         assert re.match(r'^[a-z0-9][a-z0-9-]{0,62}$', name)
-        assert name.startswith("claude-code-")
+        assert name.startswith("claude-")
+        # Should use short prefix, not full scaffold name
+        assert not name.startswith("claude-code-")
 
     @patch("agentcage.run.state.list_deployments", return_value=[])
     def test_names_are_unique(self, _mock):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,43 @@
+"""Tests for agentcage.run module (generate_name, execute)."""
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from agentcage.run import generate_name
+
+
+class TestGenerateName:
+    """Verify auto-naming for ephemeral/interactive cages."""
+
+    @patch("agentcage.run.state.list_deployments", return_value=[])
+    def test_produces_valid_cage_name(self, _mock):
+        name = generate_name("claude-code")
+        assert re.match(r'^[a-z0-9][a-z0-9-]{0,62}$', name)
+        assert name.startswith("claude-code-")
+
+    @patch("agentcage.run.state.list_deployments", return_value=[])
+    def test_names_are_unique(self, _mock):
+        names = {generate_name("test") for _ in range(50)}
+        assert len(names) >= 40
+
+    @patch("agentcage.run.state.list_deployments",
+           return_value=["test-bold-fox", "test-calm-owl"])
+    def test_avoids_existing_names(self, _mock):
+        for _ in range(20):
+            name = generate_name("test")
+            assert name not in ("test-bold-fox", "test-calm-owl")
+
+    @patch("agentcage.run.state.list_deployments", return_value=[])
+    def test_name_not_too_long(self, _mock):
+        name = generate_name("claude-code")
+        assert len(name) <= 63
+
+    @patch("agentcage.run.state.list_deployments", return_value=[])
+    def test_includes_scaffold_prefix(self, _mock):
+        name = generate_name("codex")
+        assert name.startswith("codex-")
+        # Should have adjective-noun after prefix
+        parts = name.split("-")
+        assert len(parts) >= 3

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -1,0 +1,256 @@
+"""Tests for scaffold-related CLI commands and cage list/prune/destroy integration."""
+
+from __future__ import annotations
+
+import textwrap
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from agentcage.cli import main
+
+
+def _runner():
+    return CliRunner()
+
+
+class TestInitListScaffolds:
+    """Test 'agentcage init --list-scaffolds'."""
+
+    def test_list_scaffolds_shows_available(self):
+        result = _runner().invoke(main, ["init", "--list-scaffolds"])
+        assert result.exit_code == 0
+        assert "openclaw" in result.output
+        assert "nanoclaw" in result.output
+        assert "picoclaw" in result.output
+
+    def test_list_scaffolds_header(self):
+        result = _runner().invoke(main, ["init", "--list-scaffolds"])
+        assert "Available scaffolds" in result.output
+
+
+class TestInitWithScaffold:
+    """Test 'agentcage init <name> --scaffold <scaffold>'."""
+
+    def test_invalid_scaffold_rejected(self):
+        result = _runner().invoke(main, ["init", "test", "--scaffold", "nonexistent"])
+        assert result.exit_code != 0
+        assert "unknown scaffold" in result.output
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_scaffold_creates_file(self, mock_resolve, tmp_path):
+        dest = tmp_path / "cage.yaml"
+        result = _runner().invoke(main, [
+            "init", "my-oc", "--scaffold", "openclaw", "-o", str(dest),
+        ])
+        assert result.exit_code == 0
+        assert dest.exists()
+        content = dest.read_text()
+        assert "my-oc" in content
+
+    def test_nanoclaw_scaffold_creates_file(self, tmp_path):
+        dest = tmp_path / "cage.yaml"
+        result = _runner().invoke(main, [
+            "init", "my-nano", "--scaffold", "nanoclaw", "-o", str(dest),
+        ])
+        assert result.exit_code == 0
+        assert dest.exists()
+        content = dest.read_text()
+        assert "my-nano" in content
+
+    def test_init_invalid_name_rejected(self):
+        result = _runner().invoke(main, ["init", "INVALID_NAME"])
+        assert result.exit_code != 0
+        assert "must be" in result.output
+
+    def test_init_requires_name(self):
+        result = _runner().invoke(main, ["init"])
+        assert result.exit_code != 0
+
+
+class TestCageListColumns:
+    """Test that cage list shows the expected columns."""
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_list_shows_name_column(self, mock_state, mock_get_backend):
+        mock_state.list_deployments.return_value = ["myapp"]
+        cfg = MagicMock()
+        cfg.isolation = "container"
+        cfg.lifecycle = "service"
+        cfg.scaffold = ""
+        cfg.container.nested_containers = False
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {}
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        result = _runner().invoke(main, ["cage", "list"])
+        assert result.exit_code == 0
+        assert "NAME" in result.output
+        assert "myapp" in result.output
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_list_shows_isolation_column(self, mock_state, mock_get_backend):
+        mock_state.list_deployments.return_value = ["myapp"]
+        cfg = MagicMock()
+        cfg.isolation = "container"
+        cfg.lifecycle = "service"
+        cfg.scaffold = ""
+        cfg.container.nested_containers = False
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {}
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage"]
+        backend.is_running.return_value = True
+        result = _runner().invoke(main, ["cage", "list"])
+        assert "ISOLATION" in result.output
+        assert "container" in result.output
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_list_shows_lifecycle_column(self, mock_state, mock_get_backend):
+        mock_state.list_deployments.return_value = ["myapp"]
+        cfg = MagicMock()
+        cfg.isolation = "container"
+        cfg.lifecycle = "interactive"
+        cfg.scaffold = "claude-code"
+        cfg.container.nested_containers = False
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {"lifecycle": "interactive", "scaffold": "claude-code"}
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage"]
+        backend.is_running.return_value = False
+        result = _runner().invoke(main, ["cage", "list"])
+        assert "LIFECYCLE" in result.output
+        assert "interactive" in result.output
+        assert "claude-code" in result.output
+        assert "exited" in result.output
+
+    @patch("agentcage.cli.state")
+    def test_list_empty(self, mock_state):
+        mock_state.list_deployments.return_value = []
+        result = _runner().invoke(main, ["cage", "list"])
+        assert result.exit_code == 0
+        assert "No" in result.output
+
+
+class TestCageDestroyCommand:
+    """Test cage destroy CLI command."""
+
+    @patch("agentcage.cli._destroy_cage")
+    def test_destroy_aborts_without_confirmation(self, mock_destroy):
+        result = _runner().invoke(main, ["cage", "destroy", "test"], input="n\n")
+        assert result.exit_code != 0
+        mock_destroy.assert_not_called()
+
+    @patch("agentcage.cli._destroy_cage")
+    def test_destroy_with_yes_flag(self, mock_destroy):
+        mock_destroy.return_value = ["state:test"]
+        result = _runner().invoke(main, ["cage", "destroy", "test", "-y"])
+        assert result.exit_code == 0
+
+    @patch("agentcage.cli._destroy_cage")
+    def test_destroy_nothing_to_remove(self, mock_destroy):
+        mock_destroy.return_value = []
+        result = _runner().invoke(main, ["cage", "destroy", "test", "-y"])
+        assert result.exit_code == 0
+        assert "Nothing to remove" in result.output
+
+
+class TestCagePrune:
+    """Test cage prune CLI command."""
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_prune_nothing(self, mock_state, mock_get_backend):
+        mock_state.list_deployments.return_value = []
+        result = _runner().invoke(main, ["cage", "prune"])
+        assert result.exit_code == 0
+        assert "Nothing to prune" in result.output
+
+    @patch("agentcage.cli._destroy_cage")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_prune_removes_exited_interactive(self, mock_state, mock_get_backend, mock_destroy):
+        mock_state.list_deployments.return_value = ["cc-bold-fox", "my-openclaw"]
+
+        # cc-bold-fox: interactive, stopped
+        cc_cfg = MagicMock()
+        cc_cfg.lifecycle = "interactive"
+        cc_cfg.scaffold = "claude-code"
+
+        # my-openclaw: service, running
+        oc_cfg = MagicMock()
+        oc_cfg.lifecycle = "service"
+        oc_cfg.scaffold = "openclaw"
+
+        mock_state.load_deployment_config.side_effect = lambda n: {
+            "cc-bold-fox": cc_cfg, "my-openclaw": oc_cfg
+        }[n]
+        mock_state.load_metadata.side_effect = lambda n: {
+            "cc-bold-fox": {"lifecycle": "interactive"},
+            "my-openclaw": {"lifecycle": "service"},
+        }[n]
+
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        # cc-bold-fox stopped, my-openclaw running
+        def is_running(name, svc):
+            return name == "my-openclaw"
+        backend.is_running.side_effect = is_running
+
+        mock_destroy.return_value = []
+        result = _runner().invoke(main, ["cage", "prune", "-y"])
+        assert result.exit_code == 0
+        # Only cc-bold-fox should be pruned
+        mock_destroy.assert_called_once()
+        assert "cc-bold-fox" in mock_destroy.call_args[0]
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_prune_skips_running_interactive(self, mock_state, mock_get_backend):
+        mock_state.list_deployments.return_value = ["cc-running"]
+        cfg = MagicMock()
+        cfg.lifecycle = "interactive"
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {"lifecycle": "interactive"}
+        backend = mock_get_backend.return_value
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True  # all running
+        result = _runner().invoke(main, ["cage", "prune"])
+        assert "Nothing to prune" in result.output
+
+
+class TestRunCommand:
+    """Test agentcage run CLI command basics."""
+
+    def test_run_help(self):
+        result = _runner().invoke(main, ["run", "--help"])
+        assert result.exit_code == 0
+        assert "scaffold" in result.output.lower() or "SCAFFOLD" in result.output
+
+    def test_cage_help_shows_prune(self):
+        result = _runner().invoke(main, ["cage", "--help"])
+        assert "prune" in result.output
+
+
+class TestCageHelp:
+    """Verify cage help includes expected subcommands."""
+
+    def test_cage_help_shows_list(self):
+        result = _runner().invoke(main, ["cage", "--help"])
+        assert "list" in result.output
+
+    def test_cage_help_shows_destroy(self):
+        result = _runner().invoke(main, ["cage", "--help"])
+        assert "destroy" in result.output
+
+    def test_cage_help_shows_create(self):
+        result = _runner().invoke(main, ["cage", "--help"])
+        assert "create" in result.output
+
+    def test_cage_help_shows_verify(self):
+        result = _runner().invoke(main, ["cage", "--help"])
+        assert "verify" in result.output

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -180,11 +180,11 @@ class TestCodingAgentScaffolds:
         cfg = load_config(str(p))
         validate_config(cfg)
 
-    def test_claude_code_has_named_volume(self):
+    def test_claude_code_mounts_host_claude_dir(self):
         cfg_text, _ = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
-        named = parsed.get("container", {}).get("named_volumes", {})
-        assert any("claude" in k.lower() for k in named)
+        volumes = parsed.get("container", {}).get("volumes", [])
+        assert any(".claude:" in v for v in volumes)
 
     def test_claude_code_has_secret_injection(self):
         cfg_text, _ = render_config("test-cc", scaffold="claude-code")

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -1,0 +1,234 @@
+"""Tests for scaffold listing, rendering, and metadata loading."""
+
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from agentcage.init import list_scaffolds, render_config, load_scaffold_meta
+
+
+class TestListScaffolds:
+    """Verify list_scaffolds() returns all available scaffold names."""
+
+    def test_returns_sorted_list(self):
+        scaffolds = list_scaffolds()
+        assert scaffolds == sorted(scaffolds)
+
+    def test_includes_known_scaffolds(self):
+        """The scaffolds/ directory should contain at least the shipped scaffolds."""
+        scaffolds = list_scaffolds()
+        assert "openclaw" in scaffolds
+        assert "nanoclaw" in scaffolds
+        assert "picoclaw" in scaffolds
+        assert "claude-code" in scaffolds
+        assert "codex" in scaffolds
+
+    def test_returns_list_of_strings(self):
+        scaffolds = list_scaffolds()
+        assert isinstance(scaffolds, list)
+        for s in scaffolds:
+            assert isinstance(s, str)
+
+
+class TestScaffoldMeta:
+    """Verify scaffold.yaml metadata files are loadable."""
+
+    def test_openclaw_has_build_entry(self):
+        meta = load_scaffold_meta("openclaw")
+        assert meta is not None
+        assert "build" in meta
+        assert len(meta["build"]) > 0
+
+    def test_nanoclaw_has_next_steps(self):
+        meta = load_scaffold_meta("nanoclaw")
+        assert meta is not None
+        assert "next_steps" in meta
+
+    def test_picoclaw_has_build_entry(self):
+        meta = load_scaffold_meta("picoclaw")
+        assert meta is not None
+        assert "build" in meta
+
+    def test_nonexistent_scaffold_returns_none(self):
+        assert load_scaffold_meta("nonexistent-scaffold-xyz") is None
+
+
+class TestScaffoldRendering:
+    """Verify scaffold templates render to valid YAML."""
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_renders_valid_yaml(self, mock_resolve):
+        cfg_text, tag = render_config("my-oc", scaffold="openclaw")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed["name"] == "my-oc"
+        assert "container" in parsed
+        assert "image" in parsed["container"]
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_renders_parseable_config(self, mock_resolve, tmp_path):
+        from agentcage.config import load_config
+        cfg_text, _ = render_config("test-oc", scaffold="openclaw")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        assert cfg.name == "test-oc"
+        assert cfg.container.image != ""
+
+    def test_nanoclaw_renders_valid_yaml(self):
+        cfg_text, _ = render_config("my-nano", scaffold="nanoclaw")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed["name"] == "my-nano"
+        assert "container" in parsed
+        assert parsed["container"]["nested_containers"] is True
+
+    def test_nanoclaw_renders_parseable_config(self, tmp_path):
+        from agentcage.config import load_config
+        cfg_text, _ = render_config("test-nano", scaffold="nanoclaw")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        assert cfg.name == "test-nano"
+        assert cfg.container.nested_containers is True
+
+    def test_default_scaffold_renders_valid_yaml(self):
+        cfg_text, tag = render_config("my-test")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed["name"] == "my-test"
+        assert tag is None
+
+    def test_invalid_scaffold_raises(self):
+        """Attempting to render a non-existent scaffold should raise."""
+        with pytest.raises(Exception):
+            render_config("test", scaffold="nonexistent-scaffold-xyz")
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_with_vm_isolation(self, mock_resolve):
+        cfg_text, _ = render_config("vm-oc", scaffold="openclaw", isolation="vm")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed.get("isolation") == "vm"
+        assert "vm" in parsed
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_with_custom_port(self, mock_resolve):
+        cfg_text, _ = render_config("port-oc", scaffold="openclaw", port=9999)
+        parsed = yaml.safe_load(cfg_text)
+        # The port should appear in the ports config
+        ports = parsed.get("container", {}).get("ports", [])
+        assert any("9999" in p for p in ports)
+
+
+class TestCodingAgentScaffolds:
+    """Verify claude-code and codex scaffolds render and validate correctly."""
+
+    def test_claude_code_renders_valid_yaml(self):
+        cfg_text, _ = render_config("my-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed["name"] == "my-cc"
+        assert parsed["lifecycle"] == "interactive"
+        assert parsed["scaffold"] == "claude-code"
+        assert "container" in parsed
+        assert parsed["container"]["command"] == ["sleep", "infinity"]
+
+    def test_codex_renders_valid_yaml(self):
+        cfg_text, _ = render_config("my-cx", scaffold="codex")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed["name"] == "my-cx"
+        assert parsed["lifecycle"] == "interactive"
+        assert parsed["scaffold"] == "codex"
+        assert "container" in parsed
+
+    def test_claude_code_has_anthropic_domain(self):
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        domains = parsed.get("domains", {}).get("allow", [])
+        assert "anthropic.com" in domains
+
+    def test_codex_has_openai_domain(self):
+        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        parsed = yaml.safe_load(cfg_text)
+        domains = parsed.get("domains", {}).get("allow", [])
+        assert "openai.com" in domains
+
+    def test_claude_code_has_exec_alias(self):
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        assert "exec_aliases" in parsed
+        assert "claude" in parsed["exec_aliases"]
+
+    def test_codex_has_exec_alias(self):
+        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        parsed = yaml.safe_load(cfg_text)
+        assert "exec_aliases" in parsed
+        assert "codex" in parsed["exec_aliases"]
+
+    def test_claude_code_passes_validation(self, tmp_path):
+        from agentcage.config import load_config, validate_config
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        validate_config(cfg)
+
+    def test_codex_passes_validation(self, tmp_path):
+        from agentcage.config import load_config, validate_config
+        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        validate_config(cfg)
+
+    def test_claude_code_has_named_volume(self):
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        named = parsed.get("container", {}).get("named_volumes", {})
+        assert any("claude" in k.lower() for k in named)
+
+    def test_claude_code_has_secret_injection(self):
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        secrets = parsed.get("secret_injection", [])
+        assert any(s["env"] == "ANTHROPIC_API_KEY" for s in secrets)
+
+    def test_claude_code_has_help_text(self):
+        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        parsed = yaml.safe_load(cfg_text)
+        assert parsed.get("help", "") != ""
+
+    def test_claude_code_scaffold_meta(self):
+        meta = load_scaffold_meta("claude-code")
+        assert meta is not None
+        assert "build" in meta
+        assert meta["build"][0]["image"] == "localhost/agentcage-scaffold-claude-code:latest"
+
+    def test_codex_scaffold_meta(self):
+        meta = load_scaffold_meta("codex")
+        assert meta is not None
+        assert "build" in meta
+        assert meta["build"][0]["image"] == "localhost/agentcage-scaffold-codex:latest"
+
+
+class TestScaffoldConfigIntegration:
+    """Verify scaffolds produce configs that pass validate_config."""
+
+    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
+    def test_openclaw_passes_validation(self, mock_resolve, tmp_path):
+        from agentcage.config import load_config, validate_config
+        cfg_text, _ = render_config("test-oc", scaffold="openclaw")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        # Should not raise
+        validate_config(cfg)
+
+    def test_nanoclaw_passes_validation(self, tmp_path):
+        from agentcage.config import load_config, validate_config
+        cfg_text, _ = render_config("test-nano", scaffold="nanoclaw")
+        p = tmp_path / "cage.yaml"
+        p.write_text(cfg_text)
+        cfg = load_config(str(p))
+        # validate_config returns warnings for nested_containers; should not raise
+        warnings = validate_config(cfg)
+        assert isinstance(warnings, list)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.9.0"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Add **Claude Code**, **Codex**, and **alpine-curl** scaffolds for one-command coding agent sandboxing
- New `agentcage run <scaffold>` command — creates cage, opens interactive session, stops on exit
- New `lifecycle: service | interactive | ephemeral` config field with auto-generated cage names
- Polished CLI output: version banner, spinner during builds, compact status summary
- **Blocked request notifications** — inline terminal alerts during interactive sessions
- Proxy/DNS build caching (removed unnecessary `--no-cache`)
- Version bump to **0.10.0**

### New commands
```bash
# Run Claude Code in a sandbox (one command)
agentcage run claude

# Interactive Alpine shell for proxy testing
agentcage run alpine

# With API key
agentcage run claude -s ANTHROPIC_API_KEY=sk-ant-...

# Full build output
agentcage run claude -v

# Clean up exited cages
agentcage cage prune
```

### CLI output
```
╭────────────────────────────────────────────╮
│ ✻ agentcage v0.10.0                        │
╰────────────────────────────────────────────╯

  ✓ claude-bold-fox

  /home/luca/github/myproject
  Ctrl+D to exit · agentcage cage audit claude-bold-fox

────────────────────────────────────────────
```

Blocked requests show inline during the session:
```
[agentcage] blocked → api.openai.com (domain blocked)
```

### Lifecycle modes
| Mode | Behavior | Use case |
|------|----------|----------|
| `service` (default) | Always running, auto-restart | OpenClaw, PicoClaw, NanoClaw |
| `interactive` | Stops on exit, state preserved | Claude Code, Codex |
| `ephemeral` | Stops on exit, removed by `cage prune` | One-off sessions |

## Test plan
- [x] 854 unit tests pass
- [x] E2E phases 1-6 pass (fixed flaky test 3.3)
- [x] Manual: `agentcage run alpine` — banner, spinner, blocked notification
- [x] Manual: `agentcage run claude` — Claude Code launches inside sandbox
- [x] Manual: `agentcage run claude -v` — full verbose build output
- [x] Graceful degradation when stderr is not a TTY (no spinner, plain output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)