### PR TITLE
test(e2e): phase 8 — openclaw scaffold regression canary

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,3 +49,46 @@ jobs:
 
       - name: Run E2E container tests
         run: bash tests/e2e/run.sh container
+
+  e2e-openclaw:
+    name: E2E OpenClaw (Phase 8)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install agentcage
+        run: uv tool install -e .
+
+      - name: Install jq + skopeo
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq skopeo
+
+      - name: Setup rootless Podman
+        run: |
+          sudo apt-get install -y -qq podman uidmap slirp4netns
+          sudo loginctl enable-linger $(whoami)
+
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          sudo mkdir -p "$XDG_RUNTIME_DIR"
+          sudo chown $(whoami) "$XDG_RUNTIME_DIR"
+          echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR" >> "$GITHUB_ENV"
+
+          podman info --format '{{.Host.Security.Rootless}}'
+
+      - name: Cache Podman images
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/containers/storage
+          key: podman-openclaw-${{ runner.os }}-${{ hashFiles('src/agentcage/scaffolds/openclaw/**') }}
+
+      - name: Pre-pull openclaw base image
+        run: |
+          podman image exists ghcr.io/openclaw/openclaw:latest \
+            || podman pull ghcr.io/openclaw/openclaw:latest
+
+      - name: Run phase 8
+        run: bash tests/e2e/run.sh openclaw

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,57 @@
+# TODOS
+
+Deferred work that's been explicitly considered and punted, with context
+so future readers know why. Each entry names the trigger (PR / incident /
+plan), the motivation, and where to start.
+
+## Phase 8 / openclaw regression canary
+
+### T1. HAR-capture openclaw's organic outbound to verify placeholder usage end-to-end
+
+**What.** Add an assertion to `tests/e2e/phase8_openclaw.sh` that captures
+an outbound request openclaw organically makes (not one we triggered with
+`curl`), then grep the HAR entry for the placeholder appearing in its
+`Authorization` header.
+
+**Why.** Phase 8's 8.8a/b/c close the proxy side of secret injection:
+
+- 8.8a proves the cage's environment contains the literal placeholder.
+- 8.8b proves the proxy substitutes when the placeholder is sent to an
+  injected domain.
+- 8.8c proves substitution is domain-scoped.
+
+What they do NOT prove: that openclaw's own client code actually routes
+secrets through the placeholder path. If a future openclaw build reads
+`ANTHROPIC_API_KEY` from env and does its own substitution (or, worse,
+expects the real key in env), every current assertion still passes while
+the injection silently no-ops in production.
+
+**Pros.** Closes the proxy-vs-openclaw gap. Catches a whole class of
+regression that our current tests cannot see.
+
+**Cons.** Requires investigating whether openclaw issues any outbound
+request on boot without a user prompt. If it doesn't, the assertion is
+untestable as a pure "boot and check" — we'd need to script a minimal
+openclaw action that forces a hit on an injected domain, which involves
+scripting the gateway's approval flow.
+
+**Context.** Phase 8 landed in PR e2e/phase8-openclaw-canary. The plan
+reviewer flagged this as the one real gap in the phase's coverage;
+user chose to defer to TODO rather than expand scope in the landing PR.
+
+**Where to start.**
+
+1. Enable `capture.enable_har: true` in the test cage's `cage.yaml`
+   (sed it into place during phase 8 setup, same way memory/cpus are
+   already patched).
+2. Boot the cage and observe what, if anything, openclaw sends outbound
+   with no user interaction (`agentcage cage har e2e-openclaw` after
+   `wait_ready`).
+3. If organic outbound exists: add assertion 8.11 that greps the HAR
+   for `{{ANTHROPIC_API_KEY}}` in an outbound request's body/headers.
+4. If no organic outbound: investigate whether openclaw has a
+   non-interactive CLI flag (`openclaw ping`, `--self-test`, etc.)
+   that issues one.
+
+**Depends on.** Phase 8 (this TODO is a follow-up to the initial
+canary landing).

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -310,6 +310,20 @@ destroy_cage() {
   agentcage cage destroy "$1" -y >/dev/null 2>&1 || true
 }
 
