### PR TITLE
feat: support VM isolation in agentcage run

### DIFF
--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -83,10 +83,14 @@ class VmBackend:
             vm_build_dir,
         ])
 
-        # Pull the cage image inside the VM
+        # Build or pull the cage image inside the VM
         if config and config.container.image:
-            click.echo(f"Pulling {config.container.image} inside VM...")
-            inst.exec(["podman", "pull", config.container.image], check=False)
+            if config.container.build.containerfile:
+                # Scaffold image — copy Containerfile and build inside the VM
+                self._build_cage_image_in_vm(config, deploy_name, inst, vm_build_dir)
+            else:
+                click.echo(f"Pulling {config.container.image} inside VM...")
+                inst.exec(["podman", "pull", config.container.image], check=False)
 
         # Cleanup
         inst.exec(["rm", "-rf", vm_build_dir], check=False)
@@ -146,6 +150,47 @@ class VmBackend:
             pass
         self._deploy_cage(name, inst, config)
         click.echo(f"Started {name} (Lima VM)")
+
+    def _build_cage_image_in_vm(
+        self, config: Config, deploy_name: str, inst: LimaInstance, vm_build_dir: str,
+    ) -> None:
+        """Build a scaffold's cage image inside the VM."""
+        from agentcage import state as _state
+
+        # Resolve the Containerfile from the state dir (copied there during run/create)
+        state_dir = _state.deployment_dir(deploy_name)
+        containerfile = state_dir / Path(config.container.build.containerfile).name
+        if not containerfile.exists():
+            # Fall back to scaffold source
+            from agentcage.init import _SCAFFOLDS_DIR
+            meta = _state.load_metadata(deploy_name)
+            scaffold = meta.get("scaffold", "")
+            if scaffold:
+                containerfile = _SCAFFOLDS_DIR / scaffold / config.container.build.containerfile
+        if not containerfile.exists():
+            click.echo(f"warning: Containerfile not found for {config.container.image}", err=True)
+            return
+
+        scaffold_dir = containerfile.parent
+        vm_scaffold_dir = f"{vm_build_dir}/scaffold"
+        inst.exec(["mkdir", "-p", vm_scaffold_dir])
+        subprocess.run(
+            ["limactl", "copy", "-r",
+             f"{scaffold_dir}/.", f"{inst.name}:{vm_scaffold_dir}/"],
+            check=True,
+        )
+
+        click.echo(f"Building {config.container.image} inside VM...")
+        build_cmd = [
+            "podman", "build",
+            "--cap-add=CAP_CHOWN", "--cap-add=CAP_FOWNER",
+            "--cap-add=CAP_SETUID", "--cap-add=CAP_SETGID",
+            "--cap-add=CAP_DAC_OVERRIDE", "--cap-add=CAP_SETFCAP",
+            "-t", config.container.image,
+            "-f", f"{vm_scaffold_dir}/{containerfile.name}",
+            vm_scaffold_dir,
+        ]
+        inst.exec(build_cmd)
 
     def _deploy_cage(self, name: str, inst: LimaInstance, config: Config | None = None) -> None:
         """Deploy quadlet files and start services inside the Lima VM."""

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -592,7 +592,7 @@ def cage_list():
 
 @cage.command("destroy")
 @click.argument("name")
-@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
+@click.option("-y", "--yes", "-f", "--force", is_flag=True, help="Skip confirmation prompt")
 @click.option("--keep-secrets", is_flag=True,
               help="Keep scoped secrets (useful for recreating the cage)")
 def cage_destroy(name: str, yes: bool, keep_secrets: bool):

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -220,9 +220,12 @@ def init(name: str | None, output: str, image: str, isolation: str,
 @click.option("-s", "--set-secret", "secrets", multiple=True,
               help="Set a secret (KEY=VALUE or KEY to prompt). Repeatable.")
 @click.option("-v", "--verbose", is_flag=True, help="Show full build output.")
+@click.option("--isolation", type=click.Choice(["container", "vm"]), default=None,
+              help="Isolation backend (default: auto-detect from platform).")
 @click.argument("extra_args", nargs=-1, type=click.UNPROCESSED)
 def run(scaffold: str, project_dir: str | None, name: str | None,
-        secrets: tuple[str, ...], verbose: bool, extra_args: tuple[str, ...]):
+        secrets: tuple[str, ...], verbose: bool, isolation: str | None,
+        extra_args: tuple[str, ...]):
     """Run a coding agent in a sandboxed cage.
 
     \b
@@ -230,12 +233,14 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
       agentcage run claude-code
       agentcage run codex --project /path/to/repo
       agentcage run claude-code -s ANTHROPIC_API_KEY=sk-...
+      agentcage run claude-code --isolation vm
       agentcage run claude-code --name my-session -- claude --help
     """
     from agentcage.run import execute
     exit_code = execute(
         scaffold, project_dir=project_dir, name=name,
         secrets=secrets, extra_args=extra_args, verbose=verbose,
+        isolation=isolation,
     )
     sys.exit(exit_code)
 

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -592,7 +592,7 @@ def cage_list():
 
 @cage.command("destroy")
 @click.argument("name")
-@click.option("-y", "--yes", "-f", "--force", is_flag=True, help="Skip confirmation prompt")
+@click.option("-y", "--yes", is_flag=True, help="Skip confirmation prompt")
 @click.option("--keep-secrets", is_flag=True,
               help="Keep scoped secrets (useful for recreating the cage)")
 def cage_destroy(name: str, yes: bool, keep_secrets: bool):

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import random
 import shutil
 import signal
@@ -83,8 +84,11 @@ def generate_name(scaffold: str) -> str:
     raise RuntimeError("Could not generate a unique cage name after 100 attempts")
 
 
