### PR TITLE
fix(e2e): phase 8.4 follows openclaw 2026.5+ in-process restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- e2e Phase 8: `8.4 self-restart SIGUSR1` rewritten for openclaw 2026.5+. The upstream change collapses the supervisor + `openclaw-gateway` worker into a single `openclaw` process and switches to in-process restart in containers (deliberate — `restart mode: in-process restart (container: use in-process restart to keep PID 1 alive)`), so the previous PID-delta witness can no longer fire. The new test sends SIGUSR1 to `^openclaw$`, asserts openclaw logs `received SIGUSR1; restarting` (proves the signal was authorized via `commands.restart`, which defaults to true), and probes the gateway readiness endpoint to confirm recovery.
+
 ### Removed
 - `agentcage completions <shell>` wrapper command. Click ships native shell completion via the `_AGENTCAGE_COMPLETE=<shell>_source agentcage` env-var protocol; the wrapper added zero capability over upstream and created a maintenance surface that could drift from Click. See [Shell completion](docs/cli.md#shell-completion) in the CLI reference for the env-var pattern.
 - `agentcage cage edit` — trivial `click.edit()` wrapper. Use `$EDITOR <path>` (path visible via `cage show`) followed by `agentcage cage update <name>` instead.

--- a/tests/e2e/phase8_openclaw.md
+++ b/tests/e2e/phase8_openclaw.md
@@ -26,7 +26,7 @@ test shape *cannot* catch.
 | **8.1** Gateway serves OpenClaw Control UI | GET `/` contains the literal string `OpenClaw Control` in the response body — rules out reverse-proxy error pages and other servers on the port | Doesn't load the JS bundle, doesn't follow any API route, doesn't test authenticated paths. If openclaw ships a redesign that renames the app title, 8.1 false-fails. If openclaw ships a UI that loads but the backend is broken, 8.1 false-passes. |
 | **8.2** `openclaw health` via exec_alias | Exec_aliases config wires `openclaw` → `node openclaw.mjs`; the CLI runs inside the cage; at least one agent is configured (`Agents:` appears in output) | "Agents:" is a loose match — the health command could fail its internal checks and still print the agent list. Doesn't verify heartbeat, session store, or any downstream dependency. |
 | **8.3** tini is PID 1 | Scaffold's `ENTRYPOINT ["tini", "--"]` was applied and the container started under tini (`/proc/1/comm == tini`) | Doesn't prove tini is correctly forwarding signals — only that it's present. If tini were compiled with bad defaults (e.g., ignoring SIGUSR1), this passes. That's what 8.4 is for. |
-| **8.4** Self-restart survives SIGUSR1 | SIGUSR1 sent to `openclaw-gateway` causes: (a) the gateway to exit, (b) the supervisor's `node openclaw.mjs gateway` command to end, (c) the `while true; do ... done` loop in `entrypoint.sh` to respawn with a new PID, (d) the container stays alive through the cycle, (e) the gateway responds 200 again within 60s | Only tests ONE restart cycle. Won't catch file-descriptor leaks, growing memory, or zombie-process accumulation across many restarts. The 30s poll after the signal is optimistic — on a saturated CI runner a slow restart could time out and false-fail. Doesn't verify state preservation across the restart (e.g. devices still paired). |
+| **8.4** Self-restart on SIGUSR1 | SIGUSR1 sent to the lone `openclaw` process (2026.5+ collapses the older supervisor + `openclaw-gateway` worker pair into one) causes: (a) openclaw logs `received SIGUSR1; restarting` (proves the signal landed AND `isRestartEnabled` returned true), (b) openclaw performs an in-process restart — server tears down, reinitializes, listens again — without exiting (in containers, openclaw deliberately keeps PID 1 alive), (c) the gateway responds 200 again within 60s | Only tests ONE restart cycle. Won't catch file-descriptor leaks, growing memory, or zombie-process accumulation across many restarts. PID stays the same by design, so this no longer doubles as a "tini stayed alive" canary — 8.3 is the only PID-1 witness. The log-line witness depends on openclaw's exact wording; if upstream renames it, 8.4 will false-fail loudly (which is the correct behavior). Doesn't verify state preservation across the restart (e.g. devices still paired). |
 | **8.5** `openclaw.json` has SSRF opt-out | Entrypoint wrote the config file with `.browser.ssrfPolicy.dangerouslyAllowPrivateNetwork == true` (jq-parsed, so key renames fail loudly) | Only verifies the config FILE, not the RUNTIME. If openclaw ≥ a future version renames `ssrfPolicy` → `ssrf` or ignores the key, 8.5 passes while the browser tool is still broken. Doesn't launch an actual browser. |
 | **8.6** `controlUi.allowedOrigins` includes gateway URL | Entrypoint templated the port correctly into both `http://localhost:$PORT` and `http://127.0.0.1:$PORT` | Doesn't prove device pairing actually succeeds with those origins. If the allowedOrigins key is renamed upstream, 8.6 fails loudly — which is the correct behaviour. |
 | **8.7** Matrix extension workspace workaround | `/app/node_modules/openclaw` is a symlink AND its target `package.json` is resolvable — proves the Containerfile layer that creates the symlink ran | Doesn't verify matrix-js-sdk actually loads at runtime, or that `import`s from the matrix extension resolve. A regression that breaks extension loading for a different reason (e.g. peer-dep mismatch) wouldn't be caught here. |
@@ -114,11 +114,22 @@ Things phase 8's logic *assumes* about the environment — if any of
 these stop holding, assertions could pass for the wrong reason.
 
 - **setproctitle renames survive.** 8.4 relies on `pgrep -f '^openclaw$'`
-  matching exactly the supervisor's cmdline. If openclaw stops renaming
-  argv[0] and instead runs as `node openclaw.mjs gateway`, the pgrep
-  returns empty and 8.4 bails with "could not find openclaw supervisor"
-  — which is a *correct* failure, but the test's error message will
-  mislead.
+  matching exactly the openclaw process's cmdline. If openclaw stops
+  renaming argv[0] and instead runs as `node openclaw.mjs gateway`, the
+  pgrep returns empty and 8.4 bails with "could not find openclaw
+  process" — a *correct* failure, but the message will mislead.
+- **commands.restart defaults to true.** 8.4 sends an external SIGUSR1
+  via `pkill`. openclaw's handler (see `isRestartEnabled` in
+  `dist/commands.flags-*.js`) authorizes the restart unless config sets
+  `commands.restart: false`. If a future scaffold change writes that
+  flag (or upstream flips the default), the signal is logged as
+  `received SIGUSR1` but `received SIGUSR1; restarting` never appears,
+  and 8.4 fails with "signal lost or commands.restart=false".
+- **Single-process layout.** 8.4 assumes one `openclaw` process owns
+  the SIGUSR1 handler (true since 2026.5). If upstream re-introduces a
+  worker split, the signal may need to target the worker instead — the
+  regex `^openclaw$` would then miss the handler and the restart log
+  never appears.
 - **httpbin.org and postman-echo.com are reachable.** External echo
   services are transient dependencies. Outages cause false-fails on
   8.8b/c (the `--retry 3` on curl mitigates briefly). The audit-log

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -154,39 +154,44 @@ else
   e2e_fail "8.3" "tini is PID 1" "expected 'tini', got '$pid1_comm'"
 fi
 