+# destroy_cage_with_volumes CAGE VOL...
+#   Destroy a cage and remove caller-named podman volumes.
+#   agentcage cage destroy only removes agentcage-prefixed volumes
+#   (agentcage-certs-$NAME, agentcage-podman-$NAME); user-named
+#   volumes from the cage.yaml named_volumes block survive by design.
+#   Test cages want to clean these too so re-runs don't inherit state.
+destroy_cage_with_volumes() {
+  local cage="$1"; shift
+  destroy_cage "$cage"
+  for vol in "$@"; do
+    podman volume rm -f "$vol" >/dev/null 2>&1 || true
+  done
+}
+
 # Create a cage from a config template (expands env vars) and register for cleanup.
 # Streams output to stderr so callers can redirect with >/dev/null.
 create_cage() {

--- a/tests/e2e/phase8_openclaw.md
+++ b/tests/e2e/phase8_openclaw.md
@@ -1,0 +1,175 @@
+# Phase 8 — OpenClaw Scaffold Regression Canary
+
+Companion doc to `phase8_openclaw.sh`. Reading this should tell you
+exactly what the phase proves, what it **doesn't** prove, and which
+failure modes could slip through silently.
+
+## What the phase verifies, assertion by assertion
+
+Columns: **Asserts** = the fact the test proves. **Gap** = what the
+test shape *cannot* catch.
+
+### Setup (8.0)
+
+| Step | Asserts | Gap |
+|---|---|---|
+| Log base image digest | `ghcr.io/openclaw/openclaw:latest` is present locally before cage build — failure triage knows which upstream sha ran | Doesn't record the digest on PASS runs (only visible in log) |
+| `agentcage init --scaffold openclaw --port P` | Scaffold renderer produces a valid `cage.yaml` | Doesn't diff against a known-good rendering — a template change that silently drops a field is invisible |
+| `sed`/`python3` patches to cage.yaml | CI-only resource trim (memory 4g, cpus 2.0, timeout 300s) + test-shape tweaks (`inject_to: httpbin.org`, add `httpbin.org`/`postman-echo.com` to allowlist) | Patches are idempotent; a template change that reshapes the inject block could leave the sed no-op'd and the phase would still "pass" setup |
+| `agentcage cage create -s K=V ...` | Scaffold Containerfile builds; quadlets install; container starts under user systemd | Doesn't distinguish "build passed but slow" from "build crashed and systemd swallowed stderr" — a dump_cage_diagnostics is issued on wait_ready failure but not on create failure |
+| `wait_ready BASE 300s` | Host-side port :19180 returns HTTP 200 at least once | 200 could come from the reverse proxy's error page if openclaw never bound internally — `wait_ready` polls `/` with no body check |
+
+### Assertions
+
+| # | What it asserts | What it does NOT assert |
+|---|---|---|
+| **8.1** Gateway serves OpenClaw Control UI | GET `/` contains the literal string `OpenClaw Control` in the response body — rules out reverse-proxy error pages and other servers on the port | Doesn't load the JS bundle, doesn't follow any API route, doesn't test authenticated paths. If openclaw ships a redesign that renames the app title, 8.1 false-fails. If openclaw ships a UI that loads but the backend is broken, 8.1 false-passes. |
+| **8.2** `openclaw health` via exec_alias | Exec_aliases config wires `openclaw` → `node openclaw.mjs`; the CLI runs inside the cage; at least one agent is configured (`Agents:` appears in output) | "Agents:" is a loose match — the health command could fail its internal checks and still print the agent list. Doesn't verify heartbeat, session store, or any downstream dependency. |
+| **8.3** tini is PID 1 | Scaffold's `ENTRYPOINT ["tini", "--"]` was applied and the container started under tini (`/proc/1/comm == tini`) | Doesn't prove tini is correctly forwarding signals — only that it's present. If tini were compiled with bad defaults (e.g., ignoring SIGUSR1), this passes. That's what 8.4 is for. |
+| **8.4** Self-restart survives SIGUSR1 | SIGUSR1 sent to `openclaw-gateway` causes: (a) the gateway to exit, (b) the supervisor's `node openclaw.mjs gateway` command to end, (c) the `while true; do ... done` loop in `entrypoint.sh` to respawn with a new PID, (d) the container stays alive through the cycle, (e) the gateway responds 200 again within 60s | Only tests ONE restart cycle. Won't catch file-descriptor leaks, growing memory, or zombie-process accumulation across many restarts. The 30s poll after the signal is optimistic — on a saturated CI runner a slow restart could time out and false-fail. Doesn't verify state preservation across the restart (e.g. devices still paired). |
+| **8.5** `openclaw.json` has SSRF opt-out | Entrypoint wrote the config file with `.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork == true` (jq-parsed, so key renames fail loudly) | Only verifies the config FILE, not the RUNTIME. If openclaw ≥ a future version renames `ssrfPolicy` → `ssrf` or ignores the key, 8.5 passes while the browser tool is still broken. Doesn't launch an actual browser. |
+| **8.6** `controlUi.allowedOrigins` includes gateway URL | Entrypoint templated the port correctly into both `http://localhost:$PORT` and `http://127.0.0.1:$PORT` | Doesn't prove device pairing actually succeeds with those origins. If the allowedOrigins key is renamed upstream, 8.6 fails loudly — which is the correct behaviour. |
+| **8.7** Matrix extension workspace workaround | `/app/node_modules/openclaw` is a symlink AND its target `package.json` is resolvable — proves the Containerfile layer that creates the symlink ran | Doesn't verify matrix-js-sdk actually loads at runtime, or that `import`s from the matrix extension resolve. A regression that breaks extension loading for a different reason (e.g. peer-dep mismatch) wouldn't be caught here. |
+| **8.8a** Cage env has literal placeholder | `ANTHROPIC_API_KEY` in the cage environment equals the literal string `{{ANTHROPIC_API_KEY}}` — proves secret_injection's placeholder substitution is wired and the real key does not leak into the cage | The placeholder format is hardcoded in the test. If agentcage ever changes placeholder syntax (e.g. `${X}`), the test silently passes the wrong thing while the injection contract has moved. |
+| **8.8b** Proxy logs `secrets_injected` on injected domain | Audit log records `secrets_injected: [ANTHROPIC_API_KEY]` for the flow to `httpbin.org` (in `inject_to`) — proves inject rules fire on matched domains | Follows phase 3's audit-log pattern: only proves the proxy ATTEMPTED injection, not that the real value landed on the wire. A bug where the audit log fires but the mutation doesn't persist is NOT caught here. The trigger is a `curl` from inside the cage, not openclaw's own outbound — see T1 in TODOS.md. |
+| **8.8c** Substitution is domain-scoped | Audit log does NOT record `secrets_injected` for the flow to `postman-echo.com` (allowlisted but NOT in `inject_to`) — proves the `inject_to` list is honored | Absence proof via polling is weaker than presence — a race that misses the log entry would false-pass. Doesn't test path-scoped or method-scoped injection (not features today, but future-proofing is absent). |
+| **8.9** Domain allowlist blocks unlisted host | `curl https://forbidden.example.com` through the proxy returns 403 or 502 | Doesn't test subdomain-matching edge cases (e.g. `evil.httpbin.org` when only `httpbin.org` is allowed); doesn't assert a proper audit entry for the block event. |
+| **8.10** Nested rootless podman smoke | `podman run --rm busybox echo ok` works inside the cage — proves the scaffold's subuid/subgid/`fuse-overlayfs`/`slirp4netns`/storage.conf layer is functional *when the environment supports it*. Probes `podman ps` first and `e2e_skip`s if unavailable (GHA ubuntu-24.04 uncertainty) | `busybox echo` is the smallest possible nested workload. Doesn't test CNI networking inside, doesn't test volume mounts, doesn't test running a real agent inside. The skip path could mask a regression on CI permanently — if GHA never runs 8.10, we won't notice the day scaffolds/openclaw/Containerfile drops `fuse-overlayfs`. |
+
+## Meta-gaps: things phase 8 does not cover at all
+
+These aren't per-assertion weaknesses — they're whole classes of
+regression that this phase is blind to.
+
+1. **Authenticated gateway use.** 8.1 tests the UI loads unauth. 8.2
+   tests the internal CLI. Nothing proves the `OPENCLAW_GATEWAY_PASSWORD`
+   actually authenticates an API request. If openclaw switched to
+   token-only auth and ignored the password secret, all 12 assertions
+   still pass.
+
+2. **Openclaw's own outbound requests.** Captured as TODO T1. The
+   current 8.8a/b/c prove the proxy side end-to-end but trigger the
+   flows with `curl` inside the cage. Openclaw's own client code is
+   never exercised.
+
+3. **Anthropic API shape compatibility.** If openclaw bumps its
+   Anthropic SDK and the SDK changes header/URL conventions, none of
+   the phase 8 assertions fire. We're testing the scaffold wrapper,
+   not the agent's business logic.
+
+4. **Chromium / Playwright browser tool.** 8.5 tests that the SSRF
+   *config* permits the browser. 8.10 runs busybox, not Chromium. If
+   openclaw's browser tool breaks (new Chromium version incompatible
+   with the Playwright the image ships, missing libs), no assertion
+   fires.
+
+5. **mitmproxy CA chain / TLS trust.** The entrypoint installs the
+   mitm CA into `/usr/local/share/ca-certificates` and the NSS DB at
+   `/home/node/.pki`. If a future openclaw image pre-installs a
+   hardened CA store that rejects our cert, HTTPS through the proxy
+   breaks silently. 8.8b/c drive HTTPS curls, so a TLS break would
+   actually fail them — but the failure mode (curl error) looks the
+   same as an upstream outage, which makes triage ambiguous.
+
+6. **State persistence across restart.** 8.4 verifies restart
+   mechanically works. It does NOT verify that `/home/node/.openclaw`
+   state (approved devices, session store, agent config) survives.
+
+7. **Memory / file-descriptor leaks under sustained load.**
+   Out-of-scope for a smoke test.
+
+8. **Non-default scaffold options.** Scaffold supports VM isolation,
+   custom ports, HAR capture (`capture.enable_har`), additional
+   providers (Brave, Firecrawl, OpenAI, OpenRouter). Phase 8 covers
+   only the default config path. A regression specific to a non-default
+   branch is invisible.
+
+9. **Other `openclaw` subcommands.** Scaffold help lists `openclaw
+   status`, `openclaw devices list/approve`. Only `openclaw health`
+   is exercised.
+
+10. **Reverse-proxy header plumbing (commit a795100).** 8.6 covers
+    the `controlUi.allowedOrigins` half. The matching `X-Forwarded-For`
+    / `Host` / `Origin` rewriting in the agentcage proxy isn't asserted
+    — device pairing could still fail even with 8.6 passing.
+
+11. **Cage stop/start cycle from the host.** SIGUSR1 is an *internal*
+    restart. `agentcage cage stop` + `cage start` exercises the
+    systemd/quadlet lifecycle instead and isn't covered by phase 8.
+
+12. **Scaffold build reproducibility.** We build once. Layer caching
+    bugs that only surface on a second build with a stale cache aren't
+    caught.
+
+13. **Read-only root filesystem edge case.** `entrypoint.sh` has a
+    fallback path for when `/home/node/.pki` isn't writable (emits a
+    warning instead of exiting under `set -e`). Phase 8 uses the
+    standard scaffold which mounts a `.pki` tmpfs, so the warning path
+    is never exercised. A regression that breaks the fallback only
+    surfaces for users with custom cage.yaml.
+
+## Assumptions that could break silently
+
+Things phase 8's logic *assumes* about the environment — if any of
+these stop holding, assertions could pass for the wrong reason.
+
+- **setproctitle renames survive.** 8.4 relies on `pgrep -f '^openclaw$'`
+  matching exactly the supervisor's cmdline. If openclaw stops renaming
+  argv[0] and instead runs as `node openclaw.mjs gateway`, the pgrep
+  returns empty and 8.4 bails with "could not find openclaw supervisor"
+  — which is a *correct* failure, but the test's error message will
+  mislead.
+- **httpbin.org and postman-echo.com are reachable.** External echo
+  services are transient dependencies. Outages cause false-fails on
+  8.8b/c (the `--retry 3` on curl mitigates briefly). The audit-log
+  signal still works even if the echo body is garbled, but a complete
+  service outage blocks the proxy logs from ever being written for
+  that flow.
+- **openclaw writes `/home/node/.openclaw/openclaw.json` once at
+  first boot.** 8.5/8.6 read the file the entrypoint produces. If
+  openclaw starts managing its own config (deletes + rewrites on each
+  boot), the entrypoint's initial write could be overwritten and 8.5/8.6
+  would fail — which is likely the correct behaviour, but the debug
+  story would be "why does the file not match what the entrypoint
+  wrote?" rather than "openclaw has a new config system."
+- **`agentcage cage audit` shows the last N entries across all
+  flows.** 8.8b/c poll the audit output for specific flow attributes.
+  If the audit format changes (JSON key renames, line batching), the
+  greps break. jq-parsing the audit would be more resilient — tracked
+  informally as a future hardening.
+
+## How to strengthen phase 8 without expanding scope
+
+These are cheap local tightenings that would close some gaps without
+adding new test cases:
+
+- **8.1**: add a second assertion that GET `/favicon.svg` returns
+  `image/svg+xml` — proves more than just HTML text matching.
+- **8.4**: also assert `systemctl --user show -p NRestarts --value
+  e2e-openclaw-cage.service == 0` to prove systemd never saw the
+  container die (strongest witness that tini kept PID 1 alive).
+- **8.5/8.6**: assert the same keys via a live probe against the
+  browser tool / a device-pairing request, not just file contents.
+  (Higher effort — likely T2.)
+- **8.8a**: read the placeholder syntax from the rendered cage.yaml
+  rather than hardcoding — protects against a placeholder format change.
+- **8.10**: when the probe succeeds, record the nested container's
+  podman info in the log — so we can tell if the skip path is firing
+  on CI when it shouldn't.
+
+## Related tests
+
+- Phase 1-6: cage lifecycle, secrets, domains, backup/restore, hardening
+  — all use the basic `node:22-slim` agent, so none exercise openclaw.
+- Phase 7: VM mode — openclaw isn't tested in VM mode anywhere.
+- `tests/conftest.py::openclaw_yaml`: pytest fixture for config-
+  parsing unit tests. Renders a bare `ghcr.io/openclaw/openclaw:latest`
+  directly, bypassing the scaffold Containerfile. Catches YAML-schema
+  regressions but not scaffold build regressions.
+
+## TODOs this phase surfaced
+
+- **T1** (tracked in `TODOS.md`): HAR-capture openclaw's organic
+  outbound to prove the scaffold ACTUALLY uses the placeholder in
+  its own traffic, not just that our test curl does. Addresses the
+  biggest remaining gap.

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -100,10 +100,14 @@ echo "Creating cage (scaffold build may take several minutes cold)..."
 # atomically alongside the cage; `agentcage secret set` requires the
 # cage to exist, which would be a chicken-and-egg problem here.
 e2e_timer_start
