### PR TITLE
docs: sync README and docs/ with v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,18 @@ agentcage cage destroy myapp
 |---|---|
 | `run` | *(top-level)* -- run a coding agent in a sandbox (`agentcage run claude-code`) |
 | `init` | *(top-level)* -- scaffold a config file |
-| `cage` | `create`, `update`, `edit`, `list`, `destroy`, `prune`, `verify`, `restart`, `logs`, `exec`, `audit`, `har`, `backup`, `restore` (aliases: `ls`/`ps`/`status` → `list`, `rm` → `destroy`, `reload` → `restart`) |
-| `secret` | `set`, `list`, `rm` (alias: `ls` → `list`) |
+| `doctor` | *(top-level)* -- check system prerequisites |
+| `update` | *(top-level)* -- self-update agentcage |
+| `cage` | `create`, `update`, `list`, `show`, `verify`, `start`, `stop`, `restart`, `logs`, `exec`, `shell`, `audit`, `har`, `backup`, `restore`, `destroy`, `prune` (aliases: `ls`/`ps`/`status` → `list`, `describe`/`inspect` → `show`, `rm`/`delete` → `destroy`, `reload` → `restart`) |
+| `secret` | `set`, `list`, `migrate`, `rm` (alias: `ls` → `list`) |
 | `domain` | `list`, `add`, `rm` (alias: `ls` → `list`) |
+| `scaffold` | `list`, `show`, `create`, `edit`, `delete`, `export` -- manage custom scaffolds |
 
 See [CLI Reference](docs/cli.md) for full documentation of all commands and options.
 
 ## Configuration
 
-See the [Configuration Reference](docs/configuration.md) for all settings, defaults, and examples. Example configs: [`basic/cage.yaml`](examples/basic/). Deployment state is tracked per-cage in `~/.config/agentcage/deployments/<name>/`.
+See the [Configuration Reference](docs/configuration.md) for all settings, defaults, and examples. Example configs: [`basic/cage.yaml`](examples/basic/). Deployment state is tracked per-cage in `~/.config/agentcage/cages/<name>/`.
 
 ## Security
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - [Security & Threat Model](security.md) — threat model, defense layers, isolation modes, known limitations
 - [Configuration Reference](configuration.md) — all settings, defaults, and examples
 - [CLI Reference](cli.md) — full command set and options
+- [Port Policy](proxy-audit-ports.md) — `ports.tcp` / `ports.udp` allowlists, the default-deny FORWARD chain, worked examples
 
 ## Isolation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,8 +78,8 @@ All HTTP traffic passes through a pluggable inspector chain implemented in `addo
 | `domain` | on | Domain allowlist/blocklist enforcement |
 | `secrets` | on | Regex-based secret leak detection |
 | `body-size` | on | Request body size limits |
-| `entropy` | off | Shannon entropy analysis for encrypted/compressed payloads |
-| `content-type` | off | Content-type mismatch and base64 blob detection |
+| `content-type` | on | Content-type mismatch and base64 blob detection |
+| `entropy` | off (opt-in) | Shannon entropy analysis for encrypted/compressed payloads |
 
 Custom inspectors can be added via Python files that extend the `Inspector` base class. Inspectors can also implement `inspect_response()` to scan inbound responses after forwarding.
 

--- a/docs/cage-management.md
+++ b/docs/cage-management.md
@@ -6,7 +6,7 @@ Common commands for managing an agentcage cage. Replace `myapp` with your cage n
 
 ```bash
 # Edit config directly, then apply (rebuilds + reloads)
-$EDITOR ~/.local/share/agentcage/myapp/cage.yaml && agentcage cage update myapp
+$EDITOR ~/.config/agentcage/cages/myapp/cage.yaml && agentcage cage update myapp
 
 # Rebuild and restart (after config or image changes)
 agentcage cage update myapp

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,6 +126,7 @@ Subdomains are collapsed to their parent domain (e.g. `api.stripe.com` prompts f
 | `secret list NAME` | List secrets for a cage (with status if cage exists) |
 | `secret set NAME KEY` | Set a secret (prompts for value or reads stdin) |
 | `secret rm NAME KEY` | Remove a secret |
+| `secret migrate NAME` | Migrate a cage's secrets to a different storage backend |
 
 **Aliases:** `ls` → `list`
 
@@ -147,7 +148,7 @@ Subdomains are collapsed to their parent domain (e.g. `api.stripe.com` prompts f
 agentcage cage create -c <config>
 ```
 