-# 8.4: self-restart survives SIGUSR1 (PID-delta witness).
-# openclaw forks a supervisor ("openclaw", PID N) and a gateway worker
-# ("openclaw-gateway", child of supervisor). The SIGUSR1 handler lives
-# in the gateway; signalling the supervisor alone is a no-op. Signalling
-# the gateway makes it exit, which also ends the `node openclaw.mjs
-# gateway` command, which drops out of the entrypoint.sh while-true loop
-# and gets respawned — both PIDs change. Watching the supervisor PID is
-# the stronger witness because it proves the container (and tini) stayed
-# alive across the restart.
+# 8.4: self-restart on SIGUSR1 (log-line witness + readiness probe).
+# Openclaw 2026.5+ runs as a single "openclaw" process and handles SIGUSR1
+# with an in-process restart in containers (deliberate — keeps PID 1
+# alive). The PID never changes; the gateway tears down its server,
+# reinitializes, and starts listening again. We witness this via two
+# things that must both hold: openclaw logs "received SIGUSR1; restarting"
+# (proves the signal landed AND the restart was authorized — see
+# isRestartEnabled in commands.flags), and the gateway becomes ready
+# again on the same port. commands.restart defaults to true unless the
+# config explicitly sets it false, so no scaffold change is needed.
 e2e_timer_start
 # `pgrep` exits 1 on no-match — wrap in `|| true` so `set -e` doesn't
 # kill the phase before we can report 8.4 as a failure.
-OLD_SUP=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
-if [ -z "$OLD_SUP" ]; then
-  e2e_fail "8.4" "self-restart SIGUSR1" "could not find openclaw supervisor before signal"
+OPENCLAW_PID=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
+if [ -z "$OPENCLAW_PID" ]; then
+  e2e_fail "8.4" "self-restart SIGUSR1" "could not find openclaw process before signal"
 else