+CREATE_LOG=$(mktemp /tmp/phase8-create-XXXXXX.log)
 if ! agentcage cage create -c cage.yaml \
      -s "OPENCLAW_GATEWAY_PASSWORD=$GATEWAY_PW" \
-     -s "ANTHROPIC_API_KEY=$SENTINEL" >/tmp/phase8-create.log 2>&1; then
-  e2e_fail "8.0" "cage create" "agentcage cage create failed (see /tmp/phase8-create.log)"
+     -s "ANTHROPIC_API_KEY=$SENTINEL" >"$CREATE_LOG" 2>&1; then
+  e2e_fail "8.0" "cage create" "agentcage cage create failed"
+  echo "        ── cage create output (last 60 lines) ──" >&2
+  tail -60 "$CREATE_LOG" | sed 's/^/          /' >&2
+  echo "        ── end cage create output ──" >&2
   dump_cage_diagnostics "$CAGE" "8.0 create failure"
   print_results; exit 1
 fi

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Phase 8: OpenClaw scaffold regression canary.
+#
+# Catches breakage in ghcr.io/openclaw/openclaw:latest. The openclaw image
+# moves independently of agentcage; every recent minor has shipped at least
+# one change that silently broke our scaffold (SSRF/HTTP_PROXY, tini/SIGUSR1,
+# controlUi origins, matrix extension workspace deps, etc.). This phase runs
+# the real `agentcage init --scaffold openclaw` → `cage create` flow and
+# asserts each known regression class.
+#
+# Secret-injection verification uses real external echo services
+# (httpbin.org, postman-echo.com) via the cage's mitm proxy — no mock server.
+source "$(dirname "$0")/lib.sh"
+preflight_check agentcage podman curl jq
+phase_header 8 "OpenClaw Scaffold Regression Canary"
+
+CAGE="e2e-openclaw"
+PORT=$((E2E_PORT_BASE + 100))
+BASE="http://127.0.0.1:$PORT"
+SENTINEL="e2e-sk-REAL-DEADBEEF"
+GATEWAY_PW="e2e-pw"
+BASE_IMAGE="ghcr.io/openclaw/openclaw:latest"
+
+# ── pre-run image identity ──────────────────────────────────────────
+# Log the base image digest up front so failure triage knows which
+# openclaw build ran. If this fails, the image wasn't pulled at all
+# and cage create is about to fail loudly.
+if podman image exists "$BASE_IMAGE" 2>/dev/null; then
+  echo "openclaw base image:"
+  podman image inspect "$BASE_IMAGE" \
+    --format '  {{.Id}}  {{index .RepoTags 0}}  created={{.Created}}' \
+    2>/dev/null || true
+else
+  echo "openclaw base image not present locally; cage create will pull it"
+fi
+
+# Clean any stale cage
+destroy_cage_with_volumes "$CAGE" "${CAGE}-workspace" "${CAGE}-state"
+
+# Cleanup trap — fires on normal exit AND on abort (failing assertion,
+# CTRL-C). `destroy_cage` in the lib.sh trap doesn't clean named volumes,
+# so we install our own trap that does.
+trap 'destroy_cage_with_volumes '"$CAGE"' '"${CAGE}-workspace"' '"${CAGE}-state" EXIT
+
+# ── setup: render real scaffold, patch for CI, create cage ──────────
+TMPDIR=$(mktemp -d "/tmp/e2e-openclaw-XXXXXX")
+cd "$TMPDIR"
+
+echo "Rendering openclaw scaffold..."
+# `agentcage init --scaffold openclaw` exercises the real scaffold
+# templating pipeline — the same code path users hit. Past regressions
+# have landed in the template, so we render it fresh here rather than
+# hand-crafting a YAML.
+if ! agentcage init "$CAGE" --scaffold openclaw --port "$PORT" --output cage.yaml --force >/dev/null 2>&1; then
+  e2e_fail "8.0" "scaffold init" "agentcage init --scaffold openclaw failed"
+  print_results; exit 1
+fi
+
+# Patch the rendered cage.yaml for CI resource limits AND for the
+# echo-service secret-injection shape. Only test-specific tweaks:
+#   - memory 4g / cpus 2.0: GHA ubuntu-24.04 only has 7 GiB total RAM
+#   - timeout_start_sec 300: openclaw gateway boot + ghcr pull headroom
+#   - allow httpbin.org + postman-echo.com: needed by 8.8b/8.8c
+#   - inject_to: httpbin.org (not anthropic.com) so substitution can be
+#     observed via a real echo service
+sed -i \
+  -e 's|^  memory: .*|  memory: "4g"|' \
+  -e 's|^  cpus: .*|  cpus: "2.0"|' \
+  -e 's|^  timeout_start_sec: .*|  timeout_start_sec: 300|' \
+  -e 's|      - anthropic.com$|      - httpbin.org|' \
+  cage.yaml
+
+# Append echo-service allowlist entries. The default scaffold allowlist
+# section ends with an `# Add domains your agents need access to:` comment
+# block; we insert before the final empty/hash block.
+# Simplest approach: append to the allow list directly by inserting after
+# the last existing allow entry.
+python3 - <<'PYEOF'
+import re
+from pathlib import Path
+
+path = Path("cage.yaml")
+text = path.read_text()
+
+# Inject httpbin.org and postman-echo.com into domains.allow by
+# appending to the existing allow block. Find the "domains:\n  allow:"
+# header and splice after the first allow entry.
+m = re.search(r"(domains:\s*\n\s*allow:\s*\n)", text)
+if not m:
+    raise SystemExit("could not find domains.allow in cage.yaml")
+
+insert_at = m.end()
+extra = "    - httpbin.org\n    - postman-echo.com\n"
+text = text[:insert_at] + extra + text[insert_at:]
+path.write_text(text)
+PYEOF
+
+echo "Creating cage (scaffold build may take several minutes cold)..."
+# Secrets are passed via -s KEY=VALUE so cage create can install them
+# atomically alongside the cage; `agentcage secret set` requires the
+# cage to exist, which would be a chicken-and-egg problem here.
+e2e_timer_start
+if ! agentcage cage create -c cage.yaml \
+     -s "OPENCLAW_GATEWAY_PASSWORD=$GATEWAY_PW" \
+     -s "ANTHROPIC_API_KEY=$SENTINEL" >/tmp/phase8-create.log 2>&1; then
+  e2e_fail "8.0" "cage create" "agentcage cage create failed (see /tmp/phase8-create.log)"
+  dump_cage_diagnostics "$CAGE" "8.0 create failure"
+  print_results; exit 1
+fi
+
+echo "Waiting for gateway readiness (budget 300s)..."
+e2e_timer_start
+if ! wait_ready "$BASE" 300; then
+  e2e_fail "8.0" "gateway readiness" "did not become ready within 300s"
+  dump_cage_diagnostics "$CAGE" "8.0 readiness failure"
+  print_results; exit 1
+fi
+
+# ── Assertions ──────────────────────────────────────────────────────
+
+# 8.1: gateway serves the OpenClaw Control UI unauthenticated.
+# Past assumption was 401/403; openclaw actually returns 200 with the
+# login HTML on GET / (authentication is per-API-endpoint, not page-level).
+# The signal we care about: something identifiable as openclaw is serving
+# on this port — not a stray reverse-proxy error page.
+e2e_timer_start
+body=$(curl -sS --max-time 10 "$BASE/" 2>&1 || true)
+if echo "$body" | grep -q "OpenClaw Control"; then
+  e2e_pass "8.1" "gateway serves OpenClaw Control UI"
+else
+  e2e_fail "8.1" "gateway serves OpenClaw Control UI" \
+    "expected 'OpenClaw Control' in response; got: $(echo "$body" | head -3)"
+fi
+
+# 8.2: openclaw health OK via exec alias. Proves exec_aliases wiring
+# + openclaw internal health. If tini weren't PID 1, the SIGUSR1 restart
+# would have killed the container before 8.2 runs; reaching here at all
+# is a soft witness for tini working.
+# openclaw health's output is "Agents: main (default)\nHeartbeat..."
+# rather than "ok"; grep for "Agents:" as the reliable indicator.
+assert_output_contains "8.2" "openclaw health via exec alias" "Agents:" \
+  agentcage cage exec "$CAGE" -- openclaw health
+
+# 8.3: tini is PID 1
+e2e_timer_start
+pid1_comm=$(podman exec "${CAGE}-cage" cat /proc/1/comm 2>/dev/null | tr -d '\n\r ')
+if [ "$pid1_comm" = "tini" ]; then
+  e2e_pass "8.3" "tini is PID 1"
+else
+  e2e_fail "8.3" "tini is PID 1" "expected 'tini', got '$pid1_comm'"
+fi
+
+# 8.4: self-restart survives SIGUSR1 (PID-delta witness).
+# openclaw forks a supervisor ("openclaw", PID N) and a gateway worker
+# ("openclaw-gateway", child of supervisor). The SIGUSR1 handler lives
+# in the gateway; signalling the supervisor alone is a no-op. Signalling
+# the gateway makes it exit, which also ends the `node openclaw.mjs
+# gateway` command, which drops out of the entrypoint.sh while-true loop
+# and gets respawned — both PIDs change. Watching the supervisor PID is
+# the stronger witness because it proves the container (and tini) stayed
+# alive across the restart.
+e2e_timer_start
+# `pgrep` exits 1 on no-match — wrap in `|| true` so `set -e` doesn't
+# kill the phase before we can report 8.4 as a failure.
+OLD_SUP=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
+if [ -z "$OLD_SUP" ]; then
+  e2e_fail "8.4" "self-restart SIGUSR1" "could not find openclaw supervisor before signal"
+else
+  podman exec "${CAGE}-cage" pkill -USR1 -f openclaw-gateway 2>/dev/null || true
+  NEW_SUP=""
+  for _ in $(seq 1 30); do
+    sleep 1
+    NEW_SUP=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
+    if [ -n "$NEW_SUP" ] && [ "$NEW_SUP" != "$OLD_SUP" ]; then
+      break
+    fi
+  done
+  if [ -z "$NEW_SUP" ]; then
+    e2e_fail "8.4" "self-restart SIGUSR1" "no openclaw supervisor after signal (container died?)"
+  elif [ "$NEW_SUP" = "$OLD_SUP" ]; then
+    e2e_fail "8.4" "self-restart SIGUSR1" "supervisor PID unchanged after SIGUSR1 to gateway (restart did not happen)"
+  elif ! wait_ready "$BASE/" 60; then
+    e2e_fail "8.4" "self-restart SIGUSR1" "gateway did not recover after restart"
+  else
+    e2e_pass "8.4" "self-restart SIGUSR1 (supervisor PID $OLD_SUP → $NEW_SUP)"
+  fi
+fi
+
+# 8.5: openclaw.json has SSRF opt-out (guards #71)
+e2e_timer_start
+if podman exec "${CAGE}-cage" cat /home/node/.openclaw/openclaw.json 2>/dev/null \
+   | jq -e '.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork == true' >/dev/null 2>&1; then
+  e2e_pass "8.5" "openclaw.json SSRF opt-out (#71)"
+else
+  e2e_fail "8.5" "openclaw.json SSRF opt-out (#71)" \
+    "browser.ssrfPolicy.dangerouslyAllowPrivateNetwork is not true"
+fi
+
+# 8.6: controlUi.allowedOrigins includes gateway URL (guards df9fc30)
+e2e_timer_start
+allowed=$(podman exec "${CAGE}-cage" cat /home/node/.openclaw/openclaw.json 2>/dev/null \
+          | jq -r '.gateway.controlUi.allowedOrigins // [] | join(" ")' 2>/dev/null)
+if echo "$allowed" | grep -q "http://127.0.0.1:$PORT" \
+   && echo "$allowed" | grep -q "http://localhost:$PORT"; then
+  e2e_pass "8.6" "controlUi.allowedOrigins includes gateway URL"
+else
+  e2e_fail "8.6" "controlUi.allowedOrigins includes gateway URL" \
+    "missing one of http://127.0.0.1:$PORT or http://localhost:$PORT (got: $allowed)"
+fi
+
+# 8.7: matrix extension workspace workaround present (guards fda1ca6)
+e2e_timer_start
+if podman exec "${CAGE}-cage" sh -c 'test -L /app/node_modules/openclaw && test -s /app/node_modules/openclaw/package.json' 2>/dev/null; then
+  e2e_pass "8.7" "matrix extension symlink + resolvable package.json"
+else
+  e2e_fail "8.7" "matrix extension symlink + resolvable package.json" \
+    "/app/node_modules/openclaw symlink missing or target package.json unreadable"
+fi
+
+# 8.8a: cage env has literal placeholder (not the real sentinel)
+e2e_timer_start
+if podman exec "${CAGE}-cage" env 2>/dev/null | grep -q 'ANTHROPIC_API_KEY={{ANTHROPIC_API_KEY}}'; then
+  e2e_pass "8.8a" "cage env has literal placeholder"
+else
+  actual=$(podman exec "${CAGE}-cage" env 2>/dev/null | grep '^ANTHROPIC_API_KEY=' || echo 'not set')
+  e2e_fail "8.8a" "cage env has literal placeholder" \
+    "expected ANTHROPIC_API_KEY={{ANTHROPIC_API_KEY}}, got: $actual"
+fi
+
+# 8.8b: proxy records an injection attempt on the injected domain.
+# Follows phase 3's pattern: we assert the PROXY LOGS `secrets_injected`
+# for the flow, not that the upstream service actually echoed a modified
+# value. Public echo services (httpbin.org, postman-echo.com) cannot be
+# a reliable on-wire witness because some CDNs strip/mask Authorization
+# at the edge. The audit-log signal is what catches the regression class
+# we care about: "proxy stopped attempting injection on configured
+# domains."
+e2e_timer_start
+# Trigger a fresh flow to httpbin.org with the placeholder.
+agentcage cage exec "$CAGE" -- sh -c \
+  'curl --retry 3 --retry-delay 5 -sS -o /dev/null -x "$HTTPS_PROXY" \
+    --max-time 15 \
+    -H "Authorization: Bearer {{ANTHROPIC_API_KEY}}" \
+    https://httpbin.org/headers' >/dev/null 2>&1 || true
+# The audit log lags the wire by ~1s; poll with a modest deadline.
+FOUND=false
+for _ in $(seq 1 10); do
+  sleep 1
+  if agentcage cage audit "$CAGE" --json-lines -n 30 2>/dev/null \
+     | grep httpbin.org | grep -q '"secrets_injected":\s*\[\s*"ANTHROPIC_API_KEY"\s*\]'; then
+    FOUND=true
+    break
+  fi
+done
+if [ "$FOUND" = true ]; then
+  e2e_pass "8.8b" "proxy logs secrets_injected on injected domain"
+else
+  e2e_fail "8.8b" "proxy logs secrets_injected on injected domain" \
+    "no 'secrets_injected: [ANTHROPIC_API_KEY]' entry for httpbin.org in audit log"
+fi
+
+# 8.8c: injection is domain-scoped — postman-echo.com is allowlisted
+# but NOT in inject_to. The proxy must NOT log secrets_injected for
+# that flow; the placeholder passes through to upstream verbatim.
+e2e_timer_start
+agentcage cage exec "$CAGE" -- sh -c \
+  'curl --retry 3 --retry-delay 5 -sS -o /dev/null -x "$HTTPS_PROXY" \
+    --max-time 15 \
+    -H "Authorization: Bearer {{ANTHROPIC_API_KEY}}" \
+    https://postman-echo.com/headers' >/dev/null 2>&1 || true
+LEAKED=false
+for _ in $(seq 1 10); do
+  sleep 1
+  if agentcage cage audit "$CAGE" --json-lines -n 30 2>/dev/null \
+     | grep postman-echo.com | grep -q '"secrets_injected":\s*\[\s*"ANTHROPIC_API_KEY"\s*\]'; then
+    LEAKED=true
+    break
+  fi
+done
+if [ "$LEAKED" = false ]; then
+  e2e_pass "8.8c" "injection is domain-scoped (no secrets_injected on postman-echo)"
+else
+  e2e_fail "8.8c" "injection is domain-scoped (no secrets_injected on postman-echo)" \
+    "ANTHROPIC_API_KEY injection leaked to postman-echo.com (not in inject_to list)"
+fi
+
+# 8.9: domain allowlist blocks unlisted host
+e2e_timer_start
+code=$(agentcage cage exec "$CAGE" -- sh -c \
+  'curl -sx "$HTTPS_PROXY" -o /dev/null -w "%{http_code}" \
+    --max-time 10 https://forbidden.example.com' 2>/dev/null || echo "000")
+if [ "$code" = "403" ] || [ "$code" = "502" ]; then
+  e2e_pass "8.9" "domain allowlist blocks unlisted host (HTTP $code)"
+else
+  e2e_fail "8.9" "domain allowlist blocks unlisted host" "expected 403/502, got $code"
+fi
+
+# 8.10: nested podman smoke (probe-then-skip).
+# The cage runs as root inside its userns (so podman inside reports
+# `Rootless=false`), but the OUTER podman is rootless on the host.
+# GHA ubuntu-24.04 may not allow the full nested stack; skip if
+# `podman ps` doesn't work inside, fail hard if it works but `run`
+# doesn't (the regression case we're guarding).
+e2e_timer_start
+if ! agentcage cage exec "$CAGE" -- podman ps >/dev/null 2>&1; then
+  e2e_skip "8.10" "nested podman smoke" "nested podman not usable in this environment"
+elif agentcage cage exec "$CAGE" -- podman run --rm docker.io/library/busybox echo ok 2>/dev/null | grep -q '^ok$'; then
+  e2e_pass "8.10" "nested podman smoke (busybox)"
+else
+  e2e_fail "8.10" "nested podman smoke (busybox)" \
+    "podman run inside cage failed (scaffold uid/subuid/overlay regression?)"
+fi
+
+# Trap handles teardown
+print_results

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -16,16 +16,17 @@ export REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 # ── parse args ───────────────────────────────────────────────────────
 PHASES=()
 if [ $# -eq 0 ]; then
-  PHASES=(1 2 3 4 5 6 7)
+  PHASES=(1 2 3 4 5 6 7 8)
 else
   for arg in "$@"; do
     case "$arg" in
       container) PHASES+=(1 2 3 4 5 6) ;;
       vm)        PHASES+=(7) ;;
