### PR TITLE
feat: auto-bump scaffold base image tags on cage update

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -295,7 +295,7 @@ def init(name: str | None, output: str, image: str, isolation: str,
         click.echo(f"error: {dest} already exists (use --force to overwrite)", err=True)
         sys.exit(1)
 
-    content, image_tag = render_config(name, image=image, isolation=isolation, scaffold=scaffold, port=port)
+    content = render_config(name, image=image, isolation=isolation, scaffold=scaffold, port=port)
     dest.write_text(content)
     click.echo(f"Created {dest}")
 
@@ -303,7 +303,7 @@ def init(name: str | None, output: str, image: str, isolation: str,
 
     meta = load_scaffold_meta(scaffold) if scaffold else None
     if scaffold and meta:
-        run_scaffold_setup(scaffold, name, str(dest), image_tag=image_tag)
+        run_scaffold_setup(scaffold, name, str(dest))
         # Copy Containerfile and sibling build context files from scaffold
         scaffold_dir_path = resolve_scaffold(scaffold)
         if scaffold_dir_path is not None:
@@ -436,7 +436,12 @@ def cage_create(config_path: str, secrets: tuple):
 
     # Save state
     state.save_deployment(name, config_path)
-    state.save_metadata(name, {"agentcage_version": version("agentcage")})
+    from agentcage.init import infer_scaffold_from_image
+    _metadata = {"agentcage_version": version("agentcage")}
+    _scaffold = infer_scaffold_from_image(cfg.container.image)
+    if _scaffold:
+        _metadata["scaffold"] = _scaffold
+    state.save_metadata(name, _metadata)
 
     # Copy Containerfile and sibling files into state dir so cage update
     # can rebuild (Containerfiles may COPY other files from the build context)
@@ -594,13 +599,33 @@ def cage_update(name: str, config_path: str | None):
                     if f.is_file() and f.suffix not in (".yaml", ".yml", ".j2"):
                         shutil.copy2(str(f), str(dest_dir / f.name))
     else:
-        # Auto-resolve latest image tag for stored configs
-        from agentcage.registry import resolve_latest_tag
+        # Auto-resolve latest image tags for stored configs
+        from agentcage.init import (
+            infer_scaffold_from_image,
+            load_scaffold_meta,
+        )
+        from agentcage.registry import resolve_build_args, resolve_latest_tag
 
         raw = state.load_raw_config(name)
+
+        # Resolve the scaffold name for this cage. Precedence:
+        #   1. metadata.json "scaffold" (populated by cage create / run)
+        #   2. raw.get("scaffold") (legacy inline field)
+        #   3. infer from container.image naming convention
+        stored_meta = state.load_metadata(name) or {}
+        scaffold_name = (
+            stored_meta.get("scaffold")
+            or raw.get("scaffold", "")
+            or infer_scaffold_from_image(raw.get("container", {}).get("image", ""))
+            or ""
+        )
+
+        # Top-level container.image — skip scaffold-built local images
+        # (e.g. "localhost/agentcage-scaffold-openclaw:latest") since those
+        # are never in a real registry.
         current_image = raw.get("container", {}).get("image", "")
         image_base, _, current_tag = current_image.rpartition(":")
-        if image_base and current_tag:
+        if image_base and current_tag and not image_base.startswith("localhost/"):
             new_tag = resolve_latest_tag(image_base)
             if new_tag and new_tag != current_tag:
                 raw["container"]["image"] = f"{image_base}:{new_tag}"
@@ -613,28 +638,37 @@ def cage_update(name: str, config_path: str | None):
                     err=True,
                 )
 
-        # Auto-resolve latest tags for untagged build arg image refs
+        # Build args — scaffold.yaml declaration is authoritative.
+        # Untagged-in-scaffold ⇒ auto-bump on every update (tracks upstream).
+        # Tagged-in-scaffold   ⇒ respected (author pinned on purpose).
+        # User-added args      ⇒ resolved once if untagged, then respected.
+        scaffold_declared_args: dict[str, str] = {}
+        if scaffold_name:
+            scaffold_meta = load_scaffold_meta(scaffold_name) or {}
+            for entry in scaffold_meta.get("build", []):
+                scaffold_declared_args.update(entry.get("build_args") or {})
+
         build_raw = raw.get("container", {}).get("build", {})
-        build_args = build_raw.get("args") or {}
-        args_changed = False
-        for key, val in list(build_args.items()):
-            image_base, _, tag = val.rpartition(":")
-            if image_base and tag:
-                # Already has an explicit tag — leave it alone
-                continue
-            # Untagged image ref (contains "/" so looks like a registry path)
-            if "/" in val:
-                new_tag = resolve_latest_tag(val)
-                if new_tag:
-                    build_args[key] = f"{val}:{new_tag}"
-                    args_changed = True
-                    click.echo(f"Build arg {key}: {val} \u2192 {val}:{new_tag}")
-        if args_changed:
-            raw.setdefault("container", {}).setdefault("build", {})["args"] = build_args
+        stored_args = build_raw.get("args") or {}
+        resolved_args, changes = resolve_build_args(
+            stored_args, scaffold_declared_args,
+        )
+        for key, old, new in changes:
+            click.echo(f"Build arg {key}: {old} \u2192 {new}")
+            old_base = old.rsplit(":", 1)[0]
+            new_base = new.rsplit(":", 1)[0]
+            if old_base != new_base:
+                click.echo(
+                    f"warning: base image for {key} changed "
+                    f"({old_base} \u2192 {new_base}) \u2014 scaffold updated "
+                    f"upstream reference",
+                    err=True,
+                )
+        if changes:
+            raw.setdefault("container", {}).setdefault("build", {})["args"] = resolved_args
             state.save_raw_config(name, raw)
 
         # Refresh scaffold build artifacts and command if scaffold is known
-        scaffold_name = raw.get("scaffold", "")
         if scaffold_name:
             from agentcage.init import resolve_scaffold, render_config
 
@@ -649,7 +683,7 @@ def cage_update(name: str, config_path: str | None):
                 # Re-render scaffold template and patch command + new env vars
                 try:
                     import yaml
-                    rendered, _ = render_config(name, scaffold=scaffold_name)
+                    rendered = render_config(name, scaffold=scaffold_name)
                     scaffold_cfg = yaml.safe_load(rendered) or {}
                     scaffold_container = scaffold_cfg.get("container", {})
 
@@ -686,7 +720,10 @@ def cage_update(name: str, config_path: str | None):
         for w in warnings:
             click.echo(f"warning: {w}", err=True)
 
-    state.save_metadata(name, {"agentcage_version": version("agentcage")})
+    # Merge into existing metadata so scaffold/network_octet/etc. survive updates
+    _meta = state.load_metadata(name) or {}
+    _meta["agentcage_version"] = version("agentcage")
+    state.save_metadata(name, _meta)
     config_host_path = state.save_proxy_config(name)
 
     podman = Podman()

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -437,11 +437,11 @@ def cage_create(config_path: str, secrets: tuple):
     # Save state
     state.save_deployment(name, config_path)
     from agentcage.init import infer_scaffold_from_image
-    _metadata = {"agentcage_version": version("agentcage")}
-    _scaffold = infer_scaffold_from_image(cfg.container.image)
-    if _scaffold:
-        _metadata["scaffold"] = _scaffold
-    state.save_metadata(name, _metadata)
+    metadata = {"agentcage_version": version("agentcage")}
+    scaffold_name = infer_scaffold_from_image(cfg.container.image)
+    if scaffold_name:
+        metadata["scaffold"] = scaffold_name
+    state.save_metadata(name, metadata)
 
     # Copy Containerfile and sibling files into state dir so cage update
     # can rebuild (Containerfiles may COPY other files from the build context)
@@ -721,9 +721,9 @@ def cage_update(name: str, config_path: str | None):
             click.echo(f"warning: {w}", err=True)
 
     # Merge into existing metadata so scaffold/network_octet/etc. survive updates
-    _meta = state.load_metadata(name) or {}
-    _meta["agentcage_version"] = version("agentcage")
-    state.save_metadata(name, _meta)
+    meta = state.load_metadata(name) or {}
+    meta["agentcage_version"] = version("agentcage")
+    state.save_metadata(name, meta)
     config_host_path = state.save_proxy_config(name)
 
     podman = Podman()

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -21,12 +21,26 @@ _USER_SCAFFOLDS_DIR = Path(
     os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 ) / "agentcage" / "scaffolds"
 
-# Scaffold name → base image (without tag) for version pinning.
-# picoclaw uses a local build (see scaffold comments) until a release
-# with HTTP proxy support ships upstream.
-_SCAFFOLD_IMAGES: dict[str, str] = {
-    "openclaw": "ghcr.io/openclaw/openclaw",
-}
+# Scaffold upstream image mapping lives in each scaffold's scaffold.yaml
+# (build[].build_args). resolve_build_args() in registry.py resolves tags
+# against those declarations.
+
+_SCAFFOLD_IMAGE_RE = re.compile(r"^localhost/agentcage-scaffold-([a-z0-9-]+):")
+
+
+def infer_scaffold_from_image(image: str) -> str | None:
+    """Infer scaffold name from the ``localhost/agentcage-scaffold-<NAME>:...``
+    image naming convention used by scaffold-built images.
+
+    Returns the scaffold name if it maps to a known scaffold, else ``None``.
+    Used by update to auto-discover the scaffold for cages created before
+    scaffold-name persistence landed in metadata.
+    """
+    m = _SCAFFOLD_IMAGE_RE.match(image or "")
+    if not m:
+        return None
+    name = m.group(1)
+    return name if name in list_scaffolds() else None
 
 
 def _project_scaffolds_dir() -> Path | None:
@@ -147,16 +161,21 @@ def render_config(
     isolation: str = "container",
     scaffold: str | None = None,
     port: int | None = None,
-) -> tuple[str, str | None]:
+) -> str:
     """Render a starter config.yaml from a template.
 
     When *scaffold* is ``None`` the default blank scaffold is used.
     Otherwise *scaffold* selects a file from the scaffold search path.
+
+    Upstream image tag resolution happens later, in :func:`run_scaffold_setup`
+    (via :func:`agentcage.registry.resolve_build_args`), so the rendered
+    config holds the scaffold's untagged reference verbatim and each cage
+    tracks its own pinned tag via state.
     """
     env = _make_env()
     if scaffold is None:
         tmpl = env.get_template("init-config.yaml.j2")
