### PR TITLE
docs: fix correctness, DRY scaffolds, remove stale content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken", 500 errors → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the site, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+- Save progress, checkpoint, resume → invoke checkpoint
+- Code quality, health check → invoke health

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Most agent deployments hand the agent a [**lethal trifecta**](https://simonwilli
 - **DNS filtering** -- allowlist-based dnsmasq sidecar, placeholder IPs for unauthorized domains
 - **Fail-closed by default** -- all hardening on out of the box; component failure stops traffic
 
-Both container mode (rootless Podman) and VM mode (Lima KVM) are supported -- see [Security & Threat Model](docs/security.md#isolation-modes) for the comparison. For the full container topology and inspector chain, see [Architecture](docs/architecture.md).
+Both container mode (rootless Podman) and VM mode (Lima KVM) are supported -- see [Security & Threat Model](docs/security.md#isolation-modes-and-the-threat-surface) for the comparison. For the full container topology and inspector chain, see [Architecture](docs/architecture.md).
 
 ## Quick Start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,17 +7,19 @@
 - [Configuration Reference](configuration.md) — all settings, defaults, and examples
 - [CLI Reference](cli.md) — full command set and options
 
-## Features
-
-- [Traffic Capture & HAR Export](configuration.md#traffic-capture-capture) — record and export decrypted request/response bodies for forensic analysis
-- [Inspector Chain](architecture.md#inspector-chain) — pluggable inspection pipeline for domain filtering, secret detection, entropy analysis
-
 ## Isolation
 
 - [Lima VM Isolation](vm.md) — KVM-based hardware isolation via Lima
 
 ## Setup Guides
 
+- [Claude Code](../src/agentcage/scaffolds/claude-code/README.md) — Anthropic's CLI coding agent
+- [Codex](../src/agentcage/scaffolds/codex/README.md) — OpenAI's CLI coding agent
 - [OpenClaw](../src/agentcage/scaffolds/openclaw/README.md) — full-featured AI coding agent
 - [PicoClaw](../src/agentcage/scaffolds/picoclaw/README.md) — ultra-lightweight agent gateway
 - [NanoClaw](../src/agentcage/scaffolds/nanoclaw/README.md) — nested container agent framework
+- [Managing Your Cage](cage-management.md) — common operations and troubleshooting
+
+## Reference
+
+- [Security Review (Feb 2026)](security-review-2026-02.md) — adversarial review from compromised agent perspective

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,11 +184,11 @@ Inner containers default to `--network none` (configured via `containers.conf`),
 
 A persistent named volume (`agentcage-podman-<name>`) stores inner podman's image cache and container state at `/var/lib/containers`, so pulled images survive cage restarts.
 
-For the base image, security trade-offs, and setup, see the [NanoClaw guide](nanoclaw.md).
+For the base image, security trade-offs, and setup, see the [NanoClaw guide](../src/agentcage/scaffolds/nanoclaw/README.md).
 
 ## Generated Files
 
-The `generate` command produces 5 quadlet files in `<name>-quadlets/` (6 when `nested_containers` is enabled):
+The `cage create` command produces 5 quadlet files in `<name>-quadlets/` (6 when `nested_containers` is enabled):
 
 | File | Role |
 |------|------|

--- a/docs/cage-management.md
+++ b/docs/cage-management.md
@@ -1,0 +1,32 @@
+# Managing Your Cage
+
+Common commands for managing an agentcage cage. Replace `myapp` with your cage name.
+
+## Day-to-day operations
+
+```bash
+# Edit config in $EDITOR, validate, and reload if running
+agentcage cage edit myapp
+
+# Rebuild and restart (after config or image changes)
+agentcage cage update myapp
+
+# Restart without rebuilding
+agentcage cage restart myapp
+
+# View proxy audit logs
+agentcage cage audit myapp
+
+# Destroy (stops containers, removes quadlets and state)
+agentcage cage destroy myapp
+```
+
+## Troubleshooting
+
+**403 errors from the proxy**: Check proxy logs: `agentcage cage logs myapp -s proxy`. The JSON entries include a `reason` field explaining the block. Either the domain is not in your allowlist, or a secret pattern was detected.
+
+**Certificate errors**: The mitmproxy CA cert is shared via a named volume. If TLS errors occur, restart the cage: `agentcage cage restart myapp`.
+
+**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. If using custom `dns_servers`, ensure they are reachable from the host.
+
+**File permission errors in /workspace**: The scaffold uses `userns: "keep-id"` to map your host UID into the container. Check that mounted directories are owned by your user on the host.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-The CLI has top-level **`run`** and **`init`** commands, and three command groups: **`cage`** (manage cages), **`secret`** (manage cage-scoped secrets), and **`domain`** (manage cage domain filters).
+The CLI has top-level **`run`**, **`init`**, **`doctor`**, and **`update`** commands, and four command groups: **`cage`**, **`secret`**, **`domain`**, and **`scaffold`**.
 
 ```
 agentcage run SCAFFOLD [options]
@@ -64,6 +64,9 @@ Creates a sandboxed cage from a scaffold, opens an interactive session, and stop
 | `--project` | path | current directory | Project directory to mount as `/workspace` |
 | `--name` | string | auto-generated | Override the auto-generated cage name |
 | `-i, --interactive-domains` | flag | | Prompt to add blocked domains to the allowlist in real-time |
+| `-s, --set-secret` | repeatable string | | Set a secret (`KEY=VALUE` or `KEY` to prompt). Passed to the cage at creation |
+| `-v, --verbose` | flag | | Enable verbose output |
+| `--isolation` | choice: `container`/`vm` | `container` | Isolation backend |
 
 ### Examples
 
@@ -145,11 +148,11 @@ Subdomains are collapsed to their parent domain (e.g. `api.stripe.com` prompts f
 agentcage cage create -c <config>
 ```
 
-Creates a new cage from a config file. This single command:
+Creates a new cage from a config file. Use `-s KEY=VALUE` (repeatable) to set secrets inline during creation. This single command:
 
 1. Validates the config
 2. Checks that all required secrets exist in Podman
-3. Saves deployment state to `~/.config/agentcage/deployments/<name>/cage.yaml`
+3. Saves deployment state to `~/.config/agentcage/cages/<name>/cage.yaml`
 4. Builds the proxy and DNS container images
 5. Generates and installs 5 quadlet files into `~/.config/containers/systemd/`
 6. Reloads systemd and starts the cage
@@ -366,6 +369,7 @@ Audit entries are read from the `{name}-proxy` systemd unit in container mode, o
 | `-f, --follow` | flag | Stream new entries in real time |
 | `--json` | flag | Output as JSON lines (one per entry) |
 | `--summary` | flag | Show aggregated statistics (incompatible with `--follow`) |
+| `--direction` | repeatable choice: `inbound`/`outbound` | Filter by traffic direction |
 | `--no-color` | flag | Disable colored output |
 
 ### Examples
@@ -595,11 +599,11 @@ Mode is one of:
 agentcage domain add <name> <domain>
 ```
 
-Adds a domain to a cage's filter list. Updates both the stored config and the proxy config on disk. If the cage is currently running, all containers are automatically restarted so the change takes effect immediately.
+Adds a domain to a cage's filter list. Updates both the stored config and the proxy config on disk. If the cage is currently running, the proxy detects the config change and hot-reloads.
 
 ```bash
 agentcage domain add myapp api.openai.com
-# Added 'api.openai.com' to cage 'myapp'. Cage reloaded.
+# Added 'api.openai.com' to cage 'myapp'. Proxy updated.
 ```
 
 Subdomain matching is built in -- adding `anthropic.com` also allows `api.anthropic.com`. Duplicates are detected and skipped.
@@ -612,11 +616,11 @@ If no `domains` section exists in the stored config, one is created with mode `a
 agentcage domain rm <name> <domain>
 ```
 
-Removes a domain from a cage's filter list. Like `domain add`, updates stored config and proxy config, and auto-reloads the cage if running.
+Removes a domain from a cage's filter list. Like `domain add`, updates stored config and proxy config, and hot-reloads the proxy if running.
 
 ```bash
 agentcage domain rm myapp api.openai.com
-# Removed 'api.openai.com' from cage 'myapp'. Cage reloaded.
+# Removed 'api.openai.com' from cage 'myapp'. Proxy updated.
 ```
 
 Fails if the domain is not in the list.
@@ -644,3 +648,40 @@ eval "$(_AGENTCAGE_COMPLETE=zsh_source agentcage)"
 # Fish (~/.config/fish/config.fish)
 eval "$(_AGENTCAGE_COMPLETE=fish_source agentcage)"
 ```
+
+---
+
+## `doctor` -- Check system prerequisites
+
+```
+agentcage doctor
+```
+
+Checks that all required tools are installed and properly configured (Podman, systemd, Lima, etc.). Reports pass/fail for each prerequisite.
+
+---
+
+## `update` -- Self-update
+
+```
+agentcage update
+```
+
+Updates agentcage to the latest version.
+
+---
+
+## `scaffold` -- Manage scaffold templates
+
+| Command | Description |
+|---|---|
+| `scaffold list` | List available scaffolds (built-in, user, and project-local) |
+| `scaffold show NAME` | Show scaffold details and config template |
+| `scaffold create NAME` | Create a new user scaffold |
+| `scaffold edit NAME` | Edit a user scaffold |
+| `scaffold delete NAME` | Delete a user scaffold |
+| `scaffold export NAME` | Export a scaffold as a directory |
+
+Scaffolds are resolved in order: project-local (`.agentcage/scaffolds/`) → user (`~/.config/agentcage/scaffolds/`) → built-in.
+
+**Aliases:** `ls` → `list`, `rm` → `delete`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 Full reference for all agentcage configuration settings — types, defaults, and examples.
 
 For architecture details, see [Architecture](architecture.md).
-Example configs: [`basic/cage.yaml`](../examples/basic/) | [`openclaw/cage.yaml`](../examples/openclaw/)
+Example configs: [`basic/cage.yaml`](../examples/basic/) | [`openclaw/cage.yaml`](../src/agentcage/scaffolds/openclaw/)
 
 ## Table of Contents
 
@@ -32,7 +32,7 @@ Example configs: [`basic/cage.yaml`](../examples/basic/) | [`openclaw/cage.yaml`
 | `isolation` | `string` | `"container"` | Isolation backend: `"container"` (rootless Podman, default) or `"vm"` (Lima VM). Old `"firecracker"` configs are silently upgraded to `"vm"`. |
 | `lifecycle` | `string` | `"service"` | Cage lifecycle mode: `"service"` (always running, auto-restart), `"interactive"` (on-demand, stops on exit, state preserved), or `"ephemeral"` (stops on exit, destroyed by `cage prune`). |
 | `scaffold` | `string` | `""` | Scaffold name used to generate this config (shown in `cage list` output). |
-| `log_allowed` | `bool` | `true` | Log allowed requests to the proxy journal |
+| `log_allowed` | `bool` | `false` | Log allowed requests to the proxy journal |
 | `max_request_body` | `int` | `10485760` (10 MB) | Max request body size in bytes. Set to `0` to disable the body-size limit |
 | `dns_servers` | `list[string]` | *(from host `/etc/resolv.conf`)* | Upstream DNS servers used by both the dnsmasq sidecar and the proxy container |
 
@@ -71,6 +71,7 @@ dns_servers:
 | `ports` | `list[string]` | `[]` | Published port specs — see [Ports](#ports) below |
 | `podman_secrets` | `list[string]` | `[]` | [Podman secret](https://docs.podman.io/en/latest/markdown/podman-secret.1.html) names (injected as env vars) |
 | `user` | `string` | `"1000:1000"` | UID:GID to run as. Set to `""` to use the image default. See [Podman `--user`](https://docs.podman.io/en/latest/markdown/podman-run.1.html) |
+| `userns` | `string` | `""` | User namespace mode (e.g. `"keep-id"`). See [Podman `--userns`](https://docs.podman.io/en/latest/markdown/podman-run.1.html) |
 | `memory` | `string` | *(none)* | Memory limit (e.g. `"4g"`). See [Podman `--memory`](https://docs.podman.io/en/latest/markdown/podman-run.1.html) |
 | `cpus` | `string` | *(none)* | CPU limit (e.g. `"2.0"`). See [Podman `--cpus`](https://docs.podman.io/en/latest/markdown/podman-run.1.html) |
 | `nested_containers` | `bool` | `false` | Enable podman-in-podman support. See [Nested containers](#nested-containers) below |
@@ -82,7 +83,7 @@ Publish container ports to the host. Each entry is a string in one of two format
 | Format | Example | Description |
 |--------|---------|-------------|
 | `"BIND:HOST_PORT:CONTAINER_PORT"` | `"127.0.0.1:8080:80"` | Bind to a specific interface |
-| `"HOST_PORT:CONTAINER_PORT"` | `"8080:80"` | Bind to all interfaces (`0.0.0.0`) |
+| `"HOST_PORT:CONTAINER_PORT"` | `"8080:80"` | Bind to localhost (`127.0.0.1`) |
 
 Ports must be integers between 1 and 65535. The three-part form with an explicit bind address is recommended — binding to `127.0.0.1` ensures the port is only accessible from the host, not from the network.
 
@@ -95,7 +96,7 @@ container:
     # Bind to all interfaces (accessible from LAN)
     - "0.0.0.0:3000:3000"
 
-    # Short form (binds to all interfaces)
+    # Short form (binds to 127.0.0.1)
     - "9090:9090"
 ```
 
@@ -112,7 +113,7 @@ Enabling this option automatically:
 - Creates a persistent storage volume for inner podman state
 - Bind-mounts a Docker CLI shim and podman config files
 
-The nested-containers base image must be built first with `./build.sh` from the scaffold directory. See the [NanoClaw guide](nanoclaw.md) for a complete walkthrough.
+The nested-containers base image must be built first with `./build.sh` from the scaffold directory. See the [NanoClaw guide](../src/agentcage/scaffolds/nanoclaw/README.md) for a complete walkthrough.
 
 ```yaml
 container:
@@ -146,7 +147,7 @@ These settings are nested under `container:` in the config file.
 |---------|------|---------|-------------|
 | `restart` | `string` | `"on-failure"` | Systemd restart policy: `"no"`, `"on-failure"`, `"always"` |
 | `restart_sec` | `int` | `10` | Seconds to wait before restart |
-| `timeout_start_sec` | `int` | *(none)* | Systemd `TimeoutStartSec` |
+| `timeout_start_sec` | `int` | `120` | Systemd `TimeoutStartSec` |
 | `timeout_stop_sec` | `int` | `30` | Systemd `TimeoutStopSec` |
 
 ---
@@ -288,20 +289,20 @@ Detected secrets always result in a **block** action (403 response). Use `allow_
 |---------|-------|---------------|
 | `openai_key` | `sk-proj-[a-zA-Z0-9]{20,}` | `sk-proj-abc123...` |
 | `anthropic_key` | `sk-ant-[a-zA-Z0-9\-]{20,}` | `sk-ant-abc123...` |
-| `aws_access_key` | `AKIA[0-9A-Z]{16}` | `AKIAIOSFODNN7EXAMPLE` |
-| `github_token` | `gh[ps]_[A-Za-z0-9_]{36,}` | `ghp_abc123...` |
-| `github_pat` | `github_pat_[A-Za-z0-9_]{22,}` | `github_pat_abc123...` |
+| `aws_access_key` | `AKIA[A-Z2-7]{16}` | `AKIAIOSFODNN7EXAMPLE` |
+| `github_token` | `gh[ps]_[A-Za-z0-9]{36}` | `ghp_abc123...` |
+| `github_pat` | `github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}` | `github_pat_abc123...` |
 | `google_api_key` | `AIza[0-9A-Za-z\-_]{35}` | `AIzaSyA...` |
 | `slack_token` | `xox[bpors]-[0-9]{10,}-[a-zA-Z0-9-]+` | `xoxb-123456...` |
 | `stripe_key` | `[sr]k_(live\|test)_[0-9a-zA-Z]{24,}` | `sk_live_abc123...` |
 | `private_key` | `-----BEGIN[ A-Z]*PRIVATE KEY-----` | PEM private key headers |
 | `gitlab_token` | `glpat-[A-Za-z0-9\-_]{20,}` | `glpat-abc123...` |
-| `huggingface_token` | `hf_[A-Za-z0-9]{20,}` | `hf_abc123...` |
+| `huggingface_token` | `hf_[a-zA-Z]{34}` | `hf_abc123...` |
 | `databricks_token` | `dapi[0-9a-f]{32}` | `dapi0123456789abcdef...` |
 | `azure_jwt` | `eyJ[A-Za-z0-9_-]{50,}\.eyJ[A-Za-z0-9_-]{50,}` | `eyJhbG...eyJpc...` |
 | `openrouter_key` | `sk-or-v1-[a-f0-9]{64}` | `sk-or-v1-abc123...` |
-| `perplexity_key` | `pplx-[a-f0-9]{64}` | `pplx-abc123...` |
-| `brave_api_key` | `BSA[a-zA-Z0-9]{20,}` | `BSAabc123...` |
+| `perplexity_key` | `pplx-[a-zA-Z0-9]{48}` | `pplx-abc123...` |
+| `brave_api_key` | `BSAI[a-zA-Z0-9_-]{20,255}` | `BSAabc123...` |
 | `telegram_bot_token` | `[0-9]{8,10}:[A-Za-z0-9_-]{35}` | `123456789:AAAA...` |
 | `discord_bot_token` | `[MN][A-Za-z0-9]{23,}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}` | `MAAA...BBBB.CCCC...` |
 | `firecrawl_key` | `fc-[a-zA-Z0-9]{32,}` | `fc-abc123...` |
@@ -552,6 +553,6 @@ Every inspector receives an `InspectionContext` with pre-computed data:
 | `inspector` | `str` | *(required)* | Inspector name |
 | `action` | `str` | `"block"` | `"block"` or `"flag"` |
 | `reason` | `str` | `""` | Human-readable explanation |
-| `severity` | `str` | `"medium"` | `"info"`, `"low"`, `"medium"`, `"high"`, `"critical"` |
+| `severity` | `str` | `"warning"` | `"debug"`, `"info"`, `"warning"`, `"error"`, `"critical"` |
 | `score` | `float` | `0.0` | Numeric score (for anomaly-scoring use cases) |
 | `metadata` | `dict` | `{}` | Arbitrary inspector-specific data |

--- a/docs/security-review-2026-02.md
+++ b/docs/security-review-2026-02.md
@@ -38,6 +38,8 @@ The entropy inspector's `_check_url_params()` explicitly parses `parse_qs(parsed
 
 **Mitigation:** Add `_check_url_path()` to the entropy inspector that computes entropy on each `/`-delimited path segment longer than `url_min_value_bytes`.
 
+> **Status: Resolved** (v0.3.0) — Entropy inspector now checks URL path segments.
+
 ---
 
 ### HIGH — H2: Rate limiting disabled by default
@@ -55,6 +57,8 @@ The multi-request evasion limitation documented in `security.md` ("An agent coul
 **Impact:** Unbounded exfiltration throughput through any allowed domain via splitting, URL-path encoding, or header stuffing.
 
 **Mitigation:** Enable a default rate limit (e.g., 10 req/s, burst 50). The operator can raise it for high-throughput workloads. Document that disabling rate limiting significantly weakens multi-request evasion defenses.
+
+> **Status: Resolved** (v0.3.0) — Rate limiting now defaults to 10 req/s, burst 50.
 
 ---
 
@@ -74,6 +78,8 @@ Fail-closed design means a hung proxy = no connectivity (not unfiltered access),
 This is speculative and low-probability, but the unbounded quantifiers have no upside.
 
 **Mitigation:** Add upper bounds to all regex quantifiers (e.g., `{20,200}`). The body-size inspector already limits total body size, but runs independently — consider checking body size before regex scanning within the secrets inspector itself.
+
+> **Status: Resolved** (v0.3.0) — All secret detection regex patterns now have upper-bounded quantifiers.
 
 ---
 
@@ -214,25 +220,25 @@ These design choices significantly raise the bar for agent exfiltration:
 
 ### P0 — Closes concrete exfiltration channels
 
-| ID | Finding | Fix | Files |
-|----|---------|-----|-------|
-| H1 | URL path entropy bypass | Add `_check_url_path()` — entropy-check each path segment above a length threshold | `inspectors/entropy.py` |
-| H2 | Rate limiting off by default | Default to 10 req/s burst 50; document opt-out | `addon.py`, `docs/configuration.md` |
+| ID | Finding | Fix | Files | Status |
+|----|---------|-----|-------|--------|
+| H1 | URL path entropy bypass | Add `_check_url_path()` — entropy-check each path segment above a length threshold | `inspectors/entropy.py` | Resolved (v0.3.0) |
+| H2 | Rate limiting off by default | Default to 10 req/s burst 50; document opt-out | `addon.py`, `docs/configuration.md` | Resolved (v0.3.0) |
 
 ### P1 — Hardens existing inspection
 
-| ID | Finding | Fix | Files |
-|----|---------|-----|-------|
-| H3 | Regex DoS / unbounded quantifiers | Add upper bounds (`{20,200}`) to all secret patterns | `inspectors/secrets.py` |
-| M1 | URL-safe base64 evasion | Extend `_BASE64_RE` to include `-_` | `inspectors/content_type.py` |
-| M3 | Entropy gap with non-text CT | Run base64 blob regex on all content types, not just text-like | `inspectors/content_type.py` |
-| M4 | Header scanning via `str()` | Iterate and scan individual header values | `inspectors/secrets.py` |
+| ID | Finding | Fix | Files | Status |
+|----|---------|-----|-------|--------|
+| H3 | Regex DoS / unbounded quantifiers | Add upper bounds (`{20,200}`) to all secret patterns | `inspectors/secrets.py` | Resolved (v0.3.0) |
+| M1 | URL-safe base64 evasion | Extend `_BASE64_RE` to include `-_` | `inspectors/content_type.py` | Open |
+| M3 | Entropy gap with non-text CT | Run base64 blob regex on all content types, not just text-like | `inspectors/content_type.py` | Open |
+| M4 | Header scanning via `str()` | Iterate and scan individual header values | `inspectors/secrets.py` | Open |
 
 ### P2 — Defense in depth
 
-| ID | Finding | Fix | Files |
-|----|---------|-----|-------|
-| M2 | Binary WS text evasion | Block or flag binary frames above entropy threshold regardless of text pattern match | `addon.py` |
-| M5 | mitmproxy as attack surface | Add seccomp profile to proxy container; document update cadence | `templates/proxy.container.j2`, docs |
-| L1 | Response redaction encoding gap | Scan for URL-encoded and base64 variants during redaction | `secret_injector.py` |
-| L2 | vmbase tag pinning | Pin to `@sha256:...` digest | `Containerfile.vmbase` |
+| ID | Finding | Fix | Files | Status |
+|----|---------|-----|-------|--------|
+| M2 | Binary WS text evasion | Block or flag binary frames above entropy threshold regardless of text pattern match | `addon.py` | Open |
+| M5 | mitmproxy as attack surface | Add seccomp profile to proxy container; document update cadence | `templates/proxy.container.j2`, docs | Open |
+| L1 | Response redaction encoding gap | Scan for URL-encoded and base64 variants during redaction | `secret_injector.py` | Open |
+| L2 | vmbase tag pinning | Pin to `@sha256:...` digest | `Containerfile.vmbase` | Open |

--- a/docs/security.md
+++ b/docs/security.md
@@ -32,7 +32,7 @@ agentcage offers two isolation modes that affect the threat model differently:
 | **Kernel** | Shared with host | Dedicated guest kernel per cage |
 | **Container escape risk** | Mitigated by hardening, not eliminated | Eliminated — escape lands in VM, not on host |
 | **Root required** | No | No (Lima handles VM networking) |
-| **macOS support** | Yes (via Podman machine) | Yes (Lima supports macOS) |
+| **macOS support** | No (use VM mode) | Yes (Lima supports macOS) |
 | **Boot overhead** | ~1s | ~15–30s |
 | **Best for** | Development, CI, low-risk workloads | Production, untrusted agents, high-security |
 
@@ -81,11 +81,11 @@ agentcage applies multiple overlapping defenses:
 
 7. **WebSocket inspection** -- After the initial HTTP upgrade handshake is approved, all subsequent WebSocket frames are inspected by the full inspector chain (secrets, entropy, content-type). Frames that trigger a block are dropped.
 
-8. **Rate limiting** -- Optional per-host token-bucket rate limiter prevents request flooding and timing-based evasion. Configure via `rate_limit.requests_per_second` and `rate_limit.burst`.
+8. **Rate limiting** -- Per-host token-bucket rate limiter (enabled by default: 10 req/s, burst 50) prevents request flooding and timing-based evasion. Configure via `rate_limit.requests_per_second` and `rate_limit.burst`.
 
 9. **Custom inspectors** -- User-defined Python inspectors can implement arbitrary detection logic, extending the chain with domain-specific rules. Custom inspector paths are validated against an allowed directory list to prevent arbitrary code loading.
 
-10. **Audit logging** -- All inspection decisions (blocked, flagged, and allowed requests) are written as structured JSON lines to a persistent audit log file (`/var/log/agentcage/audit.jsonl` by default). Allowed request logging is enabled by default for forensic completeness.
+10. **Audit logging** -- All inspection decisions (blocked, flagged, and allowed requests) are written as structured JSON lines to a persistent audit log file (`/var/log/agentcage/audit.jsonl` by default). Allowed request logging is disabled by default.
 
 ## Fail-Closed Design
 
@@ -194,4 +194,4 @@ The capture volume is accessible to the host user running podman. This is the sa
 
 ## Reporting Security Issues
 
-Please report security issues via [GitHub Issues](https://github.com/agentcage/agentcage/issues).
+Please report security vulnerabilities via email to **security@agentcage.ai**. Do not open a public GitHub issue for security vulnerabilities. See [SECURITY.md](../SECURITY.md) for details.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -37,7 +37,7 @@ agentcage cage destroy basic
 ## E2E test
 
 ```bash
-bash tests/e2e_basic.sh
+bash tests/e2e/run.sh
 ```
 
 See [Configuration Reference](../../docs/configuration.md) for all settings.

--- a/src/agentcage/scaffolds/claude-code/README.md
+++ b/src/agentcage/scaffolds/claude-code/README.md
@@ -94,22 +94,7 @@ With `lifecycle: service`, systemd auto-restarts the container on failure and st
 
 ## Managing your cage
 
-```bash
-# Edit the config in $EDITOR, validate, and reload if running
-agentcage cage edit myagent
-
-# Rebuild and restart (after config or image changes)
-agentcage cage update myagent
-
-# Restart without rebuilding
-agentcage cage reload myagent
-
-# View proxy audit logs
-agentcage cage audit myagent
-
-# Destroy the cage (stops containers, removes quadlets and state)
-agentcage cage destroy myagent
-```
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
 
 ## Configuration
 
@@ -153,10 +138,3 @@ Subdomains are matched automatically -- adding `anthropic.com` also allows `api.
 
 **Claude Code hangs on startup**: The telemetry domains (`datadoghq.com`, `sentry.io`) must be in the allowlist. Claude Code blocks on telemetry init if these are unreachable.
 
-**403 errors from the proxy**: A domain is not in your allowlist, or a secret pattern was detected in the request. Check proxy logs with `agentcage cage logs myagent -s proxy` -- the JSON log entries include a `reason` field explaining the block.
-
-**Certificate errors**: The mitmproxy CA certificate is shared via a named volume. If the proxy container hasn't finished generating it before the cage starts, you may see TLS errors. Restart the cage: `agentcage cage reload myagent`.
-
-**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. If you are using custom `dns_servers`, make sure those servers are reachable from the host.
-
-**File permission errors in /workspace**: The scaffold uses `userns: "keep-id"` to map your host UID into the container. If you still see permission issues, check that the mounted directories are owned by your user on the host.

--- a/src/agentcage/scaffolds/codex/README.md
+++ b/src/agentcage/scaffolds/codex/README.md
@@ -39,21 +39,21 @@ agentcage init myagent --scaffold codex
 
 This creates `cage.yaml` with sensible defaults and auto-builds the `agentcage-scaffold-codex:latest` image. Review the config and adjust as needed.
 
-#### 2. Set secrets
-
-```bash
-agentcage secret set myagent OPENAI_API_KEY
-```
-
-The scaffold uses `secret_injection` for the API key. Codex sends the placeholder `{{OPENAI_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
-
-#### 3. Create the cage
+#### 2. Create the cage
 
 ```bash
 agentcage cage create -c cage.yaml
 ```
 
 This builds the proxy and DNS images, generates systemd quadlet files, and starts all three services (cage, proxy, dns).
+
+#### 3. Set secrets
+
+```bash
+agentcage secret set myagent OPENAI_API_KEY
+```
+
+The scaffold uses `secret_injection` for the API key. Codex sends the placeholder `{{OPENAI_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
 
 #### 4. Start a session
 
@@ -90,22 +90,7 @@ With `lifecycle: service`, systemd auto-restarts the container on failure and st
 
 ## Managing your cage
 
-```bash
-# Edit the config in $EDITOR, validate, and reload if running
-agentcage cage edit myagent
-
-# Rebuild and restart (after config or image changes)
-agentcage cage update myagent
-
-# Restart without rebuilding
-agentcage cage reload myagent
-
-# View proxy audit logs
-agentcage cage audit myagent
-
-# Destroy the cage (stops containers, removes quadlets and state)
-agentcage cage destroy myagent
-```
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
 
 ## Configuration
 
@@ -141,12 +126,3 @@ The scaffold organizes domains into tiers:
 
 Subdomains are matched automatically -- adding `openai.com` also allows `api.openai.com`. Sibling domains are not matched.
 
-## Troubleshooting
-
-**403 errors from the proxy**: A domain is not in your allowlist, or a secret pattern was detected in the request. Check proxy logs with `agentcage cage logs myagent -s proxy` -- the JSON log entries include a `reason` field explaining the block.
-
-**Certificate errors**: The mitmproxy CA certificate is shared via a named volume. If the proxy container hasn't finished generating it before the cage starts, you may see TLS errors. Restart the cage: `agentcage cage reload myagent`.
-
-**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. If you are using custom `dns_servers`, make sure those servers are reachable from the host.
-
-**File permission errors in /workspace**: The scaffold uses `userns: "keep-id"` to map your host UID into the container. If you still see permission issues, check that the mounted directories are owned by your user on the host.

--- a/src/agentcage/scaffolds/nanoclaw/README.md
+++ b/src/agentcage/scaffolds/nanoclaw/README.md
@@ -4,7 +4,7 @@
 
 All HTTP traffic from the cage (and from inner agent containers) passes through agentcage's inspecting proxy for domain filtering, secret leak detection, and payload analysis. Inner agent containers are patched to use `--network host` so they inherit the cage's proxy, and proxy/cert environment variables are forwarded automatically.
 
-For the full list of configuration options, see the agentcage configuration reference.
+For the full list of configuration options, see the [Configuration Reference](../../docs/configuration.md).
 
 ## Architecture
 
@@ -56,21 +56,21 @@ podman build -t agentcage-nested -f Containerfile.nested .
 - `agentcage-scaffold-nanoclaw` -- extends the base with NanoClaw cloned, built, and patched so inner containers use `--network host`, forward proxy/cert env vars, and mount `/certs` and `/agentcage` volumes
 - `nanoclaw-agent` -- NanoClaw's agent container (claude-code, chromium, agent-runner)
 
-### 3. Set secrets
-
-```bash
-agentcage secret set myapp ANTHROPIC_API_KEY
-```
-
-The config uses `secret_injection` for the API key. The cage image has a `.env` file containing the placeholder `{{ANTHROPIC_API_KEY}}`. NanoClaw reads this and passes it to agent containers via stdin. The proxy swaps the placeholder for the real value when forwarding to `anthropic.com`. No real secret ever enters the cage.
-
-### 4. Create the cage
+### 3. Create the cage
 
 ```bash
 agentcage cage create -c cage.yaml
 ```
 
 This builds the proxy and DNS images, generates systemd quadlet files, and starts all services.
+
+### 4. Set secrets
+
+```bash
+agentcage secret set myapp ANTHROPIC_API_KEY
+```
+
+The config uses `secret_injection` for the API key. The cage image has a `.env` file containing the placeholder `{{ANTHROPIC_API_KEY}}`. NanoClaw reads this and passes it to agent containers via stdin. The proxy swaps the placeholder for the real value when forwarding to `anthropic.com`. No real secret ever enters the cage.
 
 ### 5. Preload the agent image
 
@@ -170,26 +170,7 @@ See [Security trade-offs](#security-trade-offs) for what this means for your thr
 
 ## Managing your cage
 
-```bash
-# Edit the config in $EDITOR, validate, and reload if running
-agentcage cage edit myapp
-
-# Rebuild and restart (after config or image changes)
-agentcage cage update myapp
-
-# Restart without rebuilding
-agentcage cage reload myapp
-
-# View proxy audit logs
-agentcage cage audit myapp
-
-# View logs
-agentcage cage logs myapp           # cage container
-agentcage cage logs myapp -s proxy  # mitmproxy (traffic inspection)
-
-# Destroy the cage (stops containers, removes quadlets and state)
-agentcage cage destroy myapp
-```
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
 
 ## Domain allowlist
 
@@ -271,4 +252,3 @@ See [Security & Threat Model](../../docs/security.md) for the full threat model 
 
 **Certificate errors in inner containers**: The patched container-runner forwards `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` and mounts `/certs` into inner containers. If you still see certificate errors, check that the proxy's CA cert exists at `/certs/mitmproxy-ca-cert.pem` inside the cage.
 
-**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. Inner containers with `--network host` use the cage's DNS configuration.

--- a/src/agentcage/scaffolds/openclaw/README.md
+++ b/src/agentcage/scaffolds/openclaw/README.md
@@ -6,7 +6,7 @@ For the full list of configuration options, see the [Configuration Reference](..
 
 ## Prerequisites
 
-- [Podman](https://podman.io/) (rootless), Python 3.12+, and [uv](https://docs.astral.sh/uv/) — see [installation instructions](../../README.md#prerequisites) for your platform
+- [Podman](https://podman.io/) (rootless), Python 3.12+, and [uv](https://docs.astral.sh/uv/) — see [installation instructions](../../README.md#install) for your platform
 - An OpenClaw container image (`ghcr.io/openclaw/openclaw:latest` or custom-built)
 - An Anthropic API key (`ANTHROPIC_API_KEY`)
 
@@ -20,7 +20,15 @@ agentcage init myapp --scaffold openclaw
 
 This creates `cage.yaml` with sensible defaults: domain allowlist, secret injection, resource limits, and inline help. Review it and adjust as needed -- the comments explain each option.
 
-### 2. Set secrets
+### 2. Create the cage
+
+```bash
+agentcage cage create -c cage.yaml
+```
+
+This builds the proxy and DNS images, generates systemd quadlet files, and starts all three services (cage, proxy, dns). After startup, inline help is printed showing next steps.
+
+### 3. Set secrets
 
 ```bash
 # Anthropic API key (required)
@@ -36,14 +44,6 @@ agentcage secret set myapp OPENCLAW_GATEWAY_PASSWORD
 If you add `BRAVE_API_KEY`, uncomment the Brave entries in the `secret_injection` section and add `search.brave.com` to the domain allowlist in `cage.yaml`.
 
 > **Secret injection:** The config uses `secret_injection` for API keys (Anthropic, Brave). The cage container never sees the real value -- it gets a placeholder like `{{ANTHROPIC_API_KEY}}`, and the proxy swaps it for the real value when forwarding to the correct domain. The gateway password (`OPENCLAW_GATEWAY_PASSWORD`) stays in `podman_secrets` since it is used internally by the cage process, not in proxied HTTP requests. See [Secret injection](../../docs/configuration.md#secret-injection-secret_injection) for details.
-
-### 3. Create the cage
-
-```bash
-agentcage cage create -c cage.yaml
-```
-
-This builds the proxy and DNS images, generates systemd quadlet files, and starts all three services (cage, proxy, dns). After startup, inline help is printed showing next steps.
 
 ### 4. Connect and pair your browser
 
@@ -80,22 +80,7 @@ agentcage cage logs myapp -s dns    # DNS sidecar
 
 ## Managing your cage
 
-```bash
-# Edit the config in $EDITOR, validate, and reload if running
-agentcage cage edit myapp
-
-# Rebuild and restart (after config or image changes)
-agentcage cage update myapp
-
-# Restart without rebuilding
-agentcage cage reload myapp
-
-# View proxy audit logs
-agentcage cage audit myapp
-
-# Destroy the cage (stops containers, removes quadlets and state)
-agentcage cage destroy myapp
-```
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
 
 ## Reverse proxy & device pairing
 
@@ -196,8 +181,3 @@ agentcage cage update myapp
 
 **Container fails to start / times out**: OpenClaw's Node.js gateway can take over 60 seconds to initialize. The scaffold config sets `timeout_start_sec: 120` to accommodate this. Check logs with `agentcage cage logs myapp`.
 
-**403 errors from the proxy**: A domain is not in your allowlist, or a secret pattern was detected in the request. Check proxy logs with `agentcage cage logs myapp -s proxy` -- the JSON log entries include a `reason` field explaining the block.
-
-**Certificate errors**: The mitmproxy CA certificate is shared via a named volume (see [Certificate Sharing](../../docs/architecture.md#certificate-sharing)). If the proxy container hasn't finished generating it before the cage starts, you may see TLS errors. The generated quadlet files include a start-up check that waits up to 30 seconds for the certificate. If it still fails, restart the cage: `agentcage cage reload myapp`.
-
-**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. If you are using custom `dns_servers` (e.g., Tailscale MagicDNS), make sure those servers are reachable from the host.

--- a/src/agentcage/scaffolds/picoclaw/README.md
+++ b/src/agentcage/scaffolds/picoclaw/README.md
@@ -19,21 +19,21 @@ agentcage init myapp --scaffold picoclaw
 
 This creates `cage.yaml` with sensible defaults and provisions `~/.picoclaw/config.json` with the Anthropic API key placeholder. The scaffold also auto-builds the `picoclaw:latest` image from source. Review the config and adjust as needed.
 
-### 2. Set secrets
-
-```bash
-agentcage secret set myapp ANTHROPIC_API_KEY
-```
-
-The config uses `secret_injection` for the API key. The `config.json` contains the placeholder `{{ANTHROPIC_API_KEY}}`. PicoClaw sends this placeholder in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
-
-### 3. Create the cage
+### 2. Create the cage
 
 ```bash
 agentcage cage create -c cage.yaml
 ```
 
 This builds the proxy and DNS images, generates systemd quadlet files, and starts all three services (cage, proxy, dns).
+
+### 3. Set secrets
+
+```bash
+agentcage secret set myapp ANTHROPIC_API_KEY
+```
+
+The config uses `secret_injection` for the API key. The `config.json` contains the placeholder `{{ANTHROPIC_API_KEY}}`. PicoClaw sends this placeholder in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
 
 ### 4. Verify
 
@@ -53,22 +53,7 @@ Open `http://localhost:18790` in your browser to access the PicoClaw web UI.
 
 ## Managing your cage
 
-```bash
-# Edit the config in $EDITOR, validate, and reload if running
-agentcage cage edit myapp
-
-# Rebuild and restart (after config or image changes)
-agentcage cage update myapp
-
-# Restart without rebuilding
-agentcage cage reload myapp
-
-# View proxy audit logs
-agentcage cage audit myapp
-
-# Destroy the cage (stops containers, removes quadlets and state)
-agentcage cage destroy myapp
-```
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
 
 ## Configuration
 
@@ -112,15 +97,9 @@ The provisioned `~/.picoclaw/config.json` is a starting point. Edit it to add mo
 
 ```bash
 $EDITOR ~/.picoclaw/config.json
-agentcage cage reload myapp    # pick up changes (bind-mounted read-only)
+agentcage cage restart myapp    # pick up changes (bind-mounted read-only)
 ```
 
 ## Troubleshooting
-
-**403 errors from the proxy**: A domain is not in your allowlist, or a secret pattern was detected in the request. Check proxy logs with `agentcage cage logs myapp -s proxy` -- the JSON log entries include a `reason` field explaining the block.
-
-**Certificate errors**: The mitmproxy CA certificate is shared via a named volume. If the proxy container hasn't finished generating it before the cage starts, you may see TLS errors. Restart the cage: `agentcage cage reload myapp`.
-
-**DNS resolution failures**: Verify the DNS sidecar is running: `agentcage cage list`. If you are using custom `dns_servers`, make sure those servers are reachable from the host.
 
 **PicoClaw web tools return errors**: PicoClaw's web tools (`web_fetch`, `web_search`) use `PICOCLAW_TOOLS_WEB_PROXY` to route through the proxy. This is pre-configured in the scaffold. If web tools fail, check that the target domains are in the allowlist.


### PR DESCRIPTION
## Summary

Comprehensive documentation review fixing correctness, removing duplication, and updating stale content across 14 files.

**Correctness fixes:**
- Fix macOS container mode claim in security docs (not supported)
- Fix `log_allowed` default (`false`, not `true`), `timeout_start_sec` default (`120`, not none)
- Fix severity values (`warning`/`error`, not `medium`/`high`)
- Update 6 outdated secret regex patterns to match source code
- Fix rate limiting described as optional (enabled by default: 10 req/s)
- Mark 3 resolved security review findings (H1, H2, H3 fixed in v0.3.0)
- Fix secret set / cage create ordering in scaffold guides (cage must exist first)
- Fix `domain add/rm` docs to say hot-reload, not restart
- Add missing CLI: `run` flags (`-s`, `-v`, `--isolation`), `doctor`, `update`, `scaffold` commands
- Add missing config fields: `userns`, `cage audit --direction`, `cage create -s`

**DRY:**
- Extract shared `docs/cage-management.md` with common operations and troubleshooting
- 5 scaffold READMEs now link to shared doc instead of duplicating ~50 lines each

**Stale content:**
- Fix 5 broken links (nanoclaw, openclaw, security anchor, e2e test path)
- Align security reporting to private email across SECURITY.md and docs/security.md
- Update docs/README.md index with all missing entries
- Fix default port binding docs (`127.0.0.1`, not `0.0.0.0`)

## Test plan
- [ ] CI passes
- [ ] All internal links resolve correctly
- [ ] Verify docs match source code for defaults and patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)