### PR TITLE
fix: stabilize flaky E2E tests 4.3 and 5.2

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -129,13 +129,17 @@ wait_ready() {
 wait_http_code() {
   local url="$1" expected="$2" timeout="${3:-30}"
   local deadline=$((SECONDS + timeout))
+  local delay=1
   while [ "$SECONDS" -lt "$deadline" ]; do
     local code
     code=$(curl -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
     if [ "$code" = "$expected" ]; then
       return 0
     fi
-    sleep 2
+    sleep "$delay"
+    # exponential backoff: 1, 2, 4, … capped at 8s
+    delay=$(( delay * 2 ))
+    [ "$delay" -gt 8 ] && delay=8
   done
   return 1
 }

--- a/tests/e2e/phase4_domains.sh
+++ b/tests/e2e/phase4_domains.sh
@@ -27,12 +27,12 @@ else
   e2e_fail "4.2" "Add domain" "command failed"
 fi
 
-# 4.3: New domain accessible (poll — proxy may need a moment)
-if wait_http_code "$BASE/fetch?url=http://example.com" 200 30; then
+# 4.3: New domain accessible (poll — proxy may need a moment after hot-reload)
+if wait_http_code "$BASE/fetch?url=http://example.com" 200 60; then
   e2e_pass "4.3" "New domain accessible"
 else
   # May still be restarting; check if domain is at least in config
-  e2e_fail "4.3" "New domain accessible" "did not get HTTP 200 within 30s"
+  e2e_fail "4.3" "New domain accessible" "did not get HTTP 200 within 60s"
 fi
 
 # 4.4: Remove domain

--- a/tests/e2e/phase5_backup.sh
+++ b/tests/e2e/phase5_backup.sh
@@ -38,6 +38,11 @@ else
 fi
 
 # 5.2: Subnet isolation
+# Wait for each proxy to serve its allowed domain before checking isolation.
+# Without this, all requests may return 502 if the proxy isn't ready yet.
+wait_http_code "$BASE/fetch?url=http://httpbin.org/get" 200 60 || true
+wait_http_code "$BASE2/fetch?url=http://example.com" 200 60 || true
+
 CODE_BASIC_HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/fetch?url=http://httpbin.org/get" 2>/dev/null || echo "000")
 CODE_BASIC_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/fetch?url=http://example.com" 2>/dev/null || echo "000")
 CODE_SECOND_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE2/fetch?url=http://example.com" 2>/dev/null || echo "000")


### PR DESCRIPTION
## Summary

- **Test 4.3 ("New domain accessible")**: Increased timeout from 30s to 60s. The proxy needs more time to pick up a hot-reloaded domain allowlist in CI.
- **Test 5.2 ("Subnet isolation")**: Added `wait_http_code` readiness checks for each proxy's allowed domain before running isolation assertions. Without this, all requests returned 502 because the proxy wasn't ready yet.
- **`wait_http_code` helper**: Changed from fixed 2s sleep to exponential backoff (1s, 2s, 4s, 8s cap), so the first retry happens faster while avoiding hammering the proxy under load.

## Test plan

- [ ] CI E2E suite passes without flaky failures on tests 4.3 and 5.2
- [ ] No regressions in other phases that use `wait_http_code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)