### PR TITLE
feat: build cache for fast warm starts on agentcage run

### DIFF
--- a/src/agentcage/cache.py
+++ b/src/agentcage/cache.py
@@ -85,7 +85,7 @@ def is_image_cached(scaffold: str, cache_key: str, podman: Podman) -> bool:
     Returns ``False`` (never raises) on any I/O or Podman error.
     """
     try:
-        marker = CACHE_DIR / "images" / f"{scaffold}-{cache_key}.built"
+        marker = CACHE_DIR / "images" / f"{scaffold}--{cache_key}.built"
         if not marker.exists():
             return False
         image_tag = marker.read_text().strip()
@@ -106,8 +106,8 @@ def mark_image_built(scaffold: str, cache_key: str, image_tag: str) -> None:
     marker_dir.mkdir(parents=True, exist_ok=True)
 
     # Remove stale markers for this scaffold before writing the new one
-    prefix = f"{scaffold}-"
-    new_name = f"{scaffold}-{cache_key}.built"
+    prefix = f"{scaffold}--"
+    new_name = f"{scaffold}--{cache_key}.built"
     try:
         for old in marker_dir.iterdir():
             if old.name.startswith(prefix) and old.name != new_name:
@@ -137,7 +137,7 @@ def are_quadlets_cached(cage_name: str, cache_key: str) -> bool:
     Returns ``False`` (never raises) on any I/O error.
     """
     try:
-        marker = CACHE_DIR / "quadlets" / f"{cage_name}-{cache_key}.installed"
+        marker = CACHE_DIR / "quadlets" / f"{cage_name}--{cache_key}.installed"
         return marker.exists()
     except Exception:
         return False
@@ -152,8 +152,8 @@ def mark_quadlets_installed(cage_name: str, cache_key: str) -> None:
     marker_dir.mkdir(parents=True, exist_ok=True)
 
     # Remove stale markers for this cage
-    prefix = f"{cage_name}-"
-    new_name = f"{cage_name}-{cache_key}.installed"
+    prefix = f"{cage_name}--"
+    new_name = f"{cage_name}--{cache_key}.installed"
     try:
         for old in marker_dir.iterdir():
             if old.name.startswith(prefix) and old.name != new_name:
@@ -181,7 +181,7 @@ def clear_cage_cache(cage_name: str) -> int:
         if not cache_subdir.is_dir():
             continue
         for marker in cache_subdir.iterdir():
-            if marker.name.startswith(f"{cage_name}-"):
+            if marker.name.startswith(f"{cage_name}--"):
                 marker.unlink(missing_ok=True)
                 removed += 1
     return removed