-        return tmpl.render(name=name, image=image, isolation=isolation, port=port), None
+        return tmpl.render(name=name, image=image, isolation=isolation, port=port)
 
     scaffold_dir = resolve_scaffold(scaffold)
     if scaffold_dir is None:
@@ -183,23 +202,10 @@ def render_config(
             err=True,
         )
 
-    image_tag: str | None = None
-    image_base = _SCAFFOLD_IMAGES.get(scaffold)
-    if image_base:
-        from agentcage.registry import resolve_latest_tag
-
-        image_tag = resolve_latest_tag(image_base)
-        if image_tag is None:
-            print(
-                f"warning: could not resolve latest tag for {image_base}, "
-                f"falling back to 'latest'",
-                file=sys.stderr,
-            )
-
     from agentcage.quadlets import cage_network_addrs
 
     addrs = cage_network_addrs(name)
-    return tmpl.render(name=name, isolation=isolation, port=port, image_tag=image_tag, **addrs), image_tag
+    return tmpl.render(name=name, isolation=isolation, port=port, **addrs)
 
 
 def load_scaffold_meta(scaffold: str) -> dict | None:
@@ -215,7 +221,7 @@ def load_scaffold_meta(scaffold: str) -> dict | None:
 
 
 def run_scaffold_setup(
-    scaffold: str, name: str, dest: str, *, image_tag: str | None = None, quiet: bool = False,
+    scaffold: str, name: str, dest: str, *, quiet: bool = False,
 ) -> None:
     """Execute build/provision steps from scaffold.yaml."""
     meta = load_scaffold_meta(scaffold)