-      all)       PHASES=(1 2 3 4 5 6 7) ;;
-      [1-7])     PHASES+=("$arg") ;;
+      openclaw)  PHASES+=(8) ;;
+      all)       PHASES=(1 2 3 4 5 6 7 8) ;;
+      [1-8])     PHASES+=("$arg") ;;
       -h|--help)
-        echo "Usage: $0 [PHASE...] [container|vm|all]"
+        echo "Usage: $0 [PHASE...] [container|vm|openclaw|all]"
         echo ""
         echo "Phases:"
         echo "  1  Container lifecycle & core security"
@@ -35,11 +36,13 @@ else
         echo "  5  Backup/restore & multi-cage isolation"
         echo "  6  Security hardening & edge cases"
         echo "  7  VM mode (requires Lima + KVM)"
+        echo "  8  OpenClaw scaffold regression canary (pulls openclaw:latest)"
         echo ""
         echo "Shortcuts:"
         echo "  container   Phases 1-6"
         echo "  vm          Phase 7 only"
-        echo "  all         Phases 1-7 (default)"
+        echo "  openclaw    Phase 8 only"
+        echo "  all         Phases 1-8 (default)"
         echo ""
         echo "Environment:"
         echo "  E2E_PORT_BASE    Port base for test cages (default: 19080)"
