### PR TITLE
feat: flip entropy inspector default to opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `secrets.scope` config field (`auto` | `user` | `system`, default `auto`) selects which systemd-creds key encrypts a cage's secrets. `auto` picks `user` when the invoker is non-root and `systemd-creds --user encrypt` probes successfully, else falls back to `system`. Motivating case: when a service user like `jacque-svc` runs `agentcage secret set NAME KEY` on a host with an active graphical session, the system-scope `io.systemd.credentials.encrypt` polkit action is routed to the desktop user's polkit agent and prompts for their password — which the unattended service user can't satisfy. User-scoped encryption uses the per-user key under `~/.config/credstore/` and bypasses polkit entirely. The .cred files are encrypted/decrypted with the same scope; quadlets already run under `systemctl --user`, so a user-scoped blob decrypts cleanly in the proxy `ExecStartPre`. `encrypt_secret(name, value, state_dir, scope=...)`, `resolve_scope(configured)`, and `detect_default_scope()` are the new public knobs; `agentcage doctor` reports the selected scope (and warns that user-scoped blobs are bound to the user rather than the host's TPM/hardware).
 - `host_url_param_allowlist` now accepts the wildcard entry `"*"` to disable URL entropy checks entirely for a host. A list containing the single value `"*"` short-circuits both `_check_url_params` and `_check_url_path` for the matched host (and its subdomains, matching the existing suffix logic), so neither query-param values nor path segments are entropy-scanned. Motivating case: hosts like `googleapis.com` legitimately emit many opaque high-entropy continuation cursors (Drive `pageToken`, Calendar `syncToken`, plus future tokens we haven't seen yet) and maintaining an explicit param-name list is fragile — every new Google API surface that ships a new cursor name re-blocks the cage until the operator names it. The wildcard is one knob: `host_url_param_allowlist: {"googleapis.com": ["*"]}` covers params and path segments together. Body entropy is unchanged; this only relaxes the URL-side checks.
 
+### Changed (BREAKING — security-relevant default)
+- The Shannon-entropy inspector is now **opt-in** rather than on-by-default. Pre-change, every cage that didn't explicitly set `entropy: false` had the inspector loaded in `block` mode at threshold `7.0` over request bodies, URL query parameters, and URL path segments. Post-change, the inspector is loaded only when the operator explicitly opts in — either by adding a top-level `entropy: {}` block to `cage.yaml` (empty dict = defaults, or a non-empty dict to override) or by listing `- name: entropy` under the `inspectors:` section. A bare config with no entropy key (and no `inspectors:` entry naming entropy) gets four built-in inspectors loaded — `domain`, `secrets`, `body-size`, `content-type` — but not `entropy`. The `entropy: false` legacy disable continues to be a no-op for forward compatibility.
+- **Security implication**: the entropy inspector is the only built-in that catches encrypted or compressed payload exfiltration smuggled inside an otherwise-allowlisted HTTP request — random/compressed bytes hiding in a JSON field, a URL parameter, or a path segment. Flipping the default to opt-in removes that automatic detection layer on every new cage and on every existing cage that didn't have an explicit `entropy:` section pinning the prior behavior. The other inspectors stay strict: `secrets` (regex-based key detection) still blocks every leaking pattern it knows about, `content-type` (text-with-high-entropy + base64-blob scan) still flags obvious binary smuggling in text bodies, `domain` still enforces the host allowlist, and `body-size` still caps payload bytes. Entropy was specifically the layer most likely to false-positive on legitimate high-entropy strings — Google API pagination tokens, JWTs, opaque cursors, base64-encoded UUIDs, signed S3 presigned-URL query params — and the friction was significant enough that operators were accumulating per-host content-type exemptions, URL allowlists, and `entropy: false` lines just to clear the inspector. The team's call: cleaner default, with the protection one line away for any cage that wants it.
+- **Migration**: to keep the prior on-by-default behavior verbatim, add either of the following to your `cage.yaml`:
+
+  ```yaml
+  # Option 1: top-level key, defaults applied (threshold 7.0, block mode)
+  entropy: {}
+
+  # Option 2: top-level key, explicit overrides
+  entropy:
+    threshold: 7.0
+    action: block
+
+  # Option 3: under the inspectors list (also works alongside other inspectors)
+  inspectors:
+    - name: entropy
+  ```
+
+  All built-in agentcage scaffolds (`openclaw`, `picoclaw`, `nanoclaw`, `claude-code`, `codex`, `alpine-curl`, `scaffold-starter`) already list `- name: entropy` under `inspectors:`, so cages created from those scaffolds keep their entropy inspector loaded with no further action. The behavior change only affects custom `cage.yaml` files that relied on the previous default-on behavior without an explicit opt-in. For cages that do opt in, the URL-allowlist wildcarding from #99 is the cleanest way to silence per-host false positives without disabling the inspector entirely.
+
 ## [0.15.4] - 2026-05-13
 
 ### Fixed

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -275,10 +275,12 @@ class Agentcage:
         if max_body:
             out["body-size"] = {"max_bytes": max_body}
 
-        # entropy — on by default in flag mode; disable with entropy: false
-        entropy_cfg = self.cfg.get("entropy", {})
-        if entropy_cfg is not False:
-            out["entropy"] = entropy_cfg if isinstance(entropy_cfg, dict) else {}
+        # entropy — opt-in. Enable via top-level `entropy: {...}` (dict, may be
+        # empty for defaults) or by adding `- name: entropy` to `inspectors:`.
+        # `entropy: false` continues to be a no-op (legacy disable).
+        entropy_cfg = self.cfg.get("entropy")
+        if isinstance(entropy_cfg, dict):
+            out["entropy"] = entropy_cfg
 
         # content-type — on by default in flag mode; disable with content_type: false
         ct_cfg = self.cfg.get("content_type", {})

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -51,18 +51,49 @@ class TestDefaultInspectors:
         addon._load_custom_inspectors()
         return addon
 
-    def test_entropy_and_content_type_load_by_default(self):
+    def test_entropy_not_loaded_by_default(self):
+        """Bare config (no `entropy:` key, no `inspectors:` entry) → entropy
+        inspector is NOT loaded. Opt-in default flip (vs. 0.15.4)."""
         addon = self._make_addon("domains: {}")
         names = [i.name for i in addon.inspectors]
-        assert "entropy" in names
+        assert "entropy" not in names
+
+    def test_content_type_loads_by_default(self):
+        addon = self._make_addon("domains: {}")
+        names = [i.name for i in addon.inspectors]
         assert "content-type" in names
 
-    def test_entropy_defaults_to_block_mode(self):
-        addon = self._make_addon("domains: {}")
+    def test_entropy_opt_in_empty_dict_loads_defaults(self):
+        """`entropy: {}` opts in with default config."""
+        addon = self._make_addon("entropy: {}\ndomains: {}")
         entropy = next(i for i in addon.inspectors if i.name == "entropy")
         assert entropy.action == "block"
         assert entropy.threshold == 7.0
         assert entropy.min_body_bytes == 256
+
+    def test_entropy_opt_in_via_inspectors_block(self):
+        """`inspectors: - name: entropy` opts in via the custom-inspector path."""
+        addon = self._make_addon(textwrap.dedent("""\
+            domains: {}
+            inspectors:
+              - name: entropy
+        """))
+        names = [i.name for i in addon.inspectors]
+        assert "entropy" in names
+
+    def test_entropy_opt_in_via_inspectors_block_with_config(self):
+        """`inspectors: - name: entropy` with explicit config applies overrides."""
+        addon = self._make_addon(textwrap.dedent("""\
+            domains: {}
+            inspectors:
+              - name: entropy
+                config:
+                  threshold: 7.5
+                  action: flag
+        """))
+        entropy = next(i for i in addon.inspectors if i.name == "entropy")
+        assert entropy.threshold == 7.5
+        assert entropy.action == "flag"
 
     def test_content_type_defaults_to_block_mode(self):
         addon = self._make_addon("domains: {}")
@@ -72,6 +103,7 @@ class TestDefaultInspectors:
         assert ct.detect_base64 is True
 
     def test_entropy_disabled_with_false(self):
+        """Legacy `entropy: false` still doesn't load (regression guard)."""
         addon = self._make_addon("entropy: false\ndomains: {}")
         names = [i.name for i in addon.inspectors]
         assert "entropy" not in names
@@ -92,9 +124,16 @@ class TestDefaultInspectors:
         assert entropy.threshold == 6.0
         assert entropy.action == "block"
 
-    def test_minimal_config_loads_all_five_inspectors(self):
-        """A bare config should load domain, secrets, body-size, entropy, content-type."""
+    def test_minimal_config_loads_four_inspectors(self):
+        """A bare config (no entropy opt-in) loads domain, secrets,
+        body-size, content-type — entropy is opt-in."""
         addon = self._make_addon("domains: {}\nsecrets: {}")
+        names = sorted(i.name for i in addon.inspectors)
+        assert names == ["body-size", "content-type", "domain", "secrets"]
+
+    def test_minimal_config_with_entropy_opt_in(self):
+        """Explicit `entropy: {}` brings back all five inspectors."""
+        addon = self._make_addon("domains: {}\nsecrets: {}\nentropy: {}")
         names = sorted(i.name for i in addon.inspectors)
         assert names == ["body-size", "content-type", "domain", "entropy", "secrets"]
 


### PR DESCRIPTION
## Summary

The Shannon-entropy inspector — Shannon-entropy analysis over HTTP request bodies, URL query parameters, and URL path segments — has been loaded by default on every cage since it shipped. It catches encrypted or compressed exfiltration smuggled in otherwise-allowlisted HTTP traffic, but it routinely false-positives on legitimate high-entropy strings: Google API pagination tokens, JWTs, opaque cursors, base64-encoded UUIDs, signed S3 presigned-URL query params, etc. The friction has been significant enough that operators were accumulating workarounds (`entropy: false`, explicit allowlists, per-host content-type exemptions) just to clear the inspector — at which point the default was costing more than it was paying.

**Flip the default: entropy is now opt-in.** Users who want the protection enable it explicitly; everyone else gets a cleaner default.

## Behavior change

| Config | Before | After |
|--------|--------|-------|
| (no `entropy:` key, no `inspectors:` entry) | loaded, `block` mode, threshold `7.0` | **not loaded** |
| `entropy: {}` | loaded with defaults | loaded with defaults (unchanged) |
| `entropy: {threshold: 7.5}` | loaded with overrides | loaded with overrides (unchanged) |
| `entropy: false` | not loaded | not loaded (legacy disable, preserved) |
| `inspectors: - name: entropy` | loaded via custom block | loaded via custom block (unchanged) |

Code change is six lines in `_build_legacy_config`:

```python
# entropy — opt-in. Enable via top-level `entropy: {...}` (dict, may be
# empty for defaults) or by adding `- name: entropy` to `inspectors:`.
# `entropy: false` continues to be a no-op (legacy disable).
entropy_cfg = self.cfg.get("entropy")
if isinstance(entropy_cfg, dict):
    out["entropy"] = entropy_cfg
```

`content-type` stays on-by-default — this PR is only the entropy flip.

## Security note

This removes a layer of automatic exfil detection. The entropy inspector is the only built-in that catches encrypted or compressed payloads smuggled in an allowlisted HTTP request. The other inspectors keep running:

- `secrets` (regex-based key detection) still blocks every pattern it knows about
- `content-type` (text-with-high-entropy + base64-blob scan) still flags obvious binary smuggling in text bodies
- `domain` still enforces the host allowlist
- `body-size` still caps payload bytes

Entropy was specifically the layer most prone to false-positive on legitimate content. The CHANGELOG entry calls this out explicitly with all three migration shapes.

## Migration

To keep the prior on-by-default behavior, add one of these to your `cage.yaml`:

```yaml
# Option 1: top-level key, defaults applied (threshold 7.0, block mode)
entropy: {}

# Option 2: top-level key with explicit overrides
entropy:
  threshold: 7.0
  action: block

# Option 3: under the inspectors list
inspectors:
  - name: entropy
```

All bundled scaffolds (`openclaw`, `picoclaw`, `nanoclaw`, `claude-code`, `codex`, `alpine-curl`, `scaffold-starter`) already list `- name: entropy` under `inspectors:`, so cages created from any built-in scaffold are unchanged. The flip only affects custom `cage.yaml` files that relied on the implicit default.

For cages that do opt in, #99 (URL-allowlist wildcarding) is the cleanest way to silence per-host false positives without disabling the inspector.

## Test plan

- [x] `uv run pytest tests/` — 1274 passed
- [x] New regression coverage in `tests/test_defaults.py`:
  - default config (no `entropy:` key) → entropy inspector NOT loaded
  - `entropy: {}` → loaded with defaults
  - `entropy: false` → still no-op (legacy disable)
  - `inspectors: - name: entropy` → loaded via custom block (existing opt-in path)
  - `inspectors: - name: entropy` with `config:` overrides → applied correctly
  - bare config loads four inspectors (`domain`, `secrets`, `body-size`, `content-type`); entropy opt-in brings the fifth back
- [x] Existing scaffold preset tests (`test_openclaw_preset_loads_inspectors`, `test_picoclaw_preset_loads_inspectors`) still pass — they exercise the `inspectors: - name: entropy` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)