@@ -223,6 +229,7 @@ def run_scaffold_setup(
         return
 
     from agentcage.podman import Podman
+    from agentcage.registry import resolve_build_args
 
     podman = Podman()
     scaffold_dir = resolve_scaffold(scaffold)
@@ -240,11 +247,11 @@ def run_scaffold_setup(
             _echo(f"Image {image} already exists, skipping build.")
             continue
 
-        # Resolve build_args — append resolved tag for scaffold images
-        build_args = dict(entry.get("build_args") or {})
-        for key, val in list(build_args.items()):
-            if val in _SCAFFOLD_IMAGES.values() and image_tag:
-                build_args[key] = f"{val}:{image_tag}"
+        # Resolve tags for scaffold-declared build args.
+        declared = entry.get("build_args") or {}
+        build_args, changes = resolve_build_args(declared, declared)
+        for key, _old, new in changes:
+            _echo(f"Build arg {key}: {new}")
 
         if "containerfile" in entry:
             containerfile = str(scaffold_dir / entry["containerfile"])

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -25,7 +25,7 @@ _USER_SCAFFOLDS_DIR = Path(
 # (build[].build_args). resolve_build_args() in registry.py resolves tags
 # against those declarations.
 
-_SCAFFOLD_IMAGE_RE = re.compile(r"^localhost/agentcage-scaffold-([a-z0-9-]+):")
+_SCAFFOLD_IMAGE_RE = re.compile(r"^localhost/agentcage-scaffold-([a-z0-9-]+?)(?::|$)")
 
 
 def infer_scaffold_from_image(image: str) -> str | None:

--- a/src/agentcage/registry.py
+++ b/src/agentcage/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from typing import Callable
 
 
 def _version_key(tag: str) -> list[int | str]:
@@ -64,3 +65,72 @@ def resolve_latest_tag(image: str) -> str | None:
 
     matching.sort(key=_version_key)
     return matching[-1]
+
+
+def _resolve_one(
+    current: str,
+    scaffold_val: str | None,
+    resolver: Callable[[str], str | None],
+) -> str:
+    """Resolve a single build-arg value. See resolve_build_args for semantics."""
+    if scaffold_val is not None:
+        _, _, scaffold_tag = scaffold_val.rpartition(":")
+        if ":" in scaffold_val and scaffold_tag:
+            # Scaffold author pinned it — use scaffold value verbatim
+            return scaffold_val
+        # Scaffold declares untagged — re-resolve against scaffold base
+        scaffold_base = scaffold_val.split(":", 1)[0]
+        new_tag = resolver(scaffold_base)
+        if new_tag is None:
+            # Resolver failure — preserve existing pin to avoid breaking builds
+            return current
+        return f"{scaffold_base}:{new_tag}"
+
+    # User-added arg.
+    _, _, tag = current.rpartition(":")
+    if ":" in current and tag:
+        return current  # already pinned, respect
+    if "/" in current:
+        # Registry-path-like ref without a tag — try to resolve
+        new_tag = resolver(current)
+        if new_tag:
+            return f"{current}:{new_tag}"
+    return current
+
+
+def resolve_build_args(
+    build_args: dict[str, str],
+    scaffold_args: dict[str, str] | None = None,
+    resolver: Callable[[str], str | None] | None = None,
+) -> tuple[dict[str, str], list[tuple[str, str, str]]]:
+    """Resolve image tags in *build_args*, returning (resolved, changes).
+
+    *changes* lists (key, old_value, new_value) tuples for each arg whose value
+    changed, so callers can echo transitions. When the scaffold-declared base
+    differs from the stored base (upstream rename/migration), callers can detect
+    drift by comparing the base portion of old vs new.
+
+    +-------------------+--------------------------------------+
+    | scaffold declares | behavior                             |
+    +-------------------+--------------------------------------+
+    | tagged value      | use scaffold value verbatim (respect |
+    |                   | author's pin; migrate on change)     |
+    | untagged value    | re-resolve using scaffold base       |
+    |                   | (auto-bump; migrate base on rename;  |
+    |                   | preserve stored on resolver failure) |
+    | not present       | user-added: resolve if untagged &    |
+    |                   | registry-like, else passthrough      |
+    +-------------------+--------------------------------------+
+
+    *resolver* is injectable for tests; defaults to :func:`resolve_latest_tag`.
+    """
+    scaffold_args = scaffold_args or {}
+    resolver = resolver or resolve_latest_tag
+    resolved: dict[str, str] = {}
+    changes: list[tuple[str, str, str]] = []
+    for key, current in build_args.items():
+        new_val = _resolve_one(current, scaffold_args.get(key), resolver)
+        resolved[key] = new_val
+        if new_val != current:
+            changes.append((key, current, new_val))
+    return resolved, changes

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -340,7 +340,7 @@ def execute(
 
     # Render config from scaffold template
     os.environ["PROJECT_DIR"] = project_dir
-    config_text, image_tag = render_config(
+    config_text = render_config(
         cage_name, scaffold=scaffold, isolation=isolation,
     )
 
@@ -427,7 +427,6 @@ def execute(
             if cfg.isolation != "vm":
                 run_scaffold_setup(
                     scaffold, cage_name, str(config_path),
-                    image_tag=image_tag,
                 )
             build_and_deploy(
                 cfg,
@@ -442,7 +441,7 @@ def execute(
                 if cfg.isolation != "vm":
                     run_scaffold_setup(
                         scaffold, cage_name, str(config_path),
-                        image_tag=image_tag, quiet=True,
+                        quiet=True,
                     )
                 build_and_deploy(
                     cfg,

--- a/src/agentcage/scaffolds/openclaw/Containerfile
+++ b/src/agentcage/scaffolds/openclaw/Containerfile
@@ -29,10 +29,26 @@ RUN mkdir -p /home/node/.config/containers \
     > /home/node/.config/containers/storage.conf \
  && chown -R node:node /home/node/.config
 
-# Install matrix extension dependencies (bundled but not installed in base image)
-RUN if [ -d /app/extensions/matrix ] && [ -f /app/extensions/matrix/package.json ]; then \
+# Install matrix extension dependencies for older base images that didn't
+# hoist them. openclaw 2026.4+ stages runtime deps into /app/node_modules
+# AND uses workspace:* devDependency refs that break plain `npm install`;
+# the canary (matrix-js-sdk presence in /app/node_modules) distinguishes
+# the two layouts.
+RUN if [ -d /app/extensions/matrix ] && [ -f /app/extensions/matrix/package.json ] \
+        && [ ! -d /app/node_modules/matrix-js-sdk ]; then \
         cd /app/extensions/matrix && npm install --omit=dev; \
     fi
+
+# openclaw 2026.4+ bundles extensions with self-references like
+#   import { X } from "openclaw/plugin-sdk/..."
+# but the bundled extension dir has its own package.json (name
+# "@openclaw/matrix"), so Node's self-reference doesn't resolve to the
+# openclaw root. Link /app (name "openclaw") under node_modules so the
+# import walks up and resolves via /app/package.json's exports map.
+# Safe on older bases: they don't have the bundled extension tree, the
+# symlink just goes unused.
+RUN mkdir -p /app/node_modules \
+ && ln -sfn /app /app/node_modules/openclaw
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/src/agentcage/scaffolds/openclaw/entrypoint.sh
+++ b/src/agentcage/scaffolds/openclaw/entrypoint.sh
@@ -6,11 +6,14 @@ set -e
 cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy.crt \
   && update-ca-certificates 2>/dev/null || true
 
-# Add to NSS database for Chromium/Electron.
-mkdir -p /home/node/.pki/nssdb
-certutil -d sql:/home/node/.pki/nssdb -N --empty-password 2>/dev/null || true
-certutil -d sql:/home/node/.pki/nssdb -A -t 'C,,' -n mitmproxy \
-  -i /certs/mitmproxy-ca-cert.pem 2>/dev/null || true
+# Add to NSS database for Chromium/Electron. Best-effort: skip if the
+# enclosing path isn't writable (cages with a read-only root FS and no
+# /home/node/.pki tmpfs would otherwise fail hard under `set -e`).
+if mkdir -p /home/node/.pki/nssdb 2>/dev/null; then
+  certutil -d sql:/home/node/.pki/nssdb -N --empty-password 2>/dev/null || true
+  certutil -d sql:/home/node/.pki/nssdb -A -t 'C,,' -n mitmproxy \
+    -i /certs/mitmproxy-ca-cert.pem 2>/dev/null || true
+fi
 
 # ── OpenClaw config ──
 # Write default config if none exists.  CAGE_PROXY_IP and CAGE_GATEWAY_PORT

--- a/src/agentcage/scaffolds/openclaw/entrypoint.sh
+++ b/src/agentcage/scaffolds/openclaw/entrypoint.sh
@@ -9,10 +9,15 @@ cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/mitmproxy.crt \
 # Add to NSS database for Chromium/Electron. Best-effort: skip if the
 # enclosing path isn't writable (cages with a read-only root FS and no
 # /home/node/.pki tmpfs would otherwise fail hard under `set -e`).
+# Surface the degraded state so operators can see TLS inspection is off
+# for browser traffic (agents relying on mitmproxy cert trust will see
+# cert errors until a /home/node/.pki tmpfs is added to cage.yaml).
 if mkdir -p /home/node/.pki/nssdb 2>/dev/null; then
   certutil -d sql:/home/node/.pki/nssdb -N --empty-password 2>/dev/null || true
   certutil -d sql:/home/node/.pki/nssdb -A -t 'C,,' -n mitmproxy \
     -i /certs/mitmproxy-ca-cert.pem 2>/dev/null || true
+else
+  echo "warning: /home/node/.pki not writable; Chromium/Electron in this cage will not trust the mitmproxy CA. Add '/home/node/.pki:rw,size=16M' to tmpfs in cage.yaml to enable TLS inspection for browser traffic." >&2
 fi
 
 # ── OpenClaw config ──

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -169,7 +169,7 @@ def build_container_image(
 
     *echo* is an optional callback for progress messages (e.g. click.echo).
     """
-    from agentcage.registry import resolve_latest_tag
+    from agentcage.registry import resolve_build_args
 
     bc = cfg.container.build
     containerfile = Path(bc.containerfile)
@@ -179,23 +179,13 @@ def build_container_image(
 
     context_dir = str(containerfile.parent)
 
-    # Auto-resolve latest tags for remote image refs in build args
-    resolved_args: dict[str, str] = {}
-    for key, val in bc.args.items():
-        image_base, _, tag = val.rpartition(":")
-        if image_base and tag:
-            resolved_args[key] = val
-        elif "/" in val:
-            # Looks like a remote image without tag — resolve latest
-            new_tag = resolve_latest_tag(val)
-            if new_tag:
-                resolved_args[key] = f"{val}:{new_tag}"
-                if echo:
-                    echo(f"Build arg {key}: {val}:{new_tag}")
-            else:
-                resolved_args[key] = val
-        else:
-            resolved_args[key] = val
+    # Point-in-time tag resolution for build args. Scaffold-aware bumping
+    # happens earlier in the update path — here we only fill in tags for
+    # untagged registry refs (user-provided configs).
+    resolved_args, changes = resolve_build_args(bc.args)
+    if echo:
+        for key, _old, new in changes:
+            echo(f"Build arg {key}: {new}")
 
     if echo:
         echo(f"Building {cfg.container.image}...")

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -82,6 +82,225 @@ class TestCageUpdate:
         assert "does not match" in result.output
 
 
+class TestCageUpdateBuildArgs:
+    """Verify `cage update` re-resolves scaffold-declared-untagged build args."""
+
+    def _mock_stored_raw(self, build_args: dict[str, str], scaffold: str = "openclaw"):
+        """Return a minimal raw config dict with the given build_args."""
+        return {
+            "name": "test",
+            "scaffold": scaffold,
+            "container": {
+                "image": "localhost/agentcage-scaffold-openclaw:latest",
+                "build": {
+                    "containerfile": "Containerfile",
+                    "args": dict(build_args),
+                },
+            },
+            "domains": {"allow": ["example.com"]},
+        }
+
+    def _run_update(
+        self,
+        stored_raw,
+        scaffold_meta,
+        resolver_returns,
+        mock_state,
+        MockPodman,
+        mock_systemd,
+        tmp_path,
+    ):
+        """Invoke `cage update test` with everything below the resolver mocked out."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_raw_config.return_value = stored_raw
+        # After save_raw_config, capture the raw dict so tests can assert on it.
+        saved: dict = {}
+
+        def _save(name, raw):
+            saved.clear()
+            saved.update(raw)
+
+        mock_state.save_raw_config.side_effect = _save
+        # Make load_deployment_config pass through validate_config by reusing the
+        # raw dict the test handed in (state saves are captured but we want
+        # validation to succeed regardless).
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        mock_cfg = Config(
+            name=stored_raw["name"],
+            isolation="container",
+            container=ContainerConfig(
+                image=stored_raw["container"]["image"],
+                build=BuildConfig(
+                    containerfile="Containerfile",
+                    args=stored_raw["container"]["build"]["args"],
+                ),
+            ),
+        )
+        mock_state.load_deployment_config.return_value = mock_cfg
+        mock_state.load_metadata.return_value = {"scaffold": "openclaw"}
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.save_metadata.return_value = None
+        # Use a real tmp dir so scaffold-refresh's shutil.copy2 call doesn't
+        # create a file named after the MagicMock's repr in the cwd.
+        mock_state.deployment_dir.return_value = tmp_path
+
+        podman = MockPodman.return_value
+        podman.secret_exists.return_value = True
+        podman.pull.return_value = True
+
+        with patch("agentcage.init.load_scaffold_meta", return_value=scaffold_meta), \
+             patch("agentcage.registry.resolve_latest_tag", side_effect=resolver_returns), \
+             patch("agentcage.cli._build_container_image"), \
+             patch("agentcage.cli._build_and_deploy"), \
+             patch("agentcage.cli._check_port_availability", return_value=[]), \
+             patch("agentcage.cli._check_secrets", return_value=[]), \
+             patch("agentcage.cli.get_backend") as mock_backend:
+            mock_backend.return_value.stop.return_value = None
+            result = _runner().invoke(main, ["cage", "update", "test"])
+        return result, saved
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_bumps_scaffold_untagged_arg(self, mock_state, MockPodman, mock_systemd, tmp_path):
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
+        result, saved = self._run_update(
+            stored, scaffold_meta, lambda _: "2026.4.1-1",
+            mock_state, MockPodman, mock_systemd, tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Build arg BASE_IMAGE:" in result.output
+        assert "2026.3.13-1" in result.output
+        assert "2026.4.1-1" in result.output
+        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.4.1-1"
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_respects_scaffold_pinned_arg(self, mock_state, MockPodman, mock_systemd, tmp_path):
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:v1.0.0"})
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw:v1.0.0"}}]}
+        resolve_calls: list[str] = []
+
+        def _resolver(base):
+            resolve_calls.append(base)
+            return "v9.9.9"
+
+        result, _saved = self._run_update(
+            stored, scaffold_meta, _resolver,
+            mock_state, MockPodman, mock_systemd, tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        # Scaffold pin matches stored pin — nothing changed, no resolver call
+        assert "Build arg BASE_IMAGE:" not in result.output
+        # resolve_latest_tag MUST NOT have been called for the scaffold-pinned arg
+        # (may have been called for container.image but that starts with "localhost/"
+        # so we short-circuited that path too)
+        assert resolve_calls == []
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_preserves_pin_on_resolver_failure(self, mock_state, MockPodman, mock_systemd, tmp_path):
+        """REGRESSION: offline update MUST NOT un-pin a working build."""
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
+        result, saved = self._run_update(
+            stored, scaffold_meta, lambda _: None,  # resolver fails
+            mock_state, MockPodman, mock_systemd, tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Build arg BASE_IMAGE:" not in result.output
+        # No state write for build_args happened — saved is either empty (never
+        # called) or has the original value untouched.
+        if saved:
+            assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.3.13-1"
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_migrates_on_scaffold_base_change(self, mock_state, MockPodman, mock_systemd, tmp_path):
+        """Scaffold author renamed the upstream image — users auto-migrate + warning."""
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/old/base:v1"})
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/new/base"}}]}
+        result, saved = self._run_update(
+            stored, scaffold_meta, lambda _: "v2",
+            mock_state, MockPodman, mock_systemd, tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Build arg BASE_IMAGE:" in result.output
+        assert "ghcr.io/new/base:v2" in result.output
+        # Drift warning visible
+        assert "base image for BASE_IMAGE changed" in result.output
+        assert "ghcr.io/old/base" in result.output
+        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/new/base:v2"
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_infers_scaffold_from_image_when_metadata_missing(
+        self, mock_state, MockPodman, mock_systemd, tmp_path,
+    ):
+        """Cages created before scaffold-persistence landed still auto-bump."""
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
+        # Legacy cage: no scaffold field anywhere — only the image name hints at it
+        stored.pop("scaffold", None)
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
+        # Metadata has NO scaffold key — force inference from image name
+        mock_state.load_metadata.return_value = {"agentcage_version": "0.10.1"}
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_raw_config.return_value = stored
+        saved: dict = {}
+        mock_state.save_raw_config.side_effect = lambda _n, r: saved.update(r) or None
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        mock_state.load_deployment_config.return_value = Config(
+            name=stored["name"], isolation="container",
+            container=ContainerConfig(
+                image=stored["container"]["image"],
+                build=BuildConfig(
+                    containerfile="Containerfile",
+                    args=stored["container"]["build"]["args"],
+                ),
+            ),
+        )
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.deployment_dir.return_value = tmp_path
+        podman = MockPodman.return_value
+        podman.secret_exists.return_value = True
+        podman.pull.return_value = True
+
+        with patch("agentcage.init.load_scaffold_meta", return_value=scaffold_meta), \
+             patch("agentcage.registry.resolve_latest_tag", side_effect=lambda _b: "2026.4.9"), \
+             patch("agentcage.cli._build_container_image"), \
+             patch("agentcage.cli._build_and_deploy"), \
+             patch("agentcage.cli._check_port_availability", return_value=[]), \
+             patch("agentcage.cli._check_secrets", return_value=[]), \
+             patch("agentcage.cli.get_backend") as mock_backend:
+            mock_backend.return_value.stop.return_value = None
+            result = _runner().invoke(main, ["cage", "update", "test"])
+
+        assert result.exit_code == 0, result.output
+        # Scaffold inferred from "localhost/agentcage-scaffold-openclaw:latest"
+        assert "Build arg BASE_IMAGE:" in result.output
+        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.4.9"
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_suppresses_localhost_warning(self, mock_state, MockPodman, mock_systemd, tmp_path):
+        """localhost/... image refs must not produce `could not resolve latest tag` noise."""
+        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
+        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
+        # stored["container"]["image"] is "localhost/agentcage-scaffold-openclaw:latest"
+        result, _saved = self._run_update(
+            stored, scaffold_meta, lambda _: "2026.4.1-1",
+            mock_state, MockPodman, mock_systemd, tmp_path,
+        )
+        assert result.exit_code == 0, result.output
+        assert "could not resolve latest tag" not in result.output
+
+
 class TestCageDestroy:
     @patch("agentcage.cli._destroy_cage")
     def test_destroy_with_yes(self, mock_destroy, tmp_path):

--- a/tests/test_custom_scaffolds.py
+++ b/tests/test_custom_scaffolds.py
@@ -369,7 +369,7 @@ class TestShadowWarning:
             old_stderr = sys.stderr
             try:
                 # render_config prints shadow warning to stderr via click
-                result, _ = render_config("test", scaffold="alpine-curl")
+                result = render_config("test", scaffold="alpine-curl")
                 # The warning goes through click.echo(err=True)
             finally:
                 sys.stderr = old_stderr

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -4,7 +4,7 @@ import sys
 import textwrap
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import yaml
 import pytest
@@ -98,11 +98,10 @@ class TestDefaultInspectors:
         names = sorted(i.name for i in addon.inspectors)
         assert names == ["body-size", "content-type", "domain", "entropy", "secrets"]
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_preset_loads_inspectors(self, mock_resolve):
+    def test_openclaw_preset_loads_inspectors(self):
         """The openclaw scaffold config should load entropy + content-type."""
         from agentcage.init import render_config
-        cfg_text, _ = render_config("test-oc", scaffold="openclaw")
+        cfg_text = render_config("test-oc", scaffold="openclaw")
         addon = self._make_addon(cfg_text)
         names = [i.name for i in addon.inspectors]
         assert "entropy" in names
@@ -110,11 +109,10 @@ class TestDefaultInspectors:
         assert "domain" in names
         assert "secrets" in names
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="v0.1.2")
-    def test_picoclaw_preset_loads_inspectors(self, mock_resolve):
+    def test_picoclaw_preset_loads_inspectors(self):
         """The picoclaw scaffold config should load entropy + content-type."""
         from agentcage.init import render_config
-        cfg_text, _ = render_config("test-pico", scaffold="picoclaw")
+        cfg_text = render_config("test-pico", scaffold="picoclaw")
         addon = self._make_addon(cfg_text)
         names = [i.name for i in addon.inspectors]
         assert "entropy" in names
@@ -125,7 +123,7 @@ class TestDefaultInspectors:
         """The picoclaw scaffold should produce valid YAML that load_config accepts."""
         from agentcage.init import render_config
         from agentcage.config import load_config
-        cfg_text, _ = render_config("test-pico", scaffold="picoclaw")
+        cfg_text = render_config("test-pico", scaffold="picoclaw")
         cfg_file = tmp_path / "picoclaw.yaml"
         cfg_file.write_text(cfg_text)
         cfg = load_config(str(cfg_file))
@@ -180,12 +178,11 @@ class TestBuildConfig:
         assert cfg.container.build.containerfile == ""
         assert cfg.container.build.args == {}
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_scaffold_has_build_section(self, mock_resolve, tmp_path):
+    def test_openclaw_scaffold_has_build_section(self, tmp_path):
         """The rendered openclaw scaffold should include a build section."""
         from agentcage.init import render_config
         from agentcage.config import load_config
-        cfg_text, _ = render_config("test-oc-build", scaffold="openclaw")
+        cfg_text = render_config("test-oc-build", scaffold="openclaw")
         cfg_file = tmp_path / "cage.yaml"
         cfg_file.write_text(cfg_text)
         cfg = load_config(str(cfg_file))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,233 @@
+"""Tests for registry.resolve_build_args — tag resolution semantics."""
+
+from agentcage.registry import resolve_build_args
+
+
+def _fake_resolver(mapping: dict[str, str | None]):
+    """Return a resolver that looks tags up in *mapping*, tracking calls."""
+    calls: list[str] = []
+
+    def _resolve(base: str) -> str | None:
+        calls.append(base)
+        return mapping.get(base)
+
+    _resolve.calls = calls  # type: ignore[attr-defined]
+    return _resolve
+
+
+class TestResolveBuildArgsEmpty:
+    def test_empty_args(self):
+        resolved, changes = resolve_build_args({}, {}, resolver=lambda _: "ignored")
+        assert resolved == {}
+        assert changes == []
+
+    def test_no_scaffold_no_changes(self):
+        resolver = _fake_resolver({})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1"}, resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:v1"}
+        assert changes == []
+        assert resolver.calls == []  # pinned user-added, no resolve
+
+
+class TestScaffoldUntagged:
+    """Scaffold declares an untagged image ref — auto-bump semantics."""
+
+    def test_resolves_and_bumps_existing_pin(self):
+        resolver = _fake_resolver({"ghcr.io/openclaw/openclaw": "2026.4.1-1"})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"},
+            {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.4.1-1"}
+        assert changes == [(
+            "BASE_IMAGE",
+            "ghcr.io/openclaw/openclaw:2026.3.13-1",
+            "ghcr.io/openclaw/openclaw:2026.4.1-1",
+        )]
+        assert resolver.calls == ["ghcr.io/openclaw/openclaw"]
+
+    def test_same_tag_no_change(self):
+        resolver = _fake_resolver({"ghcr.io/foo/bar": "v2"})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v2"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:v2"}
+        assert changes == []
+
+    def test_resolver_failure_preserves_stored_pin(self):
+        """REGRESSION: offline `cage update` must NOT un-pin a working build."""
+        resolver = _fake_resolver({"ghcr.io/foo/bar": None})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:v1"}
+        assert changes == []
+
+    def test_resolver_failure_with_untagged_stored_stays_untagged(self):
+        resolver = _fake_resolver({"ghcr.io/foo/bar": None})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar"}
+        assert changes == []
+
+    def test_migrates_on_scaffold_base_rename(self):
+        """Scaffold author changed the image base — auto-migrate."""
+        resolver = _fake_resolver({"ghcr.io/new/base": "v2"})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/old/base:v1"},
+            {"BASE_IMAGE": "ghcr.io/new/base"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/new/base:v2"}
+        assert changes == [(
+            "BASE_IMAGE",
+            "ghcr.io/old/base:v1",
+            "ghcr.io/new/base:v2",
+        )]
+        # Only new base queried — never resolves the old one
+        assert resolver.calls == ["ghcr.io/new/base"]
+
+
+class TestScaffoldPinned:
+    """Scaffold declares an explicit tag — respect author's pin."""
+
+    def test_respects_pin_no_resolver_call(self):
+        resolver = _fake_resolver({"ghcr.io/foo/bar": "v99"})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1.2.3"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1.2.3"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:v1.2.3"}
+        assert changes == []
+        assert resolver.calls == []  # pin is respected, no resolution
+
+    def test_migrates_stored_to_scaffold_pin(self):
+        """Scaffold bumped its pin — stored follows."""
+        resolver = _fake_resolver({})
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1.0.0"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1.2.3"},
+            resolver=resolver,
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:v1.2.3"}
+        assert changes == [(
+            "BASE_IMAGE",
+            "ghcr.io/foo/bar:v1.0.0",
+            "ghcr.io/foo/bar:v1.2.3",
+        )]
+        assert resolver.calls == []
+
+
+class TestUserAdded:
+    """Args not declared in scaffold — user-added, light-touch semantics."""
+
+    def test_pinned_user_arg_passthrough(self):
+        resolver = _fake_resolver({"docker.io/foo/bar": "v2"})
+        resolved, changes = resolve_build_args(
+            {"CUSTOM": "docker.io/foo/bar:v1"},
+            {},  # no scaffold entry for CUSTOM
+            resolver=resolver,
+        )
+        assert resolved == {"CUSTOM": "docker.io/foo/bar:v1"}
+        assert changes == []
+        assert resolver.calls == []
+
+    def test_untagged_registry_like_user_arg_resolves(self):
+        resolver = _fake_resolver({"docker.io/foo/bar": "v2"})
+        resolved, changes = resolve_build_args(
+            {"CUSTOM": "docker.io/foo/bar"},
+            {},
+            resolver=resolver,
+        )
+        assert resolved == {"CUSTOM": "docker.io/foo/bar:v2"}
+        assert changes == [(
+            "CUSTOM",
+            "docker.io/foo/bar",
+            "docker.io/foo/bar:v2",
+        )]
+
+    def test_untagged_non_registry_user_arg_passthrough(self):
+        """A bare 'foo' isn't a registry ref — don't touch it."""
+        resolver = _fake_resolver({})
+        resolved, changes = resolve_build_args(
+            {"VERSION": "1.2.3"},
+            {},
+            resolver=resolver,
+        )
+        assert resolved == {"VERSION": "1.2.3"}
+        assert changes == []
+        assert resolver.calls == []
+
+    def test_untagged_user_arg_resolver_failure_passthrough(self):
+        resolver = _fake_resolver({"docker.io/foo/bar": None})
+        resolved, changes = resolve_build_args(
+            {"CUSTOM": "docker.io/foo/bar"},
+            {},
+            resolver=resolver,
+        )
+        assert resolved == {"CUSTOM": "docker.io/foo/bar"}
+        assert changes == []
+
+
+class TestMixed:
+    def test_scaffold_and_user_args_coexist(self):
+        resolver = _fake_resolver({
+            "ghcr.io/openclaw/openclaw": "2026.4.1-1",
+            "docker.io/me/mine": "v9",
+        })
+        resolved, changes = resolve_build_args(
+            {
+                "BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1",
+                "MY_SIDECAR": "docker.io/me/mine",
+                "VERSION_STRING": "1.0.0",
+            },
+            {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"},
+            resolver=resolver,
+        )
+        assert resolved == {
+            "BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.4.1-1",
+            "MY_SIDECAR": "docker.io/me/mine:v9",
+            "VERSION_STRING": "1.0.0",
+        }
+        assert sorted(changes) == sorted([
+            (
+                "BASE_IMAGE",
+                "ghcr.io/openclaw/openclaw:2026.3.13-1",
+                "ghcr.io/openclaw/openclaw:2026.4.1-1",
+            ),
+            (
+                "MY_SIDECAR",
+                "docker.io/me/mine",
+                "docker.io/me/mine:v9",
+            ),
+        ])
+
+
+class TestDefaultResolverWiring:
+    """Smoke-check that the default resolver is `resolve_latest_tag`."""
+
+    def test_default_resolver_is_used_when_not_provided(self, monkeypatch):
+        calls: list[str] = []
+
+        def fake(base: str) -> str | None:
+            calls.append(base)
+            return "fromreal"
+
+        monkeypatch.setattr("agentcage.registry.resolve_latest_tag", fake)
+        resolved, changes = resolve_build_args(
+            {"BASE_IMAGE": "ghcr.io/foo/bar:v1"},
+            {"BASE_IMAGE": "ghcr.io/foo/bar"},
+        )
+        assert resolved == {"BASE_IMAGE": "ghcr.io/foo/bar:fromreal"}
+        assert calls == ["ghcr.io/foo/bar"]

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import pytest
 import yaml
 
-from agentcage.init import list_scaffolds, render_config, load_scaffold_meta
+from agentcage.init import (
+    infer_scaffold_from_image,
+    list_scaffolds,
+    load_scaffold_meta,
+    render_config,
+)
 
 
 class TestListScaffolds:
@@ -225,3 +230,47 @@ class TestScaffoldConfigIntegration:
         # validate_config returns warnings for nested_containers; should not raise
         warnings = validate_config(cfg)
         assert isinstance(warnings, list)
+
+
+class TestInferScaffoldFromImage:
+    """Verify infer_scaffold_from_image() correctly maps image refs to scaffold names."""
+
+    def test_tagged_openclaw_matches(self):
+        assert infer_scaffold_from_image(
+            "localhost/agentcage-scaffold-openclaw:latest"
+        ) == "openclaw"
+
+    def test_untagged_openclaw_matches(self):
+        """scaffold.yaml build entries use untagged refs — must match too."""
+        assert infer_scaffold_from_image("localhost/agentcage-scaffold-openclaw") == "openclaw"
+
+    def test_tagged_nanoclaw_matches(self):
+        assert infer_scaffold_from_image(
+            "localhost/agentcage-scaffold-nanoclaw:latest"
+        ) == "nanoclaw"
+
+    def test_untagged_nanoclaw_matches(self):
+        """nanoclaw's cage.yaml.j2 declares its image without a tag."""
+        assert infer_scaffold_from_image("localhost/agentcage-scaffold-nanoclaw") == "nanoclaw"
+
+    def test_hyphenated_scaffold_name(self):
+        assert infer_scaffold_from_image(
+            "localhost/agentcage-scaffold-claude-code:latest"
+        ) == "claude-code"
+
+    def test_non_matching_prefix_returns_none(self):
+        assert infer_scaffold_from_image("docker.io/library/node:22") is None
+        assert infer_scaffold_from_image("ghcr.io/foo/bar:v1") is None
+
+    def test_unknown_scaffold_name_returns_none(self):
+        """Prefix matches the convention but the scaffold doesn't exist."""
+        assert infer_scaffold_from_image(
+            "localhost/agentcage-scaffold-definitely-not-a-real-scaffold:latest"
+        ) is None
+
+    def test_empty_string_returns_none(self):
+        assert infer_scaffold_from_image("") is None
+
+    def test_similar_but_wrong_prefix_returns_none(self):
+        """'scaffold' without the 'agentcage-' prefix should not match."""
+        assert infer_scaffold_from_image("localhost/scaffold-openclaw:latest") is None

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -2,7 +2,6 @@
 
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 import yaml
@@ -59,18 +58,16 @@ class TestScaffoldMeta:
 class TestScaffoldRendering:
     """Verify scaffold templates render to valid YAML."""
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_renders_valid_yaml(self, mock_resolve):
-        cfg_text, tag = render_config("my-oc", scaffold="openclaw")
+    def test_openclaw_renders_valid_yaml(self):
+        cfg_text = render_config("my-oc", scaffold="openclaw")
         parsed = yaml.safe_load(cfg_text)
         assert parsed["name"] == "my-oc"
         assert "container" in parsed
         assert "image" in parsed["container"]
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_renders_parseable_config(self, mock_resolve, tmp_path):
+    def test_openclaw_renders_parseable_config(self, tmp_path):
         from agentcage.config import load_config
-        cfg_text, _ = render_config("test-oc", scaffold="openclaw")
+        cfg_text = render_config("test-oc", scaffold="openclaw")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))
@@ -78,7 +75,7 @@ class TestScaffoldRendering:
         assert cfg.container.image != ""
 
     def test_nanoclaw_renders_valid_yaml(self):
-        cfg_text, _ = render_config("my-nano", scaffold="nanoclaw")
+        cfg_text = render_config("my-nano", scaffold="nanoclaw")
         parsed = yaml.safe_load(cfg_text)
         assert parsed["name"] == "my-nano"
         assert "container" in parsed
@@ -86,7 +83,7 @@ class TestScaffoldRendering:
 
     def test_nanoclaw_renders_parseable_config(self, tmp_path):
         from agentcage.config import load_config
-        cfg_text, _ = render_config("test-nano", scaffold="nanoclaw")
+        cfg_text = render_config("test-nano", scaffold="nanoclaw")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))
@@ -94,26 +91,23 @@ class TestScaffoldRendering:
         assert cfg.container.nested_containers is True
 
     def test_default_scaffold_renders_valid_yaml(self):
-        cfg_text, tag = render_config("my-test")
+        cfg_text = render_config("my-test")
         parsed = yaml.safe_load(cfg_text)
         assert parsed["name"] == "my-test"
-        assert tag is None
 
     def test_invalid_scaffold_raises(self):
         """Attempting to render a non-existent scaffold should raise."""
         with pytest.raises(Exception):
             render_config("test", scaffold="nonexistent-scaffold-xyz")
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_with_vm_isolation(self, mock_resolve):
-        cfg_text, _ = render_config("vm-oc", scaffold="openclaw", isolation="vm")
+    def test_openclaw_with_vm_isolation(self):
+        cfg_text = render_config("vm-oc", scaffold="openclaw", isolation="vm")
         parsed = yaml.safe_load(cfg_text)
         assert parsed.get("isolation") == "vm"
         assert "vm" in parsed
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_with_custom_port(self, mock_resolve):
-        cfg_text, _ = render_config("port-oc", scaffold="openclaw", port=9999)
+    def test_openclaw_with_custom_port(self):
+        cfg_text = render_config("port-oc", scaffold="openclaw", port=9999)
         parsed = yaml.safe_load(cfg_text)
         # The port should appear in the ports config
         ports = parsed.get("container", {}).get("ports", [])
@@ -124,7 +118,7 @@ class TestCodingAgentScaffolds:
     """Verify claude-code and codex scaffolds render and validate correctly."""
 
     def test_claude_code_renders_valid_yaml(self):
-        cfg_text, _ = render_config("my-cc", scaffold="claude-code")
+        cfg_text = render_config("my-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         assert parsed["name"] == "my-cc"
         assert parsed["lifecycle"] == "interactive"
@@ -133,7 +127,7 @@ class TestCodingAgentScaffolds:
         assert parsed["container"]["command"] == ["sleep", "infinity"]
 
     def test_codex_renders_valid_yaml(self):
-        cfg_text, _ = render_config("my-cx", scaffold="codex")
+        cfg_text = render_config("my-cx", scaffold="codex")
         parsed = yaml.safe_load(cfg_text)
         assert parsed["name"] == "my-cx"
         assert parsed["lifecycle"] == "interactive"
@@ -141,32 +135,32 @@ class TestCodingAgentScaffolds:
         assert "container" in parsed
 
     def test_claude_code_has_anthropic_domain(self):
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         domains = parsed.get("domains", {}).get("allow", [])
         assert "anthropic.com" in domains
 
     def test_codex_has_openai_domain(self):
-        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        cfg_text = render_config("test-cx", scaffold="codex")
         parsed = yaml.safe_load(cfg_text)
         domains = parsed.get("domains", {}).get("allow", [])
         assert "openai.com" in domains
 
     def test_claude_code_has_exec_alias(self):
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         assert "exec_aliases" in parsed
         assert "claude" in parsed["exec_aliases"]
 
     def test_codex_has_exec_alias(self):
-        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        cfg_text = render_config("test-cx", scaffold="codex")
         parsed = yaml.safe_load(cfg_text)
         assert "exec_aliases" in parsed
         assert "codex" in parsed["exec_aliases"]
 
     def test_claude_code_passes_validation(self, tmp_path):
         from agentcage.config import load_config, validate_config
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))
@@ -174,26 +168,26 @@ class TestCodingAgentScaffolds:
 
     def test_codex_passes_validation(self, tmp_path):
         from agentcage.config import load_config, validate_config
-        cfg_text, _ = render_config("test-cx", scaffold="codex")
+        cfg_text = render_config("test-cx", scaffold="codex")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))
         validate_config(cfg)
 
     def test_claude_code_mounts_host_claude_dir(self):
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         volumes = parsed.get("container", {}).get("volumes", [])
         assert any(".claude:" in v for v in volumes)
 
     def test_claude_code_has_secret_injection(self):
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         secrets = parsed.get("secret_injection", [])
         assert any(s["env"] == "ANTHROPIC_API_KEY" for s in secrets)
 
     def test_claude_code_has_help_text(self):
-        cfg_text, _ = render_config("test-cc", scaffold="claude-code")
+        cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)
         assert parsed.get("help", "") != ""
 
@@ -213,10 +207,9 @@ class TestCodingAgentScaffolds:
 class TestScaffoldConfigIntegration:
     """Verify scaffolds produce configs that pass validate_config."""
 
-    @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
-    def test_openclaw_passes_validation(self, mock_resolve, tmp_path):
+    def test_openclaw_passes_validation(self, tmp_path):
         from agentcage.config import load_config, validate_config
-        cfg_text, _ = render_config("test-oc", scaffold="openclaw")
+        cfg_text = render_config("test-oc", scaffold="openclaw")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))
@@ -225,7 +218,7 @@ class TestScaffoldConfigIntegration:
 
     def test_nanoclaw_passes_validation(self, tmp_path):
         from agentcage.config import load_config, validate_config
-        cfg_text, _ = render_config("test-nano", scaffold="nanoclaw")
+        cfg_text = render_config("test-nano", scaffold="nanoclaw")
         p = tmp_path / "cage.yaml"
         p.write_text(cfg_text)
         cfg = load_config(str(p))


### PR DESCRIPTION
## Summary

- `cage update` now re-resolves scaffold-declared-untagged build-arg image tags on every run, so users track upstream instead of staying frozen on whatever tag was current at `cage create` time. Scaffold.yaml's `build_args` is authoritative: untagged means auto-bump, explicit tag means respect the author's pin.
- Consolidates the previously-triplicated tag-resolution logic (`cli.py` update, `services.py` build, `init.py` scaffold setup) into one `registry.resolve_build_args()` helper, and deletes the hardcoded `_SCAFFOLD_IMAGES` map (scaffold.yaml is now the single source of truth).
- Fixes three openclaw scaffold compatibility issues exposed by bumping to `ghcr.io/openclaw/openclaw:2026.4.15` (workspace:* devDep breakage, matrix bundle self-reference, entrypoint read-only-path hard-fail).

## Why

Reproducing the user-visible bug: `agentcage cage update openclaw01` printed `Building ... STEP 1/7: FROM ghcr.io/openclaw/openclaw:2026.3.13-1` every time, even after upstream released newer tags. Root cause was an intentional `continue` in the update-path resolver ("already has an explicit tag — leave it alone") that made first-run pinning permanent. That's the opposite of what `update` should do for scaffold-managed base tags.

## Design notes

- **Scaffold-base drift** (upstream renaming the image) is handled: scaffold.yaml's declared base wins over the stored base, with a `warning: base image for X changed` line on migration.
- **Offline/resolver-failure** preserves the existing pin — `cage update` on a laptop without internet must never un-pin a working build. Covered by a regression-critical test.
- **Legacy cages** (created before `scaffold` was persisted to metadata.json) still benefit: scaffold is inferred from the `localhost/agentcage-scaffold-<NAME>:...` image naming convention. New cages get it persisted explicitly.
- **Metadata preservation**: `cage update` used to overwrite metadata.json with just `agentcage_version`, losing `scaffold` and `network_octet`. Now merges.
- **Noise reduction**: the `warning: could not resolve latest tag for localhost/...` that fired on every update is suppressed for scaffold-built local image refs.

## Openclaw scaffold fixes (2nd commit)

Bumping to 2026.4.15 surfaced three issues, all fixed in the scaffold layer:

1. **npm workspace protocol** — upstream's `matrix/package.json` now has `workspace:*` devDeps that break `npm install --omit=dev`. New bases also hoist runtime deps to `/app/node_modules/`, making the install redundant. Gated on a `/app/node_modules/matrix-js-sdk` canary.
2. **Matrix self-reference (`Cannot find package 'openclaw'`)** — bundled matrix code imports `openclaw/plugin-sdk/...`, but `/app/dist/extensions/matrix/package.json` creates a scope boundary that stops Node from resolving via `/app/package.json`. Added `/app/node_modules/openclaw -> /app` symlink.
3. **Entrypoint read-only hard-fail** — `mkdir -p /home/node/.pki/nssdb` under `set -e` kills the container on legacy cages whose stored tmpfs list lacks `.pki`. Guarded with `if mkdir ...; then` so cert-install is best-effort.

## Live test

Tested end-to-end on `openclaw01` (running under `openclaw-svc`):

```
$ agentcage cage update openclaw01
Build arg BASE_IMAGE: ghcr.io/openclaw/openclaw:2026.3.13-1 → ghcr.io/openclaw/openclaw:2026.4.15
Stopping services...
Building localhost/agentcage-scaffold-openclaw:latest...
  (10 steps, build succeeds)
Started openclaw01-cage
Updated cage 'openclaw01'
```

Post-update: HTTP 200 on gateway, `openclaw health` clean, matrix plugin loads (no more `Cannot find package 'openclaw'`).

## Test plan

- [x] `pytest tests/` — 1044 passing (15 new for `resolve_build_args`, 6 new for `cage update` integration, including REGRESSION-critical test for offline resolver failure preserving pins)
- [x] Live test on openclaw01: bump succeeded, gateway healthy post-upgrade
- [ ] Reviewer: confirm scaffold-author-pinned case still works (test `test_respects_scaffold_pinned_arg` asserts resolver is never called when scaffold has an explicit tag)
- [ ] Reviewer: confirm base-drift warning fires correctly (test `test_migrates_on_scaffold_base_change` asserts `warning: base image for BASE_IMAGE changed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)