### PR TITLE
feat(imap): require_authentication via SEARCH-command rewrite (default on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- IMAP relay: `policy.require_authentication` (default **true**) rewrites every SEARCH/UID SEARCH command to append three `HEADER "Authentication-Results"` criteria — `dkim=pass`, `spf=pass`, `dmarc=pass`. The upstream IMAP server applies the filter; the response forwards verbatim. The cage thus only sees UIDs of mail the receiving MTA stamped as authenticated. Sequence-numbered `FETCH`/`STORE` are rejected at the command layer so the cage cannot bypass the SEARCH filter by referencing messages by position. Multi-line SEARCH commands containing IMAP literal-string criteria are rejected with `NO`. New audit entries: `kind: imap_search_rewritten`, plus `kind: imap_command, decision: blocked` for the FETCH/STORE rejections. See `docs/configuration.md` ("Inbound message authentication") for the full design.
+
+### Changed
+- IMAP relay: the new `require_authentication` policy defaults to **true**. Existing relays that don't override this will start filtering SEARCH responses to authenticated mail only. **If your upstream MTA doesn't stamp `Authentication-Results`** (uncommon but possible for self-hosted setups), set `policy.require_authentication: false` in the relay entry to restore the prior verbatim-passthrough behavior.
+
 ## [0.14.3] - 2026-05-04
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,6 +308,7 @@ Like `secret_injection`, the goal is the same: the cage container holds no upstr
 |---------|------|----------|-------------|
 | `policy.readonly` | `bool` | no | If `true`, block APPEND/DELETE/STORE/EXPUNGE/CREATE/RENAME/MOVE/COPY plus the write subcommands of UID. Default `false`. |
 | `policy.folder_allowlist` | `list[string]` | no | If non-empty, restrict SELECT/EXAMINE/STATUS to these mailbox names. LIST/LSUB always pass through (metadata only). Default `[]` (no filter). |
+| `policy.require_authentication` | `bool` | no | If `true` (default), rewrite SEARCH commands to require `dkim=pass spf=pass dmarc=pass` server-side, and block sequence-numbered FETCH/STORE so the cage can't bypass the filter. See "Inbound message authentication" below. Set `false` if the upstream MTA doesn't stamp `Authentication-Results`. |
 | `policy.conn_rate_limit` | `string` | no | Connection rate cap, e.g. `"30/min"`. Default `"30/min"`. |
 
 ### SMTP-specific policy (`type: smtp`)
@@ -336,6 +337,25 @@ On client connect, the relay opens an authenticated TLS connection upstream and 
 If the cage tries LOGIN or AUTHENTICATE anyway, the relay intercepts and forges an `OK already authenticated` response — the spurious credentials never reach the upstream server.
 
 Each policy decision (allowed, blocked, login attempt) emits a structured log line that the proxy container forwards to the existing audit pipeline.
+
+### Inbound message authentication (`require_authentication`)
+
+When `policy.require_authentication: true` (the default), the IMAP relay enforces that the cage only sees mail the upstream MTA stamped as authenticated — DKIM, SPF, and DMARC must all show `=pass` on the `Authentication-Results:` header that the receiving MTA (Migadu, Fastmail, etc.) writes on every inbound message.
+
+How it works:
+
+* Every `SEARCH` and `UID SEARCH` command from the cage is rewritten on its way upstream. The relay appends three IMAP `HEADER` search criteria (RFC 3501 §6.4.4) — `HEADER "Authentication-Results" "dkim=pass"`, `HEADER "Authentication-Results" "spf=pass"`, `HEADER "Authentication-Results" "dmarc=pass"` — to the client's existing search criteria. IMAP search keys are implicit-AND, so this narrows the result set without disturbing the original criteria.
+* The upstream IMAP server applies the filter. The relay forwards its response verbatim. The cage thus only ever learns the UIDs of messages that match its own criteria *and* have all three authentication methods stamped `=pass`.
+* To prevent bypass, sequence-numbered `FETCH` and `STORE` are rejected at the command layer (`UID FETCH` / `UID STORE` are still allowed). Without this gate, a cage could issue `FETCH 1:* (UID)` and learn UIDs the rewritten SEARCH would have hidden.
+* Multi-line SEARCH commands containing IMAP literal-string criteria (`{N}\r\n<bytes>`) are rejected with `NO`, since the rewrite logic only handles single-line commands. Modern IMAP clients (himalaya, mutt) build queries with quoted strings, not literals, so this is a no-op for the supported deployments.
+
+Why "rewrite" rather than "filter responses": appending criteria to the SEARCH command pushes filtering to the upstream IMAP server and keeps the relay close to its byte-passthrough role. No side-channel connection, no response parsing, no per-session state. The upstream server already does the heavy lifting; we just narrow the question.
+
+`HEADER` is a substring match on the raw header value. The RFC 8601 result tokens (`none`, `pass`, `fail`, `neutral`, `softfail`, `temperror`, `permerror`, `policy`) are a closed set with `pass` as the only one starting with that string, so `dkim=pass` substring match is precise enough in practice. The relay does not parse the `Authentication-Results` value structurally — that's the upstream MTA's job.
+
+A `kind: imap_search_rewritten` audit entry records every rewrite. Sequence-numbered FETCH/STORE rejections emit `kind: imap_command` with `decision: blocked, reason: UID-prefix required when require_authentication is on`.
+
+**Default on.** Most upstream MTAs stamp `Authentication-Results`, and a cage acting on unauthenticated mail is almost always wrong. Set `false` only when the upstream MTA doesn't write that header, or for relays explicitly intended for unfiltered access (e.g. an admin/inspection relay).
 
 ### SMTP relay behavior
 

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -169,6 +169,16 @@ class RelayPolicy:
     # IMAP
     readonly: bool = False
     folder_allowlist: list[str] = field(default_factory=list)
+    # When true (default), the IMAP relay rewrites SEARCH / UID SEARCH
+    # commands to append HEADER "Authentication-Results" "dkim=pass" /
+    # spf=pass / dmarc=pass criteria. The upstream IMAP server applies the
+    # filter; the cage receives only UIDs that pass DKIM, SPF, and DMARC
+    # at the receiving MTA. Sequence-numbered FETCH/STORE is also rejected
+    # so the cage cannot bypass the filter by referencing messages by
+    # position. Set to False if the upstream MTA does not stamp
+    # Authentication-Results, or for relays where filtering is not
+    # appropriate (e.g. a debugging/inspection relay).
+    require_authentication: bool = True
 
     # SMTP
     sender_allowlist: list[str] = field(default_factory=list)
@@ -435,6 +445,9 @@ def load_config(path: str) -> Config:
             idle_timeout_seconds=int(pol_raw.get("idle_timeout_seconds", 0)),
             readonly=bool(pol_raw.get("readonly", False)),
             folder_allowlist=list(pol_raw.get("folder_allowlist") or []),
+            require_authentication=bool(
+                pol_raw.get("require_authentication", True)
+            ),
             sender_allowlist=list(pol_raw.get("sender_allowlist") or []),
             recipient_allowlist=recipient_allowlist,
             max_message_bytes=int(

--- a/src/agentcage/data/proxy/relays/imap.py
+++ b/src/agentcage/data/proxy/relays/imap.py
@@ -67,6 +67,69 @@ _STRIPPED_CAPABILITIES = frozenset({"COMPRESS=DEFLATE"})
 # discover the allowlisted folders.
 _MAILBOX_ARG_COMMANDS = frozenset({"SELECT", "EXAMINE", "STATUS"})
 
+# Subcommands that must be UID-prefixed when require_authentication is
+# active. A sequence-numbered FETCH/STORE on ``1:*`` would bypass the
+# rewritten SEARCH (which only constrains UIDs the client learns through
+# a filtered SEARCH response). Forcing UID prefix means the client can
+# only act on UIDs the relay returned to it.
+_REQUIRE_UID_WHEN_FILTERING = frozenset({"FETCH", "STORE"})
+
+# IMAP literal-string trailer: ``{N}\r\n`` (synchronizing) or ``{N+}\r\n``
+# (non-synchronizing, RFC 7888). A SEARCH command line ending with this
+# means the criteria continue with a literal payload on subsequent reads.
+# We don't try to rewrite multi-line SEARCH commands — the server-side
+# filter is appended only when the entire command fits on one readline.
+_LITERAL_TRAIL_RE = re.compile(rb"\{\d+\+?\}\r?\n$")
+
+# The HEADER constraints we append to a SEARCH command when
+# require_authentication is on. IMAP search keys are implicit-AND by
+# juxtaposition (RFC 3501 §6.4.4), so appending narrows the result set
+# to messages that match the client's criteria AND have all three of
+# ``dkim=pass``, ``spf=pass``, and ``dmarc=pass`` somewhere in the
+# Authentication-Results header value. ``HEADER`` is a substring match
+# server-side; the result tokens of RFC 8601 (none/pass/fail/neutral/
+# softfail/temperror/permerror/policy) are a closed set with ``pass`` as
+# the only one starting with that string, so substring is precise enough
+# in practice.
+_AUTHRES_REQUIRED_CRITERIA = (
+    b' HEADER "Authentication-Results" "dkim=pass"'
+    b' HEADER "Authentication-Results" "spf=pass"'
+    b' HEADER "Authentication-Results" "dmarc=pass"'
+)
+
+
+def _is_search_line(line: bytes) -> bool:
+    """Return True iff *line* is an untagged ``SEARCH`` or ``UID SEARCH``
+    command. Used to decide whether to rewrite the line."""
+    parts = line.split(None, 2)
+    if len(parts) < 2:
+        return False
+    cmd = parts[1].rstrip(b"\r\n").upper()
+    if cmd == b"SEARCH":
+        return True
+    if cmd == b"UID" and len(parts) >= 3:
+        sub = parts[2].split(None, 1)[0].rstrip(b"\r\n").upper()
+        return sub == b"SEARCH"
+    return False
+
+
+def _is_literal_continued(line: bytes) -> bool:
+    """Return True iff *line* ends with an IMAP literal marker, meaning
+    the command continues with the literal payload on subsequent reads.
+    """
+    return bool(_LITERAL_TRAIL_RE.search(line))
+
+
+def _rewrite_search_with_authres(line: bytes) -> bytes:
+    """Append the auth-results HEADER criteria to a single-line SEARCH
+    command. Caller must verify ``not _is_literal_continued(line)``.
+    """
+    if line.endswith(b"\r\n"):
+        return line[:-2] + _AUTHRES_REQUIRED_CRITERIA + b"\r\n"
+    if line.endswith(b"\n"):
+        return line[:-1] + _AUTHRES_REQUIRED_CRITERIA + b"\n"
+    return line + _AUTHRES_REQUIRED_CRITERIA + b"\r\n"
+
 
 _RATE_LIMIT_RE = re.compile(r"^\s*(\d+)\s*/\s*(sec|s|min|m|hour|h)\s*$")
 _RATE_UNIT_SECS = {"sec": 1, "s": 1, "min": 60, "m": 60, "hour": 3600, "h": 3600}
@@ -146,6 +209,17 @@ class _RelayConfig:
         self.idle_timeout_seconds: int = int(
             policy.get("idle_timeout_seconds", 1800)
         )
+        # Inbound message authentication: rewrite SEARCH commands to
+        # require dkim/spf/dmarc =pass on Authentication-Results, and
+        # block sequence-numbered FETCH/STORE so the cage cannot
+        # bypass the SEARCH filter by referencing messages by position.
+        # Default on — most upstream MTAs stamp Authentication-Results
+        # and the cage shouldn't act on mail that failed authentication
+        # at the receiving boundary. Set false for relays whose upstream
+        # doesn't stamp the header or where filtering is undesirable.
+        self.require_authentication: bool = bool(
+            policy.get("require_authentication", True)
+        )
 
 
 class ImapRelay:
@@ -191,13 +265,14 @@ class ImapRelay:
         )
         log.info(
             "imap relay %s listening on %s -> %s:%d (readonly=%s, "
-            "folders=%s)",
+            "folders=%s, require_authentication=%s)",
             self._cfg.name,
             self._cfg.listen,
             self._cfg.upstream_host,
             self._cfg.upstream_port,
             self._cfg.readonly,
             self._cfg.folder_allowlist or "(any)",
+            self._cfg.require_authentication,
         )
 
     async def stop(self) -> None:
@@ -509,16 +584,69 @@ class ImapRelay:
             if not line:
                 return
             decision = self._policy_check(line)
-            if decision is None:
-                upstream_writer.write(line)
-                await upstream_writer.drain()
+            if decision is not None:
+                tag, reason, fake_status = decision
+                client_writer.write(
+                    tag + b" " + fake_status + b" "
+                    + reason.encode() + b"\r\n"
+                )
+                await client_writer.drain()
                 continue
 
-            tag, reason, fake_status = decision
+            line = await self._maybe_rewrite(line, client_writer)
+            if line is None:
+                # Already responded to the client (deny path inside the
+                # rewrite — e.g. literal-continued SEARCH).
+                continue
+            upstream_writer.write(line)
+            await upstream_writer.drain()
+
+    async def _maybe_rewrite(
+        self,
+        line: bytes,
+        client_writer: asyncio.StreamWriter,
+    ) -> Optional[bytes]:
+        """Apply inbound-filter rewrites to *line* before it goes upstream.
+
+        Returns the (possibly rewritten) line for the caller to forward,
+        or ``None`` if the relay has already responded to the client and
+        the line should not be forwarded at all.
+        """
+        if not self._cfg.require_authentication:
+            return line
+        if not _is_search_line(line):
+            return line
+        if _is_literal_continued(line):
+            tag = line.split(None, 1)[0]
+            log.warning(
+                "imap relay %s: blocked SEARCH with literal continuation "
+                "(require_authentication: only single-line SEARCH supported)",
+                self._cfg.name,
+            )
+            self._audit_log({
+                "kind": "imap_command",
+                "relay": self._cfg.name,
+                "command": "SEARCH",
+                "decision": "blocked",
+                "reason": (
+                    "SEARCH with literal continuation not supported "
+                    "under require_authentication"
+                ),
+            })
             client_writer.write(
-                tag + b" " + fake_status + b" " + reason.encode() + b"\r\n"
+                tag + b" NO SEARCH with literal continuation not "
+                b"permitted under require_authentication\r\n"
             )
             await client_writer.drain()
+            return None
+
+        rewritten = _rewrite_search_with_authres(line)
+        self._audit_log({
+            "kind": "imap_search_rewritten",
+            "relay": self._cfg.name,
+            "reason": "require_authentication",
+        })
+        return rewritten
 
     async def _pipe_upstream_to_client(
         self,
@@ -603,6 +731,36 @@ class ImapRelay:
                     f"{effective_cmd} not permitted (readonly)",
                     b"NO",
                 )
+
+        # Inbound-filter policy: when require_authentication is on, the
+        # only UIDs the client should know about are those the rewritten
+        # SEARCH returned. Sequence-numbered FETCH/STORE references
+        # messages by position, bypassing the filter; reject so the cage
+        # has to use UID FETCH / UID STORE on UIDs it learned legitimately.
+        if (
+            self._cfg.require_authentication
+            and cmd in _REQUIRE_UID_WHEN_FILTERING
+        ):
+            log.warning(
+                "imap relay %s: blocked sequence-numbered %s "
+                "(require_authentication: UID prefix required)",
+                self._cfg.name, cmd,
+            )
+            self._audit_log({
+                "kind": "imap_command",
+                "relay": self._cfg.name,
+                "command": cmd,
+                "decision": "blocked",
+                "reason": (
+                    "UID-prefix required when require_authentication is on"
+                ),
+            })
+            return (
+                tag,
+                f"{cmd} not permitted without UID prefix "
+                f"(require_authentication active)",
+                b"NO",
+            )
 
         if (
             cmd in _MAILBOX_ARG_COMMANDS

--- a/tests/test_protocol_relays.py
+++ b/tests/test_protocol_relays.py
@@ -962,3 +962,364 @@ class TestImapIdleTimeout:
                 await silent.wait_closed()
 
         _run(_go())
+
+
+# ── require_authentication: SEARCH command rewrite ──────
+
+
+from relays.imap import (
+    _AUTHRES_REQUIRED_CRITERIA,
+    _is_literal_continued,
+    _is_search_line,
+    _rewrite_search_with_authres,
+)
+
+
+class TestIsSearchLine:
+    def test_plain_search(self):
+        assert _is_search_line(b"a1 SEARCH UNSEEN\r\n") is True
+
+    def test_uid_search(self):
+        assert _is_search_line(b"a1 UID SEARCH ALL\r\n") is True
+
+    def test_lowercase(self):
+        assert _is_search_line(b"a1 uid search all\r\n") is True
+
+    def test_uid_fetch_is_not_search(self):
+        assert _is_search_line(b"a1 UID FETCH 1 (FLAGS)\r\n") is False
+
+    def test_fetch(self):
+        assert _is_search_line(b"a1 FETCH 1 (FLAGS)\r\n") is False
+
+    def test_select(self):
+        assert _is_search_line(b"a1 SELECT INBOX\r\n") is False
+
+    def test_too_short(self):
+        assert _is_search_line(b"a1\r\n") is False
+
+
+class TestIsLiteralContinued:
+    def test_synchronizing_literal(self):
+        assert _is_literal_continued(b"a1 SEARCH SUBJECT {12}\r\n") is True
+
+    def test_non_synchronizing_literal(self):
+        assert _is_literal_continued(b"a1 SEARCH SUBJECT {12+}\r\n") is True
+
+    def test_no_literal(self):
+        assert _is_literal_continued(b"a1 SEARCH UNSEEN\r\n") is False
+
+    def test_literal_in_middle_not_at_end(self):
+        # IMAP literals are command continuations — they're always at
+        # end-of-line. A {N} mid-line that isn't followed by CRLF isn't
+        # a continuation marker.
+        assert _is_literal_continued(b'a1 SEARCH HEADER "X" "{12}"\r\n') is False
+
+
+class TestRewriteSearchWithAuthres:
+    def test_appends_constraints_before_crlf(self):
+        rewritten = _rewrite_search_with_authres(b"a1 UID SEARCH UNSEEN\r\n")
+        assert rewritten.endswith(b"\r\n")
+        assert _AUTHRES_REQUIRED_CRITERIA in rewritten
+        assert rewritten.startswith(b"a1 UID SEARCH UNSEEN")
+
+    def test_appends_when_only_lf(self):
+        # Tolerant of bare LF for tests/manual entry; the relay always
+        # gets CRLF over the wire from real clients.
+        rewritten = _rewrite_search_with_authres(b"a1 SEARCH ALL\n")
+        assert rewritten.endswith(b"\n")
+        assert _AUTHRES_REQUIRED_CRITERIA in rewritten
+
+    def test_three_separate_header_clauses(self):
+        rewritten = _rewrite_search_with_authres(b"a1 UID SEARCH ALL\r\n")
+        assert rewritten.count(b'HEADER "Authentication-Results"') == 3
+        assert b'"dkim=pass"' in rewritten
+        assert b'"spf=pass"' in rewritten
+        assert b'"dmarc=pass"' in rewritten
+
+
+# ── End-to-end SEARCH-rewrite ───────────────────────────
+
+
+def _filter_relay_entry(upstream_port: int, **overrides) -> dict:
+    """A relay entry with require_authentication explicit. The default is
+    True now, but tests prefer to be explicit so the intent is clear."""
+    entry = _relay_entry(upstream_port)
+    entry["policy"]["require_authentication"] = True
+    entry["policy"].update(overrides)
+    return entry
+
+
+class TestSearchRewriteOnTheWire:
+    """Verify the SEARCH command upstream actually saw the appended
+    HEADER criteria."""
+
+    def test_uid_search_unseen_rewritten(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()  # PREAUTH
+                        writer.write(b"a1 UID SEARCH UNSEEN\r\n")
+                        await writer.drain()
+                        await _read_until_tag(reader, b"a1")
+                # Upstream's recorded line must contain all three HEADER
+                # constraints, AND'd to the original criteria.
+                forwarded = next(
+                    c for c in recorder.commands
+                    if b"UID SEARCH" in c.upper()
+                )
+                assert b"UNSEEN" in forwarded
+                assert b'HEADER "Authentication-Results" "dkim=pass"' in forwarded
+                assert b'HEADER "Authentication-Results" "spf=pass"' in forwarded
+                assert b'HEADER "Authentication-Results" "dmarc=pass"' in forwarded
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_plain_search_also_rewritten(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 SEARCH ALL\r\n")
+                        await writer.drain()
+                        await _read_until_tag(reader, b"a1")
+                forwarded = next(
+                    c for c in recorder.commands
+                    if c.upper().startswith(b"A1 SEARCH")
+                )
+                assert b"ALL" in forwarded.upper()
+                assert b'"dkim=pass"' in forwarded
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_existing_criteria_preserved(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(
+                            b'a1 UID SEARCH OR FROM "x@y.com" SUBJECT "hi" UNSEEN\r\n'
+                        )
+                        await writer.drain()
+                        await _read_until_tag(reader, b"a1")
+                forwarded = next(
+                    c for c in recorder.commands
+                    if b"UID SEARCH" in c.upper()
+                )
+                # Original criteria intact, ours appended.
+                assert b'OR FROM "x@y.com" SUBJECT "hi" UNSEEN' in forwarded
+                assert forwarded.find(
+                    b'HEADER "Authentication-Results"'
+                ) > forwarded.find(b"UNSEEN")
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_search_with_literal_continuation_rejected(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        # Continuation literal — the criterion would
+                        # arrive on the next read. We block this whole
+                        # form because rewriting would corrupt the
+                        # multi-line command.
+                        writer.write(b"a1 UID SEARCH SUBJECT {5}\r\n")
+                        await writer.drain()
+                        line = await _read_until_tag(reader, b"a1")
+                        assert b" NO " in line
+                        assert b"literal" in line.lower()
+                # Upstream never saw it.
+                for c in recorder.commands:
+                    assert b"UID SEARCH" not in c.upper(), c
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_disabled_passes_search_through_unmodified(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                entry = _relay_entry(up_port)
+                entry["policy"]["require_authentication"] = False
+                async with _running_relay(entry) as (_, port):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 UID SEARCH UNSEEN\r\n")
+                        await writer.drain()
+                        await _read_until_tag(reader, b"a1")
+                forwarded = next(
+                    c for c in recorder.commands
+                    if b"UID SEARCH" in c.upper()
+                )
+                # No rewrite — exact command on the wire.
+                assert forwarded.strip() == b"a1 UID SEARCH UNSEEN"
+                assert b"Authentication-Results" not in forwarded
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_default_is_on(self):
+        """The relay defaults require_authentication=True; an entry
+        that omits the field still gets the rewrite."""
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                # _relay_entry() omits require_authentication entirely.
+                async with _running_relay(_relay_entry(up_port)) as (_, port):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 UID SEARCH ALL\r\n")
+                        await writer.drain()
+                        await _read_until_tag(reader, b"a1")
+                forwarded = next(
+                    c for c in recorder.commands
+                    if b"UID SEARCH" in c.upper()
+                )
+                assert b'"dkim=pass"' in forwarded
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+
+class TestSequenceFetchStoreBlock:
+    """Sequence-numbered FETCH/STORE bypass the SEARCH filter (since
+    they reference messages by position, not UIDs the filtered SEARCH
+    returned). Reject at the policy layer."""
+
+    def test_sequence_fetch_rejected_when_filter_on(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 FETCH 1:* (UID)\r\n")
+                        await writer.drain()
+                        line = await _read_until_tag(reader, b"a1")
+                        assert b" NO " in line
+                        assert b"UID" in line
+                # Upstream never saw the command.
+                for c in recorder.commands:
+                    assert not c.upper().startswith(b"A1 FETCH"), c
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_sequence_store_rejected_when_filter_on(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 STORE 1 +FLAGS \\Seen\r\n")
+                        await writer.drain()
+                        line = await _read_until_tag(reader, b"a1")
+                        assert b" NO " in line
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_uid_fetch_passes_through(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                async with _running_relay(_filter_relay_entry(up_port)) as (
+                    _, port,
+                ):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 UID FETCH 1 (FLAGS)\r\n")
+                        await writer.drain()
+                        line = await _read_until_tag(reader, b"a1")
+                        assert line.startswith(b"a1 OK"), line
+                forwarded = next(
+                    c for c in recorder.commands
+                    if b"UID FETCH" in c.upper()
+                )
+                assert b"UID FETCH 1" in forwarded
+                # Not rewritten.
+                assert b"Authentication-Results" not in forwarded
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())
+
+    def test_sequence_fetch_allowed_when_filter_off(self):
+        async def _go():
+            recorder = FakeUpstreamRecorder()
+            upstream, up_port = await _start_fake_upstream(
+                recorder, "real-user@example.com", "real-app-password",
+            )
+            try:
+                entry = _relay_entry(up_port)
+                entry["policy"]["require_authentication"] = False
+                async with _running_relay(entry) as (_, port):
+                    async with _imap_client(port) as (reader, writer):
+                        await reader.readline()
+                        writer.write(b"a1 FETCH 1 (FLAGS)\r\n")
+                        await writer.drain()
+                        line = await _read_until_tag(reader, b"a1")
+                        # Fake upstream OKs everything.
+                        assert line.startswith(b"a1 OK"), line
+            finally:
+                upstream.close()
+                await upstream.wait_closed()
+        _run(_go())


### PR DESCRIPTION
## Summary

Push email authentication enforcement out of the agent and into the IMAP relay. When `policy.require_authentication: true` (the new **default**), the relay rewrites every `SEARCH` and `UID SEARCH` command on its way upstream to append three IMAP `HEADER` search criteria:

```
HEADER "Authentication-Results" "dkim=pass"
HEADER "Authentication-Results" "spf=pass"
HEADER "Authentication-Results" "dmarc=pass"
```

IMAP search keys are implicit-AND (RFC 3501 §6.4.4), so the appended criteria narrow the result set to messages that match the client's original criteria AND have all three authentication methods stamped `=pass`. The upstream IMAP server (Migadu, Dovecot) does the filtering; the relay forwards the response verbatim. The cage thus only sees UIDs of mail the receiving MTA stamped as authenticated.

**One of three coordinated changes** to push email-authentication enforcement out of the agent and into the layers designed for it.

## Design

```
client                       relay                            upstream IMAP
  │                            │                                    │
  │  a1 UID SEARCH UNSEEN ───▶ │ ── append HEADER criteria ─────▶   │
  │                            │   a1 UID SEARCH UNSEEN              │  filter
  │                            │   HEADER "AR" "dkim=pass"           │  server-
  │                            │   HEADER "AR" "spf=pass"            │  side
  │                            │   HEADER "AR" "dmarc=pass"          │
  │                            │                                    │
  │                            │ ◀── * SEARCH 12 17 ──────────────  │  (only
  │ ◀── * SEARCH 12 17 ──────  │    (verbatim passthrough)           │  passing
  │                            │                                    │  UIDs)
```

No side-channel. No response parser. No per-session state. One byte transformation per SEARCH command.

## Bypass mitigations

- **Sequence-numbered FETCH/STORE blocked.** A cage could otherwise issue `FETCH 1:* (UID)` to learn UIDs the rewritten SEARCH hides. `UID FETCH` and `UID STORE` remain allowed — those operate on UIDs the cage already has.
- **Literal-continued SEARCH blocked.** `a1 SEARCH SUBJECT {12}\r\n<bytes>` would split across reads, breaking the rewrite. Rejected with `NO`. Modern clients (himalaya, mutt) use quoted strings, not literals, so this is a no-op in practice.

## Why default on

Most upstream MTAs stamp `Authentication-Results`, and a cage acting on unauthenticated mail is almost always wrong. Existing relays whose upstream MTA doesn't stamp the header (uncommon but possible for self-hosted setups) need to set `policy.require_authentication: false` explicitly. CHANGELOG flags this as a behavioral change.

## What got dropped vs. an earlier prototype

This PR replaces a previous side-channel-based prototype (closed: #87) that buffered SEARCH responses, opened a second IMAP connection, and parsed FETCH responses for header inspection — ~1500 LOC. The rewrite approach gets to ~100 LOC of relay code. The side-channel was solving a problem that already had a server-side answer.

## Files

- `src/agentcage/data/proxy/relays/imap.py` (+170, mostly comments + helpers): `_is_search_line`, `_is_literal_continued`, `_rewrite_search_with_authres`, the rewrite hook in `_pipe_client_to_upstream`, the sequence-FETCH/STORE rejection in `_policy_check`, plus the new policy field on `_RelayConfig`.
- `src/agentcage/config.py` (+13): `RelayPolicy.require_authentication: bool = True` and parser entry.
- `tests/test_protocol_relays.py` (+361): 24 new tests across `TestIsSearchLine`, `TestIsLiteralContinued`, `TestRewriteSearchWithAuthres`, `TestSearchRewriteOnTheWire`, `TestSequenceFetchStoreBlock`.
- `docs/configuration.md` (+20): new "Inbound message authentication" subsection.
- `CHANGELOG.md` (+6): `Unreleased / Added` and `Changed` (default flip).

## Test plan

- [x] `uv run pytest tests/` — 1220 passed (1196 before + 24 new), 0 regressions.
- [ ] Smoke against `jacque-cage` with the new field set; verify `kind: imap_search_rewritten` audit entries appear and the cage's heartbeat sees only authenticated mail.

## Coordinated PRs

- [jacque-setup#1](https://github.com/lucamartinetti/jacque-setup/pull/1) — push email PGP out of the agent (himalaya `+pgp-commands`).
- This PR — DKIM/SPF/DMARC enforcement at the IMAP relay.
- Follow-up — IMAP relay `from_allowlist` (sender allowlist; appends `OR FROM "x" FROM "y"` criteria using the same rewrite machinery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)