-  podman exec "${CAGE}-cage" pkill -USR1 -f openclaw-gateway 2>/dev/null || true
-  NEW_SUP=""
+  # Capture the current log size so we only inspect lines emitted after
+  # the signal. Avoids matching a "received SIGUSR1" from an earlier
+  # restart in the same container.
+  LOG_BEFORE=$(podman logs "${CAGE}-cage" 2>&1 | wc -l | tr -d ' ')
+  podman exec "${CAGE}-cage" pkill -USR1 -f '^openclaw$' 2>/dev/null || true
+  RESTART_LOGGED=""
   for _ in $(seq 1 30); do
     sleep 1
-    NEW_SUP=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
-    if [ -n "$NEW_SUP" ] && [ "$NEW_SUP" != "$OLD_SUP" ]; then
+    if podman logs "${CAGE}-cage" 2>&1 | tail -n "+$((LOG_BEFORE + 1))" \
+         | grep -q 'received SIGUSR1; restarting'; then
+      RESTART_LOGGED=yes
       break
     fi
   done
-  if [ -z "$NEW_SUP" ]; then
-    e2e_fail "8.4" "self-restart SIGUSR1" "no openclaw supervisor after signal (container died?)"
-  elif [ "$NEW_SUP" = "$OLD_SUP" ]; then
-    e2e_fail "8.4" "self-restart SIGUSR1" "supervisor PID unchanged after SIGUSR1 to gateway (restart did not happen)"
+  if [ -z "$RESTART_LOGGED" ]; then
+    e2e_fail "8.4" "self-restart SIGUSR1" \
+      "openclaw did not log 'received SIGUSR1; restarting' within 30s (signal lost or commands.restart=false)"
   elif ! wait_ready "$BASE/" 60; then
-    e2e_fail "8.4" "self-restart SIGUSR1" "gateway did not recover after restart"
+    e2e_fail "8.4" "self-restart SIGUSR1" "gateway did not recover after in-process restart"
   else
-    e2e_pass "8.4" "self-restart SIGUSR1 (supervisor PID $OLD_SUP → $NEW_SUP)"
+    e2e_pass "8.4" "self-restart SIGUSR1 (in-process; PID $OPENCLAW_PID held)"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Master CI has been red since the 2026-05-03 openclaw image landed (last green: 2026-04-26). All recent PR builds inherit the failure (#76, #79 hit it on rerun). Failure: `8.4 self-restart SIGUSR1 — supervisor PID unchanged after SIGUSR1 to gateway (restart did not happen)`.
- Root cause is upstream: openclaw 2026.5.0 collapses the supervisor + `openclaw-gateway` worker into a single `openclaw` process and switches container restarts to in-process — `restart mode: in-process restart (container: use in-process restart to keep PID 1 alive)`. The PID stays the same by design, so the old PID-delta witness in 8.4 can no longer fire.
- Test 8.4 now signals `^openclaw$`, asserts the log line `received SIGUSR1; restarting` (proves the signal landed AND the restart was authorized — `isRestartEnabled` defaults to true), and probes readiness. Same intent, witnesses that survive the upstream model change.

## Verification

Reproduced locally against `ghcr.io/openclaw/openclaw:latest` (image id `a0a130822fdd`, version `2026.5.2` — the same image that's failing CI):

```
OPENCLAW_PID before: [4]
Sent SIGUSR1
Saw restart log at t=1s
Gateway ready after restart at t=1s
OPENCLAW_PID after: [4] (expected same as before: 4)
PID held — in-process restart confirmed
```

The full upstream restart sequence on SIGUSR1:
```
[gateway] signal SIGUSR1 received
[gateway] received SIGUSR1; restarting
[shutdown] started: gateway restarting
[gateway] restart mode: in-process restart (container: use in-process restart to keep PID 1 alive)
[gateway] starting HTTP server...
[gateway] ready
```

## Test plan

- [ ] Phase 8 E2E (`E2E OpenClaw (Phase 8)`) passes on this PR.
- [ ] Other phases unaffected (`E2E Container (Phases 1-6)`, `Tests`).

## Notes

- No scaffold changes. `commands.restart` defaults to true; only an explicit `false` in config would block the restart, and our scaffold doesn't set the key.
- 8.3 (`tini is PID 1`) is now the only PID-1 liveness witness in phase 8 — 8.4 used to double as one because PID delta required the container to survive. Companion doc (`tests/e2e/phase8_openclaw.md`) updated to call this out, plus the new silent-failure modes (upstream renaming the log line or flipping the `commands.restart` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)