--- a/src/agentcage/cache.py
+++ b/src/agentcage/cache.py
@@ -1,0 +1,118 @@
+"""Build cache for fast warm starts.
+
+Caches image builds and quadlet installations so that repeat ``agentcage run``
+invocations skip expensive rebuild steps when nothing has changed.
+
+Cache failures are never fatal — callers should always fall through to a
+full build on any exception.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import shutil
+from pathlib import Path
+
+from agentcage.podman import Podman
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIR = Path.home() / ".cache" / "agentcage"
+
+
+# ── Image cache ──────────────────────────────────────────
+
+
+def image_cache_key(scaffold: str, containerfile_content: str, scaffold_config: str) -> str:
+    """Hash the Containerfile + scaffold config to create a cache key."""
+    h = hashlib.sha256()
+    h.update(scaffold.encode())
+    h.update(containerfile_content.encode())
+    h.update(scaffold_config.encode())
+    return h.hexdigest()[:16]
+
+
+def is_image_cached(scaffold: str, cache_key: str, podman: Podman) -> bool:
+    """Check if image with this cache key exists in Podman."""
+    marker = CACHE_DIR / "images" / f"{scaffold}-{cache_key}.built"
+    if not marker.exists():
+        return False
+    # Also verify the image actually exists in podman
+    image_tag = marker.read_text().strip()
+    if not image_tag:
+        return False
+    return podman.image_exists(image_tag)
+
+
+def mark_image_built(scaffold: str, cache_key: str, image_tag: str) -> None:
+    """Record that an image was built with this cache key."""
+    marker_dir = CACHE_DIR / "images"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    marker = marker_dir / f"{scaffold}-{cache_key}.built"
+    marker.write_text(image_tag)
+
+
+# ── Quadlet cache ────────────────────────────────────────
+
+
+def quadlet_cache_key(quadlet_contents: dict[str, str]) -> str:
+    """Hash all quadlet file contents."""
+    h = hashlib.sha256()
+    for name in sorted(quadlet_contents):
+        h.update(name.encode())
+        h.update(quadlet_contents[name].encode())
+    return h.hexdigest()[:16]
+
+
+def are_quadlets_cached(cage_name: str, cache_key: str) -> bool:
+    """Check if installed quadlets match this cache key."""
+    marker = CACHE_DIR / "quadlets" / f"{cage_name}-{cache_key}.installed"
+    return marker.exists()
+
+
+def mark_quadlets_installed(cage_name: str, cache_key: str) -> None:
+    """Record that quadlets were installed with this cache key."""
+    marker_dir = CACHE_DIR / "quadlets"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    marker = marker_dir / f"{cage_name}-{cache_key}.installed"
+    marker.write_text("")
+
+
+# ── Cache cleanup ────────────────────────────────────────
+
+
+def clear_cage_cache(cage_name: str) -> int:
+    """Remove all cache markers for a specific cage.
+
+    Returns the number of markers removed.
+    """
+    removed = 0
+    for subdir in ("images", "quadlets"):
+        cache_subdir = CACHE_DIR / subdir
+        if not cache_subdir.is_dir():
+            continue
+        for marker in cache_subdir.iterdir():
+            if marker.name.startswith(f"{cage_name}-"):
+                marker.unlink(missing_ok=True)
+                removed += 1
+    return removed
+
+
+def clear_all_cache() -> int:
+    """Remove the entire cache directory.
+
+    Returns the number of markers removed.
+    """
+    removed = 0
+    for subdir in ("images", "quadlets"):
+        cache_subdir = CACHE_DIR / subdir
+        if not cache_subdir.is_dir():
+            continue
+        for marker in cache_subdir.iterdir():
+            marker.unlink(missing_ok=True)
+            removed += 1
+    # Remove directory structure too
+    if CACHE_DIR.is_dir():
+        shutil.rmtree(str(CACHE_DIR), ignore_errors=True)
+    return removed

--- a/src/agentcage/cache.py
+++ b/src/agentcage/cache.py
@@ -3,15 +3,23 @@
 Caches image builds and quadlet installations so that repeat ``agentcage run``
 invocations skip expensive rebuild steps when nothing has changed.
 
-Cache failures are never fatal — callers should always fall through to a
-full build on any exception.
+Cache failures are never fatal — every public function in this module is
+designed so callers can wrap calls in ``try/except Exception`` and fall
+through to a full build.
+
+Limitation: the cache key does NOT include the upstream base-image digest.
+If a base image (e.g. ``node:22-slim``) receives a security update, the
+cache will still report a hit.  Users can force a rebuild with
+``agentcage cache clear``.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import shutil
+import tempfile
 from pathlib import Path
 
 from agentcage.podman import Podman
@@ -21,36 +29,94 @@ logger = logging.getLogger(__name__)
 CACHE_DIR = Path.home() / ".cache" / "agentcage"
 
 
+def _package_version() -> str:
+    """Return the installed agentcage version (part of every cache key)."""
+    try:
+        from importlib.metadata import version
+        return version("agentcage")
+    except Exception:
+        return "unknown"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via rename.
+
+    Prevents partial reads when two processes write concurrently.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    closed = False
+    try:
+        os.write(fd, content.encode())
+        os.close(fd)
+        closed = True
+        os.rename(tmp, str(path))
+    except BaseException:
+        if not closed:
+            os.close(fd)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 # ── Image cache ──────────────────────────────────────────
 
 
 def image_cache_key(scaffold: str, containerfile_content: str, scaffold_config: str) -> str:
-    """Hash the Containerfile + scaffold config to create a cache key."""
+    """Hash the Containerfile + scaffold config + package version to create a cache key.
+
+    The package version is included so that upgrading agentcage (which may
+    ship new infra images or scaffold changes) automatically invalidates
+    the cache.
+    """
     h = hashlib.sha256()
     h.update(scaffold.encode())
     h.update(containerfile_content.encode())
     h.update(scaffold_config.encode())
+    h.update(_package_version().encode())
     return h.hexdigest()[:16]
 
 
 def is_image_cached(scaffold: str, cache_key: str, podman: Podman) -> bool:
-    """Check if image with this cache key exists in Podman."""
-    marker = CACHE_DIR / "images" / f"{scaffold}-{cache_key}.built"
-    if not marker.exists():
+    """Check if image with this cache key exists in Podman.
+
+    Returns ``False`` (never raises) on any I/O or Podman error.
+    """
+    try:
+        marker = CACHE_DIR / "images" / f"{scaffold}-{cache_key}.built"
+        if not marker.exists():
+            return False
+        image_tag = marker.read_text().strip()
+        if not image_tag:
+            return False
+        return podman.image_exists(image_tag)
+    except Exception:
         return False
-    # Also verify the image actually exists in podman
-    image_tag = marker.read_text().strip()
-    if not image_tag:
-        return False
-    return podman.image_exists(image_tag)
 
 
 def mark_image_built(scaffold: str, cache_key: str, image_tag: str) -> None:
-    """Record that an image was built with this cache key."""
+    """Record that an image was built with this cache key.
+
+    Atomically writes the marker and removes stale markers for the same
+    scaffold (previous cache keys).
+    """
     marker_dir = CACHE_DIR / "images"
     marker_dir.mkdir(parents=True, exist_ok=True)
-    marker = marker_dir / f"{scaffold}-{cache_key}.built"
-    marker.write_text(image_tag)
+
+    # Remove stale markers for this scaffold before writing the new one
+    prefix = f"{scaffold}-"
+    new_name = f"{scaffold}-{cache_key}.built"
+    try:
+        for old in marker_dir.iterdir():
+            if old.name.startswith(prefix) and old.name != new_name:
+                old.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+    marker = marker_dir / new_name
+    _atomic_write(marker, image_tag)
 
 
 # ── Quadlet cache ────────────────────────────────────────
@@ -66,17 +132,36 @@ def quadlet_cache_key(quadlet_contents: dict[str, str]) -> str:
 
 
 def are_quadlets_cached(cage_name: str, cache_key: str) -> bool:
-    """Check if installed quadlets match this cache key."""
-    marker = CACHE_DIR / "quadlets" / f"{cage_name}-{cache_key}.installed"
-    return marker.exists()
+    """Check if installed quadlets match this cache key.
+
+    Returns ``False`` (never raises) on any I/O error.
+    """
+    try:
+        marker = CACHE_DIR / "quadlets" / f"{cage_name}-{cache_key}.installed"
+        return marker.exists()
+    except Exception:
+        return False
 
 
 def mark_quadlets_installed(cage_name: str, cache_key: str) -> None:
-    """Record that quadlets were installed with this cache key."""
+    """Record that quadlets were installed with this cache key.
+
+    Removes stale markers for the same cage before writing.
+    """
     marker_dir = CACHE_DIR / "quadlets"
     marker_dir.mkdir(parents=True, exist_ok=True)
-    marker = marker_dir / f"{cage_name}-{cache_key}.installed"
-    marker.write_text("")
+
+    # Remove stale markers for this cage
+    prefix = f"{cage_name}-"
+    new_name = f"{cage_name}-{cache_key}.installed"
+    try:
+        for old in marker_dir.iterdir():
+            if old.name.startswith(prefix) and old.name != new_name:
+                old.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+    _atomic_write(marker_dir / new_name, "")
 
 
 # ── Cache cleanup ────────────────────────────────────────
@@ -84,6 +169,9 @@ def mark_quadlets_installed(cage_name: str, cache_key: str) -> None:
 
 def clear_cage_cache(cage_name: str) -> int:
     """Remove all cache markers for a specific cage.