-Creates a new cage from a config file. Use `-s KEY=VALUE` (repeatable) to set secrets inline during creation. This single command:
+Creates a new cage from a config file. Use `-s KEY=VALUE` (repeatable) to set secrets inline during creation. Pass `--no-cache` to force a full image rebuild (ignore podman's layer cache) or `--pull` to force a re-pull of the base image from the registry. This single command:
 
 1. Validates the config
 2. Checks that all required secrets exist in Podman
@@ -187,6 +188,13 @@ Rebuild and restart an existing cage. Use this after changing code or config:
 
 Stops the running services before rebuilding, then starts them again.
 
+### Options
+
+| Option | Description |
+|---|---|
+| `--no-cache` | Force a full image rebuild, ignoring podman's layer cache. Use after pulling a fresh agentcage release that changed the `Containerfile` or its build context. |
+| `--pull` | Force a re-pull of the base image from the registry (`--pull=always`). Invalidates the base-image cache, independent of `--no-cache`. Combine both for a fully clean rebuild. |
+
 ## `cage list`
 
 ```
@@ -214,7 +222,7 @@ Tears down a cage completely:
 2. Removes quadlet files from `~/.config/containers/systemd/`
 3. Removes the Podman network and certificate volume
 4. Removes all scoped secrets (e.g., `myapp.ANTHROPIC_API_KEY`) — unless `--keep-secrets` is passed
-5. Removes deployment state from `~/.config/agentcage/deployments/<name>/`
+5. Removes deployment state from `~/.config/agentcage/cages/<name>/`
 
 User-defined named volumes and bind-mounted data are never removed. Pass `-y` to skip the confirmation prompt. Pass `--keep-secrets` to preserve scoped secrets (useful when destroying and recreating a cage).
 
@@ -291,7 +299,7 @@ Start a stopped cage.
 agentcage cage restart <name>
 ```
 
-Restarts containers without rebuilding images. Useful after config-only changes (the config YAML is bind-mounted into the proxy container, so a restart picks it up).
+Restarts containers without rebuilding images. Useful after config-only changes: `restart` (and `start`) regenerate `proxy-config.yaml` and `dns-allowlist.conf` from `cage.yaml` before bouncing services, so the running cage always reflects the current config on disk.
 
 **Alias:** `cage reload`
 
@@ -554,6 +562,21 @@ agentcage secret rm <name> <key>
 ```
 
 Removes a secret from Podman. If the cage is currently running, it is automatically reloaded.
+
+## `secret migrate`
+
+```
+agentcage secret migrate <name> [--backend systemd-creds] [--remove-old|--keep-old]
+```
+
+Migrates a cage's secrets to a different storage backend. The `systemd-creds` backend re-encrypts each secret with a systemd-creds key so the plaintext no longer lives in the Podman secret store.
+
+| Option | Description |
+|---|---|
+| `--backend systemd-creds` | Target backend for secret storage. |
+| `--remove-old` / `--keep-old` | Remove (or keep) the old plaintext secrets in the Podman store after migration. |
+
+The encrypting key's scope — `user` or `system` — follows the cage's `secrets.scope` config field (`auto` | `user` | `system`, default `auto`). `agentcage doctor` reports the scope a cage resolved to.
 
 ## `domain list`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -667,28 +667,30 @@ agentcage uses a **pluggable inspector chain**. Each HTTP request passes through
 | `domain` | on | Domain allowlist/blocklist enforcement |
 | `secrets` | on | Regex-based secret leak detection (always blocks) |
 | `body-size` | on | Request body size limits (loaded when `max_request_body` > 0; default is 10 MB). Per-host overrides via `host_max_bytes` — see below |
-| `entropy` | off | Shannon entropy analysis — detects encrypted/compressed payloads |
-| `content-type` | off | Content-type mismatch detection and base64 blob scanning |
+| `content-type` | on | Content-type mismatch detection and base64 blob scanning. Disable with top-level `content_type: false` |
+| `entropy` | off (opt-in) | Shannon entropy analysis — detects encrypted/compressed payloads |
 
-The `domain`, `secrets`, and `body-size` inspectors are loaded automatically from their top-level config sections. The `entropy` and `content-type` inspectors must be explicitly enabled via the `inspectors:` section:
+The `domain`, `secrets`, `body-size`, and `content-type` inspectors are loaded automatically: `domain`, `secrets`, and `content-type` from their top-level config sections, `body-size` whenever `max_request_body` is non-zero.
 
-```yaml
-inspectors:
-  - name: entropy
-    config:
-      threshold: 7.0
-  - name: content-type
-    config:
-      detect_base64: true
-```
-
-You can also enable them with no config to use all defaults:
+`entropy` is the only built-in **not** loaded by default. As of v0.16.0 it is opt-in — a cage with no entropy configuration runs without it. Enable it with a top-level `entropy:` block or by listing it under `inspectors:`:
 
 ```yaml
+# Option 1 — top-level block, empty {} applies defaults (threshold 7.0, block mode)
+entropy: {}
+
+# Option 2 — top-level block with overrides
+entropy:
+  threshold: 7.0
+  action: block
+
+# Option 3 — under the inspectors list
 inspectors:
   - name: entropy
-  - name: content-type
 ```
+
+All built-in scaffolds list `- name: entropy` under `inspectors:`, so cages created from a scaffold keep the entropy inspector loaded. Only a custom `cage.yaml` that relied on the pre-v0.16.0 default-on behavior needs to add one of the above; `entropy: false` remains a no-op for backward compatibility.
+
+To tune `content-type` (e.g. base64 detection), re-declare it under `inspectors:` — see [Content-type inspector](#content-type-inspector).
 
 ### Body-size inspector
 
@@ -718,7 +720,7 @@ Detects high-entropy payloads that may indicate encrypted or compressed data exf
 |---------|------|---------|-------------|
 | `threshold` | `float` | `7.0` | Entropy threshold in bits/byte (0.0–8.0) to trigger |
 | `min_body_bytes` | `int` | `256` | Minimum body size to evaluate |
-| `action` | `string` | `"flag"` | `"block"` or `"flag"` |
+| `action` | `string` | `"block"` | `"block"` or `"flag"` |
 | `exempt_content_types` | `list[string]` | `["image/", "application/gzip", "application/zip", "application/octet-stream"]` | Content-type prefixes to skip |
 
 Reference entropy ranges:
@@ -740,7 +742,7 @@ Detects content-type mismatches (text type with high entropy) and hidden base64 
 | `entropy_ceiling` | `float` | `6.5` | Max expected entropy for text content types |
 | `detect_base64` | `bool` | `true` | Enable base64 blob detection |
 | `base64_min_len` | `int` | `256` | Minimum base64 match length to trigger |
-| `action` | `string` | `"flag"` | `"block"` or `"flag"` |
+| `action` | `string` | `"block"` | `"block"` or `"flag"` |
 | `host_exempt_content_types` | `dict[string, list[string]]` | `{}` | Per-host content-type exemptions (subdomain suffix matching). Mirrors the entropy inspector's knob — use it for legitimate high-entropy bodies declared as a "text-like" content-type, e.g. `multipart/form-data` PDF uploads to a paperless-ngx host. |
 
 Text content-type prefixes checked: `application/json`, `application/xml`, `text/`, `application/x-www-form-urlencoded`, `multipart/form-data`.


### PR DESCRIPTION
## What

Documentation sync. The README and `docs/` had drifted across releases 0.11.0 → 0.16.0 — the README was last content-updated before 0.11.0.

## Changes

**Stale state-directory path** — the real dir is `~/.config/agentcage/cages/<name>/` (`state.py:17`). Corrected in `README.md`, `docs/cli.md`, and `docs/cage-management.md` (the last pointed `cage.yaml` at the capture dir, `~/.local/share/agentcage/`).

**README command table** — listed the removed `cage edit` (#74) and was missing `cage show`/`start`/`stop`/`shell`, the `doctor`/`scaffold`/`update` top-level commands, and `secret migrate`. Rebuilt from live `--help` output.

**docs/cli.md** — added the `secret migrate` command (shipped in v0.16.0, was undocumented), documented `--no-cache`/`--pull` on `cage create`/`cage update` (v0.15.3), and corrected the `cage restart` description (v0.15.1 made restart re-apply `cage.yaml` by regenerating `proxy-config.yaml`/`dns-allowlist.conf`).

**Inspector defaults (security-relevant)** — `configuration.md` and `architecture.md` said `content-type` was off / opt-in, but `addon.py:285-288` loads it by default. They also gave the inspector `action` default as `"flag"`; `entropy.py:89` and `content_type.py:60` default to `"block"`. Fixed the tables and rewrote the configuration.md inspector section to state plainly that `entropy` is the one opt-in built-in as of v0.16.0, with all three enable routes.

**docs/README.md** — `proxy-audit-ports.md` (15 KB) wasn't linked from the docs index. Added.

## Not included — flagged for a maintainer

- `docs/security.md:157` claims URL params/paths aren't entropy-scanned. The entropy inspector now does scan them (`_check_url_params` / `_check_url_path`, `url_threshold`). Left untouched because it's a threat-model doc and the honest rewrite also has to account for entropy now being opt-in.
- `secrets.scope` (the v0.16.0 config field) has no entry in the Configuration Reference. Worth a dedicated subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)