@@ -71,10 +74,12 @@ fi
 cleanup_all() {
   echo ""
   echo "Final cleanup..."
-  for name in basic e2e-har e2e-secrets e2e-second e2e-clone e2e-hardened e2e-vm; do
+  for name in basic e2e-har e2e-secrets e2e-second e2e-clone e2e-hardened e2e-vm e2e-openclaw; do
     podman rm -f "${name}-mock" >/dev/null 2>&1 || true
     agentcage cage destroy "$name" -y >/dev/null 2>&1 || true
   done
+  # Phase 8 uses user-named volumes that aren't cleaned by cage destroy
+  podman volume rm -f e2e-openclaw-workspace e2e-openclaw-state >/dev/null 2>&1 || true
 }
 trap cleanup_all EXIT
 
@@ -89,6 +94,7 @@ PHASE_SCRIPTS=(
   [5]="phase5_backup.sh"
   [6]="phase6_hardening.sh"
   [7]="phase7_vm.sh"
+  [8]="phase8_openclaw.sh"
 )
 
 TOTAL_PASS=0
@@ -243,9 +249,16 @@ for i in "${!BG_PIDS[@]}"; do
   tally_bg_phase "${BG_PHASES[$i]}"
 done
 
-# ── phase 7 (VM) runs last ────────────────────────────────────────
+# ── phase 7 (VM) runs after parallel phases ───────────────────────
 if HAS_PHASE 7 && [ "$SUITE_FAILED" = false ]; then
   run_and_tally 7
