### PR TITLE
fix(openclaw): opt out of browser SSRF check that refuses with HTTP_PROXY set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- openclaw scaffold: default `openclaw.json` now sets `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: true`. openclaw's browser plugin refuses every navigation when `HTTP_PROXY`/`HTTPS_PROXY` is set (error: `Navigation blocked: strict browser SSRF policy cannot be enforced while env proxy variables are set`). In agentcage, egress is already policed by the mitm proxy + domain allowlist + inspectors, so this guard is redundant and purely blocks the browser tool. Opting out restores browser-tool functionality; the cage's own egress controls remain authoritative.
+
 ## [0.10.4] - 2026-04-20
 
 ### Added

--- a/src/agentcage/scaffolds/openclaw/entrypoint.sh
+++ b/src/agentcage/scaffolds/openclaw/entrypoint.sh
@@ -25,7 +25,14 @@ fi
 # are set by the cage.yaml template.
 chmod 700 /home/node/.openclaw
 if [ ! -f /home/node/.openclaw/openclaw.json ]; then
-  printf '{"browser": {"defaultProfile": "openclaw"}, "gateway": {"trustedProxies": ["%s"], "controlUi": {"allowedOrigins": ["http://localhost:%s", "http://127.0.0.1:%s"]} } }' \
+  # browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: openclaw's browser
+  # plugin refuses to navigate whenever HTTP_PROXY/HTTPS_PROXY env vars
+  # are set ("strict browser SSRF policy cannot be enforced while env
+  # proxy variables are set"). In agentcage, egress is already policed
+  # by the mitm proxy + domain allowlist + inspectors, so this redundant
+  # guard just blocks the browser tool. Opt out — cage egress controls
+  # remain authoritative.
+  printf '{"browser": {"defaultProfile": "openclaw", "ssrfPolicy": {"dangerouslyAllowPrivateNetwork": true}}, "gateway": {"trustedProxies": ["%s"], "controlUi": {"allowedOrigins": ["http://localhost:%s", "http://127.0.0.1:%s"]} } }' \
     "${CAGE_PROXY_IP}" "${CAGE_GATEWAY_PORT}" "${CAGE_GATEWAY_PORT}" \
     > /home/node/.openclaw/openclaw.json
 fi


### PR DESCRIPTION
## Summary

openclaw's browser plugin ([`extensions/browser/src/browser/navigation-guard.ts`](https://github.com/openclaw/openclaw)) has a standalone SSRF guard that throws on every `Page.navigate` when `HTTP_PROXY` / `HTTPS_PROXY` env vars are set:

```
[tools] browser failed: Navigation blocked: strict browser SSRF policy
cannot be enforced while env proxy variables are set
raw_params={"action":"open","url":"https://www.wikipedia.org"}
```

Since agentcage injects `HTTP_PROXY=HTTPS_PROXY=http://<proxy-ip>:8080` into every cage by design, this refusal fires for every browser-tool call in an openclaw cage, with no escape hatch short of unsetting the proxy env (which would break the cage's whole purpose).

In a cage, egress is already enforced by the mitm proxy + domain allowlist + inspectors; the openclaw-side SSRF guard is redundant. Set `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: true` in the default `openclaw.json` written by the scaffold entrypoint. The cage's own egress controls remain authoritative — the opt-out only disables openclaw's duplicate guard.

## Repro (before fix)
```
$ agentcage cage exec <openclaw-cage> -- <ask agent to open a URL in the browser>
[tools] browser failed: Navigation blocked: strict browser SSRF policy
cannot be enforced while env proxy variables are set
```

## Verification (after fix)
- Applied the `ssrfPolicy` patch to the live `openclaw.json` in an existing cage (openclaw01), restarted.
- Agent browser tool no longer fails at the nav-guard; navigation proceeds to Chromium via CDP (openclaw's `cdp-proxy-bypass.ts` already handles the loopback proxy-env trap internally, so no other env changes needed).
- Egress allowlist still enforced end-to-end: allowed domain returns 302, blocked domain returns 403.

## Notes
- Branch name is `fix/no-proxy-loopback` — leftover from an earlier hypothesis before I found the real refusal in `navigation-guard.ts`. The fix in this PR is a single commit, scoped to the openclaw scaffold.
- Existing cages need either `podman volume rm <name>-state` (to force regeneration of `openclaw.json` on next start) or a manual JSON patch — the entrypoint only writes defaults when the file is absent. Documented in the test plan.

## Test plan
- [ ] `agentcage cage create` a fresh openclaw cage; confirm the generated `openclaw.json` has `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork: true`.
- [ ] Agent inside the cage invokes the `browser` tool → navigation to an allowlisted domain succeeds.
- [ ] Existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)