+
+    Checks both cage name (quadlet markers) and scaffold name (image
+    markers) prefixes.
 
     Returns the number of markers removed.
     """

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -245,6 +245,65 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
     sys.exit(exit_code)
 
 
+# ── cache group ───────────────────────────────────────────
+
+
+@main.group()
+def cache():
+    """Manage the build cache."""
+
+
+@cache.command("clear")
+@click.argument("name", required=False, default=None)
+def cache_clear(name: str | None):
+    """Clear the build cache.
+
+    If NAME is given, only clear cache for that cage/scaffold.
+    Otherwise, clear the entire cache.
+    """
+    from agentcage.cache import clear_all_cache, clear_cage_cache
+
+    if name:
+        n = clear_cage_cache(name)
+        if n > 0:
+            click.echo(f"Cleared {n} cache marker(s) for '{name}'.")
+        else:
+            click.echo(f"No cache entries found for '{name}'.")
+    else:
+        n = clear_all_cache()
+        if n > 0:
+            click.echo(f"Cleared {n} cache marker(s).")
+        else:
+            click.echo("Cache is already empty.")
+
+
+@cache.command("status")
+def cache_status():
+    """Show cache status."""
+    from agentcage.cache import CACHE_DIR
+
+    images_dir = CACHE_DIR / "images"
+    quadlets_dir = CACHE_DIR / "quadlets"
+
+    image_markers = list(images_dir.iterdir()) if images_dir.is_dir() else []
+    quadlet_markers = list(quadlets_dir.iterdir()) if quadlets_dir.is_dir() else []
+
+    if not image_markers and not quadlet_markers:
+        click.echo("Cache is empty.")
+        return
+
+    if image_markers:
+        click.echo(f"Image cache: {len(image_markers)} entries")
+        for m in sorted(image_markers):
+            tag = m.read_text().strip() if m.stat().st_size > 0 else "(empty)"
+            click.echo(f"  {m.stem} → {tag}")
+
+    if quadlet_markers:
+        click.echo(f"Quadlet cache: {len(quadlet_markers)} entries")
+        for m in sorted(quadlet_markers):
+            click.echo(f"  {m.stem}")
+
+
 # ── cage group ────────────────────────────────────────────
 
 

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -285,7 +285,6 @@ def execute(
         # ── Cache: determine what can be skipped ──
         skip_scaffold_build = False
         skip_build = False
-        skip_install = False
 
         try:
             from agentcage import cache
@@ -305,7 +304,7 @@ def execute(
             infra_key = cache.image_cache_key(
                 "__infra__",
                 "",  # infra images have no user Containerfile
-                "",  # no scaffold config
+                "",  # no scaffold config — version is included automatically
             )
             if cache.is_image_cached("__infra__", infra_key, podman):
                 skip_build = True
@@ -315,7 +314,6 @@ def execute(
             # Cache check failed — fall through to full build
             skip_scaffold_build = False
             skip_build = False
-            skip_install = False
 
         if verbose:
             # VM mode builds images inside the VM — skip host scaffold setup
@@ -332,7 +330,6 @@ def execute(
                 podman=podman,
                 used_octets=used_octets,
                 skip_build=skip_build,
-                skip_install=skip_install,
             )
         else:
             with output.Spinner("Starting cage..."):
@@ -351,7 +348,6 @@ def execute(
                     used_octets=used_octets,
                     quiet=True,
                     skip_build=skip_build,
-                    skip_install=skip_install,
                 )
 
         # ── Cache: record successful builds ──

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -35,7 +35,7 @@ from agentcage.backends import get_backend
 from agentcage.config import load_config, validate_config
 from agentcage.init import list_scaffolds, load_scaffold_meta, render_config, run_scaffold_setup, _SCAFFOLDS_DIR
 from agentcage.podman import Podman
-from agentcage.services import build_and_deploy, check_port_availability, destroy_cage
+from agentcage.services import build_and_deploy, check_port_availability, destroy_cage, ensure_patches
 
 # Word lists for auto-generated cage names (Docker-style)
 _ADJECTIVES = [
@@ -282,18 +282,21 @@ def execute(
         # Save proxy config and get its host path (mounted into proxy container)
         config_host_path = state.save_proxy_config(cage_name)
 
+        # ── Scaffold Containerfile content (computed once) ──
+        scaffold_dir = _SCAFFOLDS_DIR / scaffold
+        containerfile_path = scaffold_dir / "Containerfile"
+        cf_content = containerfile_path.read_text() if containerfile_path.exists() else ""
+
         # ── Cache: determine what can be skipped ──
         skip_scaffold_build = False
         skip_build = False
+        skip_install = False
 
         try:
             from agentcage import cache
 
             # Check scaffold image cache
             if cfg.isolation != "vm":
-                scaffold_dir = _SCAFFOLDS_DIR / scaffold
-                containerfile_path = scaffold_dir / "Containerfile"
-                cf_content = containerfile_path.read_text() if containerfile_path.exists() else ""
                 img_key = cache.image_cache_key(scaffold, cf_content, config_text)
                 if cache.is_image_cached(scaffold, img_key, podman):
                     skip_scaffold_build = True
@@ -310,10 +313,25 @@ def execute(
                 skip_build = True
                 if verbose:
                     output.step_done(output.dim("Infra image cache hit, skipping build"))
+
+            # Check quadlet cache
+            if cfg.isolation != "vm":
+                backend = get_backend(cfg)
+                patches_work = ensure_patches(podman)
+                units = backend.generate_units(
+                    cfg, config_host_path, patches_work,
+                    cage_name, used_octets=used_octets,
+                )
+                qkey = cache.quadlet_cache_key(units)
+                if cache.are_quadlets_cached(cage_name, qkey):
+                    skip_install = True
+                    if verbose:
+                        output.step_done(output.dim("Quadlet cache hit, skipping install"))
         except Exception:
             # Cache check failed — fall through to full build
             skip_scaffold_build = False
             skip_build = False
+            skip_install = False
 
         if verbose:
             # VM mode builds images inside the VM — skip host scaffold setup
@@ -330,6 +348,7 @@ def execute(
                 podman=podman,
                 used_octets=used_octets,
                 skip_build=skip_build,
+                skip_install=skip_install,
             )
         else:
             with output.Spinner("Starting cage..."):
@@ -348,6 +367,7 @@ def execute(
                     used_octets=used_octets,
                     quiet=True,
                     skip_build=skip_build,
+                    skip_install=skip_install,
                 )
 
         # ── Cache: record successful builds ──
@@ -355,17 +375,21 @@ def execute(
             from agentcage import cache
 
             if cfg.isolation != "vm" and not skip_scaffold_build:
-                scaffold_dir = _SCAFFOLDS_DIR / scaffold
-                containerfile_path = scaffold_dir / "Containerfile"
-                cf_content = containerfile_path.read_text() if containerfile_path.exists() else ""
                 img_key = cache.image_cache_key(scaffold, cf_content, config_text)
-                # Record the scaffold image tag
-                scaffold_image = cfg.container.image
-                cache.mark_image_built(scaffold, img_key, scaffold_image)
+                cache.mark_image_built(scaffold, img_key, cfg.container.image)
 
             if not skip_build:
                 infra_key = cache.image_cache_key("__infra__", "", "")
                 cache.mark_image_built("__infra__", infra_key, "agentcage-proxy")
+
+            if not skip_install:
+                backend = get_backend(cfg)
+                units = backend.generate_units(
+                    cfg, config_host_path, ensure_patches(podman),
+                    cage_name, used_octets=used_octets,
+                )
+                qkey = cache.quadlet_cache_key(units)
+                cache.mark_quadlets_installed(cage_name, qkey)
         except Exception:
             pass  # Cache write failure is not fatal
 

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -33,7 +33,7 @@ import click
 from agentcage import state
 from agentcage.backends import get_backend
 from agentcage.config import load_config, validate_config
-from agentcage.init import list_scaffolds, load_scaffold_meta, render_config, run_scaffold_setup
+from agentcage.init import list_scaffolds, load_scaffold_meta, render_config, run_scaffold_setup, _SCAFFOLDS_DIR
 from agentcage.podman import Podman
 from agentcage.services import build_and_deploy, check_port_availability, destroy_cage
 
@@ -282,28 +282,67 @@ def execute(
         # Save proxy config and get its host path (mounted into proxy container)
         config_host_path = state.save_proxy_config(cage_name)
 
+        # ── Cache: determine what can be skipped ──
+        skip_scaffold_build = False
+        skip_build = False
+        skip_install = False
+
+        try:
+            from agentcage import cache
+
+            # Check scaffold image cache
+            if cfg.isolation != "vm":
+                scaffold_dir = _SCAFFOLDS_DIR / scaffold
+                containerfile_path = scaffold_dir / "Containerfile"
+                cf_content = containerfile_path.read_text() if containerfile_path.exists() else ""
+                img_key = cache.image_cache_key(scaffold, cf_content, config_text)
+                if cache.is_image_cached(scaffold, img_key, podman):
+                    skip_scaffold_build = True
+                    if verbose:
+                        output.step_done(output.dim("Image cache hit, skipping scaffold build"))
+
+            # Check infrastructure image cache (proxy + dns)
+            infra_key = cache.image_cache_key(
+                "__infra__",
+                "",  # infra images have no user Containerfile
+                "",  # no scaffold config
+            )
+            if cache.is_image_cached("__infra__", infra_key, podman):
+                skip_build = True
+                if verbose:
+                    output.step_done(output.dim("Infra image cache hit, skipping build"))
+        except Exception:
+            # Cache check failed — fall through to full build
+            skip_scaffold_build = False
+            skip_build = False
+            skip_install = False
+
         if verbose:
             # VM mode builds images inside the VM — skip host scaffold setup
             if cfg.isolation != "vm":
-                run_scaffold_setup(
-                    scaffold, cage_name, str(config_path),
-                    image_tag=image_tag,
-                )
+                if not skip_scaffold_build:
+                    run_scaffold_setup(
+                        scaffold, cage_name, str(config_path),
+                        image_tag=image_tag,
+                    )
             build_and_deploy(
                 cfg,
                 config_host_path=config_host_path,
                 deploy_name=cage_name,
                 podman=podman,
                 used_octets=used_octets,
+                skip_build=skip_build,
+                skip_install=skip_install,
             )
         else:
             with output.Spinner("Starting cage..."):
                 # VM mode builds images inside the VM — skip host scaffold setup
                 if cfg.isolation != "vm":
-                    run_scaffold_setup(
-                        scaffold, cage_name, str(config_path),
-                        image_tag=image_tag, quiet=True,
-                    )
+                    if not skip_scaffold_build:
+                        run_scaffold_setup(
+                            scaffold, cage_name, str(config_path),
+                            image_tag=image_tag, quiet=True,
+                        )
                 build_and_deploy(
                     cfg,
                     config_host_path=config_host_path,
@@ -311,7 +350,29 @@ def execute(
                     podman=podman,
                     used_octets=used_octets,
                     quiet=True,
+                    skip_build=skip_build,
+                    skip_install=skip_install,
                 )
+
+        # ── Cache: record successful builds ──
+        try:
+            from agentcage import cache
+
+            if cfg.isolation != "vm" and not skip_scaffold_build:
+                scaffold_dir = _SCAFFOLDS_DIR / scaffold
+                containerfile_path = scaffold_dir / "Containerfile"
+                cf_content = containerfile_path.read_text() if containerfile_path.exists() else ""
+                img_key = cache.image_cache_key(scaffold, cf_content, config_text)
+                # Record the scaffold image tag
+                scaffold_image = cfg.container.image
+                cache.mark_image_built(scaffold, img_key, scaffold_image)
+
+            if not skip_build:
+                infra_key = cache.image_cache_key("__infra__", "", "")
+                cache.mark_image_built("__infra__", infra_key, "agentcage-proxy")
+        except Exception:
+            pass  # Cache write failure is not fatal
+
         output.step_done(output.dim(cage_name))
     except subprocess.CalledProcessError as e:
         output.step_fail("Build failed")

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -170,8 +170,15 @@ def build_and_deploy(
     podman: Podman,
     used_octets: set[int] | None = None,
     quiet: bool = False,
+    skip_build: bool = False,
+    skip_install: bool = False,
 ):
-    """Build images, generate quadlets, install, and start."""
+    """Build images, generate quadlets, install, and start.
+
+    When *skip_build* is True, the image build step is skipped (cache hit).
+    When *skip_install* is True, quadlet generation/install and daemon-reload
+    are skipped, but services are still started.
+    """
     from agentcage.quadlets import cage_network_addrs
 
     backend = get_backend(cfg)
@@ -184,10 +191,12 @@ def build_and_deploy(
     with open(resolv_path, "w") as f:
         f.write(f"nameserver {addrs['ip_dns']}\n")
 
-    backend.build_artifacts(cfg, deploy_name, quiet=quiet)
+    if not skip_build:
+        backend.build_artifacts(cfg, deploy_name, quiet=quiet)
 
-    units = backend.generate_units(cfg, config_host_path, patches_work, deploy_name, used_octets=used_octets)
-    backend.install_units(units, quiet=quiet)
+    if not skip_install:
+        units = backend.generate_units(cfg, config_host_path, patches_work, deploy_name, used_octets=used_octets)
+        backend.install_units(units, quiet=quiet)
 
     # Persist the actual assigned network octet so collect_used_octets()
     # can read the real value instead of recomputing the hash (which
@@ -236,5 +245,14 @@ def destroy_cage(
     if state.deployment_exists(name):
         state.remove_deployment(name)
         removed.append(f"state:{name}")
+
+    # Clean up cache markers for this cage
+    try:
+        from agentcage.cache import clear_cage_cache
+        n = clear_cage_cache(name)
+        if n > 0:
+            removed.append(f"cache:{n} markers")
+    except Exception:
+        pass  # Cache cleanup failure is not fatal
 
     return removed

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -56,6 +56,14 @@ class TestImageCacheKey:
         k2 = cache.image_cache_key("s", "cf", "config-b")
         assert k1 != k2
 
+    def test_includes_package_version(self, monkeypatch):
+        """Cache key changes when agentcage version changes."""
+        monkeypatch.setattr(cache, "_package_version", lambda: "1.0.0")
+        k1 = cache.image_cache_key("s", "cf", "cfg")
+        monkeypatch.setattr(cache, "_package_version", lambda: "1.1.0")
+        k2 = cache.image_cache_key("s", "cf", "cfg")
+        assert k1 != k2
+
 
 # ── is_image_cached / mark_image_built ───────────────────
 
@@ -95,11 +103,34 @@ class TestImageCache:
         marker_dir = cache.CACHE_DIR / "images"
         marker_dir.mkdir(parents=True)
         (marker_dir / "s-key123.built").write_text("\x00\x01bad-data")
-        # Should return True since the podman image_exists mock returns True
-        # and the marker content is non-empty
         result = cache.is_image_cached("s", "key123", podman)
-        # The important thing is it doesn't crash
         assert isinstance(result, bool)
+
+    def test_fallthrough_on_podman_error(self):
+        """If podman.image_exists raises, is_image_cached returns False."""
+        podman = _make_podman()
+        podman.image_exists.side_effect = RuntimeError("podman died")
+        cache.mark_image_built("s", "key123", "localhost/test:latest")
+        assert not cache.is_image_cached("s", "key123", podman)
+
+    def test_stale_markers_cleaned_on_write(self):
+        """Writing a new marker for the same scaffold removes old ones."""
+        marker_dir = cache.CACHE_DIR / "images"
+        cache.mark_image_built("scaffold-a", "old-key", "img:old")
+        assert (marker_dir / "scaffold-a-old-key.built").exists()
+        cache.mark_image_built("scaffold-a", "new-key", "img:new")
+        assert not (marker_dir / "scaffold-a-old-key.built").exists()
+        assert (marker_dir / "scaffold-a-new-key.built").exists()
+
+    def test_stale_cleanup_does_not_affect_other_scaffolds(self):
+        """Stale marker cleanup only removes markers for the same scaffold."""
+        marker_dir = cache.CACHE_DIR / "images"
+        cache.mark_image_built("scaffold-a", "k1", "img:a")
+        cache.mark_image_built("scaffold-b", "k2", "img:b")
+        # Re-mark scaffold-a with new key
+        cache.mark_image_built("scaffold-a", "k3", "img:a2")
+        assert not (marker_dir / "scaffold-a-k1.built").exists()
+        assert (marker_dir / "scaffold-b-k2.built").exists()
 
 
 # ── quadlet_cache_key ────────────────────────────────────
@@ -141,6 +172,15 @@ class TestQuadletCache:
     def test_miss_on_different_key(self):
         cache.mark_quadlets_installed("cage1", "key-aaa")
         assert not cache.are_quadlets_cached("cage1", "key-bbb")
+
+    def test_stale_markers_cleaned_on_write(self):
+        """Writing a new quadlet marker removes old ones for the same cage."""
+        marker_dir = cache.CACHE_DIR / "quadlets"
+        cache.mark_quadlets_installed("cage1", "old-key")
+        assert (marker_dir / "cage1-old-key.installed").exists()
+        cache.mark_quadlets_installed("cage1", "new-key")
+        assert not (marker_dir / "cage1-old-key.installed").exists()
+        assert (marker_dir / "cage1-new-key.installed").exists()
 
 
 # ── clear_cage_cache ─────────────────────────────────────

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -94,7 +94,7 @@ class TestImageCache:
         podman = _make_podman(image_exists=True)
         marker_dir = cache.CACHE_DIR / "images"
         marker_dir.mkdir(parents=True)
-        (marker_dir / "s-key123.built").write_text("")
+        (marker_dir / "s--key123.built").write_text("")
         assert not cache.is_image_cached("s", "key123", podman)
 
     def test_fallthrough_on_corrupted_cache(self):
@@ -102,7 +102,7 @@ class TestImageCache:
         podman = _make_podman(image_exists=True)
         marker_dir = cache.CACHE_DIR / "images"
         marker_dir.mkdir(parents=True)
-        (marker_dir / "s-key123.built").write_text("\x00\x01bad-data")
+        (marker_dir / "s--key123.built").write_text("\x00\x01bad-data")
         result = cache.is_image_cached("s", "key123", podman)
         assert isinstance(result, bool)
 
@@ -117,10 +117,10 @@ class TestImageCache:
         """Writing a new marker for the same scaffold removes old ones."""
         marker_dir = cache.CACHE_DIR / "images"
         cache.mark_image_built("scaffold-a", "old-key", "img:old")
-        assert (marker_dir / "scaffold-a-old-key.built").exists()
+        assert (marker_dir / "scaffold-a--old-key.built").exists()
         cache.mark_image_built("scaffold-a", "new-key", "img:new")
-        assert not (marker_dir / "scaffold-a-old-key.built").exists()
-        assert (marker_dir / "scaffold-a-new-key.built").exists()
+        assert not (marker_dir / "scaffold-a--old-key.built").exists()
+        assert (marker_dir / "scaffold-a--new-key.built").exists()
 
     def test_stale_cleanup_does_not_affect_other_scaffolds(self):
         """Stale marker cleanup only removes markers for the same scaffold."""
@@ -129,8 +129,17 @@ class TestImageCache:
         cache.mark_image_built("scaffold-b", "k2", "img:b")
         # Re-mark scaffold-a with new key
         cache.mark_image_built("scaffold-a", "k3", "img:a2")
-        assert not (marker_dir / "scaffold-a-k1.built").exists()
-        assert (marker_dir / "scaffold-b-k2.built").exists()
+        assert not (marker_dir / "scaffold-a--k1.built").exists()
+        assert (marker_dir / "scaffold-b--k2.built").exists()
+
+    def test_no_prefix_collision(self):
+        """Scaffold 'foo' must not delete markers for 'foo-bar'."""
+        podman = _make_podman(image_exists=True)
+        cache.mark_image_built("foo", "k1", "img:foo")
+        cache.mark_image_built("foo-bar", "k2", "img:foobar")
+        # Re-mark 'foo' — 'foo-bar' must survive
+        cache.mark_image_built("foo", "k3", "img:foo2")
+        assert cache.is_image_cached("foo-bar", "k2", podman)
 
 
 # ── quadlet_cache_key ────────────────────────────────────
@@ -177,10 +186,10 @@ class TestQuadletCache:
         """Writing a new quadlet marker removes old ones for the same cage."""
         marker_dir = cache.CACHE_DIR / "quadlets"
         cache.mark_quadlets_installed("cage1", "old-key")
-        assert (marker_dir / "cage1-old-key.installed").exists()
+        assert (marker_dir / "cage1--old-key.installed").exists()
         cache.mark_quadlets_installed("cage1", "new-key")
-        assert not (marker_dir / "cage1-old-key.installed").exists()
-        assert (marker_dir / "cage1-new-key.installed").exists()
+        assert not (marker_dir / "cage1--old-key.installed").exists()
+        assert (marker_dir / "cage1--new-key.installed").exists()
 
 
 # ── clear_cage_cache ─────────────────────────────────────

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,189 @@
+"""Tests for agentcage.cache — build cache for fast warm starts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentcage import cache
+
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    """Redirect CACHE_DIR to a temp directory for every test."""
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path / ".cache" / "agentcage")
+
+
+def _make_podman(image_exists: bool = True) -> MagicMock:
+    podman = MagicMock()
+    podman.image_exists.return_value = image_exists
+    return podman
+
+
+# ── image_cache_key ──────────────────────────────────────
+
+
+class TestImageCacheKey:
+    def test_deterministic(self):
+        k1 = cache.image_cache_key("claude-code", "FROM node:22", "name: test")
+        k2 = cache.image_cache_key("claude-code", "FROM node:22", "name: test")
+        assert k1 == k2
+
+    def test_length(self):
+        k = cache.image_cache_key("s", "cf", "cfg")
+        assert len(k) == 16
+
+    def test_hex_chars(self):
+        k = cache.image_cache_key("s", "cf", "cfg")
+        assert all(c in "0123456789abcdef" for c in k)
+
+    def test_changes_on_containerfile(self):
+        k1 = cache.image_cache_key("s", "FROM node:22", "cfg")
+        k2 = cache.image_cache_key("s", "FROM node:23", "cfg")
+        assert k1 != k2
+
+    def test_changes_on_scaffold(self):
+        k1 = cache.image_cache_key("a", "cf", "cfg")
+        k2 = cache.image_cache_key("b", "cf", "cfg")
+        assert k1 != k2
+
+    def test_changes_on_config(self):
+        k1 = cache.image_cache_key("s", "cf", "config-a")
+        k2 = cache.image_cache_key("s", "cf", "config-b")
+        assert k1 != k2
+
+
+# ── is_image_cached / mark_image_built ───────────────────
+
+
+class TestImageCache:
+    def test_miss_when_no_marker(self):
+        podman = _make_podman()
+        assert not cache.is_image_cached("s", "key123", podman)
+
+    def test_hit_after_mark(self):
+        podman = _make_podman(image_exists=True)
+        cache.mark_image_built("s", "key123", "localhost/test:latest")
+        assert cache.is_image_cached("s", "key123", podman)
+        podman.image_exists.assert_called_with("localhost/test:latest")
+
+    def test_miss_when_image_removed(self):
+        podman = _make_podman(image_exists=False)
+        cache.mark_image_built("s", "key123", "localhost/test:latest")
+        assert not cache.is_image_cached("s", "key123", podman)
+
+    def test_miss_on_different_key(self):
+        podman = _make_podman(image_exists=True)
+        cache.mark_image_built("s", "key-aaa", "localhost/test:latest")
+        assert not cache.is_image_cached("s", "key-bbb", podman)
+
+    def test_miss_on_empty_marker(self):
+        """A corrupted marker with empty content is a miss."""
+        podman = _make_podman(image_exists=True)
+        marker_dir = cache.CACHE_DIR / "images"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "s-key123.built").write_text("")
+        assert not cache.is_image_cached("s", "key123", podman)
+
+    def test_fallthrough_on_corrupted_cache(self):
+        """Corrupted marker file should not crash."""
+        podman = _make_podman(image_exists=True)
+        marker_dir = cache.CACHE_DIR / "images"
+        marker_dir.mkdir(parents=True)
+        (marker_dir / "s-key123.built").write_text("\x00\x01bad-data")
+        # Should return True since the podman image_exists mock returns True
+        # and the marker content is non-empty
+        result = cache.is_image_cached("s", "key123", podman)
+        # The important thing is it doesn't crash
+        assert isinstance(result, bool)
+
+
+# ── quadlet_cache_key ────────────────────────────────────
+
+
+class TestQuadletCacheKey:
+    def test_deterministic(self):
+        contents = {"a.container": "content-a", "b.network": "content-b"}
+        k1 = cache.quadlet_cache_key(contents)
+        k2 = cache.quadlet_cache_key(contents)
+        assert k1 == k2
+
+    def test_order_independent(self):
+        k1 = cache.quadlet_cache_key({"a": "1", "b": "2"})
+        k2 = cache.quadlet_cache_key({"b": "2", "a": "1"})
+        assert k1 == k2
+
+    def test_changes_on_content(self):
+        k1 = cache.quadlet_cache_key({"a.container": "v1"})
+        k2 = cache.quadlet_cache_key({"a.container": "v2"})
+        assert k1 != k2
+
+    def test_length(self):
+        k = cache.quadlet_cache_key({"f": "c"})
+        assert len(k) == 16
+
+
+# ── are_quadlets_cached / mark_quadlets_installed ────────
+
+
+class TestQuadletCache:
+    def test_miss_when_no_marker(self):
+        assert not cache.are_quadlets_cached("cage1", "key123")
+
+    def test_hit_after_mark(self):
+        cache.mark_quadlets_installed("cage1", "key123")
+        assert cache.are_quadlets_cached("cage1", "key123")
+
+    def test_miss_on_different_key(self):
+        cache.mark_quadlets_installed("cage1", "key-aaa")
+        assert not cache.are_quadlets_cached("cage1", "key-bbb")
+
+
+# ── clear_cage_cache ─────────────────────────────────────
+
+
+class TestClearCageCache:
+    def test_clear_removes_markers(self):
+        podman = _make_podman()
+        cache.mark_image_built("mycage", "k1", "img:1")
+        cache.mark_quadlets_installed("mycage", "k2")
+        assert cache.is_image_cached("mycage", "k1", podman)
+        assert cache.are_quadlets_cached("mycage", "k2")
+
+        removed = cache.clear_cage_cache("mycage")
+        assert removed == 2
+        assert not cache.is_image_cached("mycage", "k1", podman)
+        assert not cache.are_quadlets_cached("mycage", "k2")
+
+    def test_clear_only_affects_target(self):
+        podman = _make_podman()
+        cache.mark_image_built("cage-a", "k1", "img:1")
+        cache.mark_image_built("cage-b", "k2", "img:2")
+
+        cache.clear_cage_cache("cage-a")
+        assert not cache.is_image_cached("cage-a", "k1", podman)
+        assert cache.is_image_cached("cage-b", "k2", podman)
+
+    def test_clear_empty_returns_zero(self):
+        assert cache.clear_cage_cache("nonexistent") == 0
+
+
+# ── clear_all_cache ──────────────────────────────────────
+
+
+class TestClearAllCache:
+    def test_clear_all(self):
+        cache.mark_image_built("a", "k1", "img:1")
+        cache.mark_image_built("b", "k2", "img:2")
+        cache.mark_quadlets_installed("c", "k3")
+
+        removed = cache.clear_all_cache()
+        assert removed == 3
+        assert not cache.CACHE_DIR.exists()
+
+    def test_clear_all_empty(self):
+        assert cache.clear_all_cache() == 0


### PR DESCRIPTION
## Summary
- Add build cache system (`cache.py`) to skip redundant image builds on `agentcage run`, enabling fast warm starts
- Harden cache against race conditions, version skew, and stale markers
- Add `agentcage cache` CLI commands for inspection and cleanup

## Test plan
- [ ] Verify first run builds the image, second run skips the build
- [ ] Verify cache invalidation on scaffold changes
- [ ] Run `pytest tests/test_cache.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)