+fi
+
+# ── phase 8 (openclaw) runs sequentially after VM ─────────────────
+# Heavy cage (4 GiB even after CI trim); keep out of the parallel block
+# so it doesn't contend with other phases for Podman resources.
+if HAS_PHASE 8 && [ "$SUITE_FAILED" = false ]; then
+  run_and_tally 8
 fi
 
 # ── summary ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New e2e phase that spins up the real openclaw scaffold against `ghcr.io/openclaw/openclaw:latest` and hard-fails on every regression class we've had to patch in the last few bumps. Runnable locally via `bash tests/e2e/run.sh openclaw`; wired into CI as its own parallel GitHub Actions job (`e2e-openclaw`) so openclaw upstream flake doesn't gate phases 1-6.

The openclaw image moves independently of agentcage. Every recent minor has shipped at least one change that silently broke our scaffold — today that surfaces only when a user files a bug. After this PR lands, upstream regressions fail CI instead.

## What it guards against

| # | Regression | Commit that fixed it |
|---|---|---|
| SSRF browser refusal when `HTTP_PROXY` is set | #71 | 66fc916 |
| tini PID 1 needed to survive SIGUSR1 self-restart | — | b1885b1 |
| `controlUi.allowedOrigins` must include reverse-proxy URL | — | df9fc30 |
| matrix-js-sdk `workspace:*` devDeps + `node_modules/openclaw` self-reference | — | fda1ca6 |