-def _monitor_proxy(proxy_container: str, stop_event: threading.Event) -> None:
+def _monitor_proxy(log_cmd: list[str], stop_event: threading.Event) -> None:
     """Tail proxy logs and print blocked-request notifications to the terminal.
+
+    *log_cmd* is the full command to stream proxy logs (e.g.
+    ``["podman", "logs", "-f", "name-proxy"]`` or the limactl equivalent).
 
     Runs as a daemon thread alongside the interactive session.  Writes
     directly to ``/dev/tty`` so output appears even while podman exec
@@ -97,7 +101,7 @@ def _monitor_proxy(proxy_container: str, stop_event: threading.Event) -> None:
 
     try:
         proc = subprocess.Popen(
-            ["podman", "logs", "-f", proxy_container],
+            log_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -142,6 +146,11 @@ def _monitor_proxy(proxy_container: str, stop_event: threading.Event) -> None:
         tty.close()
 
 
+def _detect_isolation() -> str:
+    """Return 'vm' on macOS, 'container' on Linux."""
+    return "vm" if platform.system() == "Darwin" else "container"
+
+
 def execute(
     scaffold: str,
     *,
@@ -150,6 +159,7 @@ def execute(
     secrets: tuple[str, ...] = (),
     extra_args: tuple[str, ...] = (),
     verbose: bool = False,
+    isolation: str | None = None,
 ) -> int:
     """Create a cage from a scaffold, run an interactive session, and clean up.
 
@@ -197,10 +207,13 @@ def execute(
     from importlib.metadata import version
     output.banner(version("agentcage"))
 
+    # Determine isolation mode
+    isolation = isolation or _detect_isolation()
+
     # Render config from scaffold template
     os.environ["PROJECT_DIR"] = project_dir
     config_text, image_tag = render_config(
-        cage_name, scaffold=scaffold, isolation="container",
+        cage_name, scaffold=scaffold, isolation=isolation,
     )
 
     # Write temp config file
@@ -337,17 +350,27 @@ def execute(
     proxy_container = f"{cfg.name}-proxy"
     exec_flags = ["-it"] if sys.stdin.isatty() else []
 
+    # Build exec and log commands — VM mode goes through limactl
+    if cfg.isolation == "vm":
+        from agentcage.lima.instance import LimaInstance
+        inst = LimaInstance(cfg.name)
+        run_cmd = ["limactl", "shell", inst.name, "--",
+                   "podman", "exec", *exec_flags, container_name, *exec_cmd]
+        log_cmd = ["limactl", "shell", inst.name, "--",
+                   "podman", "logs", "-f", proxy_container]
+    else:
+        run_cmd = ["podman", "exec", *exec_flags, container_name, *exec_cmd]
+        log_cmd = ["podman", "logs", "-f", proxy_container]
+
     # Monitor proxy logs for blocked requests
     monitor_stop = threading.Event()
     monitor_thread = threading.Thread(
-        target=_monitor_proxy, args=(proxy_container, monitor_stop), daemon=True,
+        target=_monitor_proxy, args=(log_cmd, monitor_stop), daemon=True,
     )
     monitor_thread.start()
 
     try:
-        result = subprocess.run(
-            ["podman", "exec"] + exec_flags + [container_name] + exec_cmd,
-        )
+        result = subprocess.run(run_cmd)
         exit_code = result.returncode
     except KeyboardInterrupt:
         click.echo("\nSession interrupted.")

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -283,10 +283,12 @@ def execute(
         config_host_path = state.save_proxy_config(cage_name)
 
         if verbose:
-            run_scaffold_setup(
-                scaffold, cage_name, str(config_path),
-                image_tag=image_tag,
-            )
+            # VM mode builds images inside the VM — skip host scaffold setup
+            if cfg.isolation != "vm":
+                run_scaffold_setup(
+                    scaffold, cage_name, str(config_path),
+                    image_tag=image_tag,
+                )
             build_and_deploy(
                 cfg,
                 config_host_path=config_host_path,
@@ -296,10 +298,12 @@ def execute(
             )
         else:
             with output.Spinner("Starting cage..."):
-                run_scaffold_setup(
-                    scaffold, cage_name, str(config_path),
-                    image_tag=image_tag, quiet=True,
-                )
+                # VM mode builds images inside the VM — skip host scaffold setup
+                if cfg.isolation != "vm":
+                    run_scaffold_setup(
+                        scaffold, cage_name, str(config_path),
+                        image_tag=image_tag, quiet=True,
+                    )
                 build_and_deploy(
                     cfg,
                     config_host_path=config_host_path,

--- a/src/agentcage/scaffolds/alpine-curl/cage.yaml.j2
+++ b/src/agentcage/scaffolds/alpine-curl/cage.yaml.j2
@@ -7,6 +7,14 @@
 #   curl -v https://example.com
 
 name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 1
+  mem_mb: 1024
+{% endif %}
 
 lifecycle: interactive
 


### PR DESCRIPTION
## Summary

- Auto-detect isolation mode from platform: `vm` on macOS, `container` on Linux
- Add `--isolation container|vm` flag to `agentcage run` for explicit override
- VM mode routes exec and log tailing through `limactl shell`
- Build scaffold images inside the VM (host podman images aren't accessible there)
- Add VM config block to alpine-curl scaffold template

### Usage
```bash
# Auto-detect (vm on macOS, container on Linux)
agentcage run claude

# Explicit override
agentcage run claude --isolation vm
```

## Test plan
- [x] 854 unit tests pass
- [x] Manual: `agentcage run alpine --isolation vm` on Linux — VM boots, scaffold image builds inside VM, cage starts
- [ ] Manual: `agentcage run claude` on macOS (auto-detects vm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)