## Assertions (12 total, ~72s wall-time warm-cache)

- **8.1** gateway serves OpenClaw Control UI
- **8.2** `openclaw health` via exec_alias works
- **8.3** tini is PID 1 (`/proc/1/comm == tini`)
- **8.4** SIGUSR1 to openclaw-gateway → supervisor PID changes + gateway recovers (PID-delta witness; fixed sleep replaced with poll)
- **8.5** `openclaw.json` has `dangerouslyAllowPrivateNetwork: true` (jq-parsed, not grepped)
- **8.6** `controlUi.allowedOrigins` includes `http://127.0.0.1:$PORT` + `localhost:$PORT`
- **8.7** `/app/node_modules/openclaw` symlink + resolvable `package.json`
- **8.8a** cage env has literal `{{ANTHROPIC_API_KEY}}` placeholder (real key does not leak)
- **8.8b** proxy logs `secrets_injected: [ANTHROPIC_API_KEY]` for httpbin.org (in `inject_to`)
- **8.8c** proxy does NOT log `secrets_injected` for postman-echo.com (not in `inject_to` — domain-scoped)
- **8.9** domain allowlist blocks unlisted hosts (HTTP 403/502)
- **8.10** nested rootless podman smoke (probe-then-skip for environments without support)

Secret-injection assertions follow phase 3's audit-log pattern — on-wire echo verification via public httpbin.org proved unreliable for TLS flows (CDN behavior) and is captured as follow-up TODO T1 ("HAR-capture openclaw's organic outbound") in `TODOS.md`.

## Test plan

- [x] Local cold-cache run: `bash tests/e2e/run.sh openclaw` passes all 12 (8 min cold, 72s warm)
- [x] Shell syntax validated on all modified scripts (`bash -n`)
- [x] `run.sh --help` shows updated usage with `openclaw` shortcut
- [x] Existing phases untouched (lib.sh helper is additive, run.sh changes are additive)
- [ ] CI confirms `e2e-openclaw` job appears and passes in parallel with `e2e-container`
- [ ] CI confirms phase 8 also passes on cold GHA runner (will skip 8.10 if nested rootless unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)