### PR TITLE
fix: stage sibling directories into cage build context (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `cage update` (without `-c`) no longer breaks rebuilds for cages whose Containerfile `COPY`s a directory tree. The build-context staging step copied sibling *files* into the cage state dir but skipped sibling *directories*, so a bare `cage update` — which rebuilds from the state dir — could not reproduce a build context that `cage update -c` (which builds from the original config dir) handled fine. The rebuild then failed inside `podman build` with `copier: stat: "...": no such file or directory`, and because the cage container is removed during the update the cage was left `stopped`. Staging now copies directories as well as files (skipping `__pycache__`, `.git`, `node_modules` and soft-deleted leftovers), across all four sites that snapshot a build context: `cage create`, `cage update -c`, `cage update`'s scaffold refresh, and scaffold init.
+
 ## [0.16.1] - 2026-05-20
 
 ### Fixed

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -69,6 +69,46 @@ def _build_container_image(cfg, config_dir: Path, podman: Podman,
                                no_cache=no_cache, pull=pull)
 
 
+# Entries in a Containerfile's directory that are agentcage config, not
+# build inputs — skipped when staging the build context.
+_BUILD_CONTEXT_SKIP_SUFFIXES = (".yaml", ".yml", ".j2")
+
+# Build noise that must never be copied into a cage's staged build context:
+# caches, VCS metadata, dependency trees, soft-deleted leftovers.
+_BUILD_CONTEXT_IGNORE = shutil.ignore_patterns(
+    "__pycache__", "*.pyc", ".git", "node_modules", "*.deleted.*",
+)
+
+
+def _stage_build_context(src_dir: Path, dest_dir: Path,
+                         *, clobber: bool = True) -> None:
+    """Copy a Containerfile's sibling build inputs into a cage's state dir.
+
+    Stages both files *and* directories so a later ``cage update`` (without
+    ``-c``) — which rebuilds from the state dir — has the complete build
+    context. A Containerfile that ``COPY``s a directory tree (skill
+    bundles, vendored packages) would otherwise fail the rebuild because
+    only sibling files were staged.
+
+    cage.yaml-style configs and ``.j2`` templates are skipped; build noise
+    (``__pycache__``, ``.git``, ``node_modules``, ...) is filtered out of
+    copied directories. With *clobber* false, entries already present in
+    *dest_dir* are left untouched.
+    """
+    for f in src_dir.iterdir():
+        if f.suffix in _BUILD_CONTEXT_SKIP_SUFFIXES:
+            continue
+        dest = dest_dir / f.name
+        if not clobber and dest.exists():
+            continue
+        if f.is_dir():
+            shutil.copytree(
+                f, dest, ignore=_BUILD_CONTEXT_IGNORE, dirs_exist_ok=True,
+            )
+        elif f.is_file():
+            shutil.copy2(str(f), str(dest))
+
+
 def _restart_cage(name: str, cfg=None):
     """Restart all services for a cage using the appropriate backend.
 
@@ -324,11 +364,9 @@ def init(name: str | None, output: str, image: str, isolation: str,
                 if "containerfile" in entry:
                     src_cf = scaffold_dir_path / entry["containerfile"]
                     if src_cf.is_file():
-                        for f in src_cf.parent.iterdir():
-                            if f.is_file() and f.suffix not in (".yaml", ".yml", ".j2"):
-                                dst = dest.parent / f.name
-                                if not dst.exists():
-                                    shutil.copy2(str(f), str(dst))
+                        _stage_build_context(
+                            src_cf.parent, dest.parent, clobber=False,
+                        )
     scaffold_dir = resolve_scaffold(scaffold) if scaffold else None
     if meta and meta.get("next_steps"):
         click.echo("\nNext steps:")
@@ -460,15 +498,13 @@ def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool):
         metadata["scaffold"] = scaffold_name
     state.save_metadata(name, metadata)
 
-    # Copy Containerfile and sibling files into state dir so cage update
-    # can rebuild (Containerfiles may COPY other files from the build context)
+    # Copy the Containerfile and its sibling build inputs into the state dir
+    # so cage update can rebuild (Containerfiles may COPY files and whole
+    # directory trees from the build context)
     if cfg.container.build.containerfile:
         src_cf = Path(config_path).parent / cfg.container.build.containerfile
         if src_cf.is_file():
-            dest_dir = state.deployment_dir(name)
-            for f in src_cf.parent.iterdir():
-                if f.is_file() and f.suffix not in (".yaml", ".yml", ".j2"):
-                    shutil.copy2(str(f), str(dest_dir / f.name))
+            _stage_build_context(src_cf.parent, state.deployment_dir(name))
 
     # Set secrets passed via --set-secret (before build so they're available)
     if secrets:
@@ -622,15 +658,13 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
             )
             sys.exit(1)
         state.save_deployment(name, config_path)
-        # Copy Containerfile and sibling files into state dir so future
-        # updates can rebuild (Containerfiles may COPY from build context)
+        # Copy the Containerfile and its sibling build inputs into the state
+        # dir so future updates can rebuild (Containerfiles may COPY files
+        # and whole directory trees from the build context)
         if cfg.container.build.containerfile:
             src_cf = Path(config_path).parent / cfg.container.build.containerfile
             if src_cf.is_file():
-                dest_dir = state.deployment_dir(name)
-                for f in src_cf.parent.iterdir():
-                    if f.is_file() and f.suffix not in (".yaml", ".yml", ".j2"):
-                        shutil.copy2(str(f), str(dest_dir / f.name))
+                _stage_build_context(src_cf.parent, state.deployment_dir(name))
     else:
         # Auto-resolve latest image tags for stored configs
         from agentcage.init import (
@@ -707,11 +741,9 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
 
             scaffold_dir = resolve_scaffold(scaffold_name)
             if scaffold_dir is not None:
-                # Copy fresh Containerfile + sibling files from scaffold
-                dest_dir = state.deployment_dir(name)
-                for f in scaffold_dir.iterdir():
-                    if f.is_file() and f.suffix not in (".yaml", ".yml", ".j2"):
-                        shutil.copy2(str(f), str(dest_dir / f.name))
+                # Copy fresh Containerfile + sibling build inputs (files and
+                # directory trees) from the scaffold
+                _stage_build_context(scaffold_dir, state.deployment_dir(name))
 
                 # Re-render scaffold template and patch command + new env vars
                 try:

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch, call, ANY
 import click
 from click.testing import CliRunner
 
-from agentcage.cli import main
+from agentcage.cli import main, _stage_build_context
 
 
 def _runner():
@@ -1083,3 +1083,98 @@ class TestCageExec:
         mock_run.assert_called_once_with(
             ["podman", "exec", "myapp-cage", "cat", "/etc/hostname"]
         )
+
+
+class TestStageBuildContext:
+    """`_stage_build_context` snapshots a Containerfile's build inputs into
+    the cage state dir so `cage update` (without -c) can rebuild."""
+
+    def _src(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "Containerfile").write_text("FROM scratch\nCOPY skill /opt/skill\n")
+        return src
+
+    def test_stages_sibling_directory(self, tmp_path):
+        """REGRESSION (#95): a directory the Containerfile COPYs in must be
+        staged — the old file-only copy silently dropped it, breaking the
+        rebuild with 'no such file or directory'."""
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        skill = src / "skill"
+        skill.mkdir()
+        (skill / "main.py").write_text("print('hi')")
+        (skill / "nested").mkdir()
+        (skill / "nested" / "data.txt").write_text("payload")
+
+        _stage_build_context(src, dest)
+
+        assert (dest / "skill" / "main.py").read_text() == "print('hi')"
+        assert (dest / "skill" / "nested" / "data.txt").read_text() == "payload"
+
+    def test_stages_sibling_files(self, tmp_path):
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        (src / "entrypoint.sh").write_text("#!/bin/sh\n")
+
+        _stage_build_context(src, dest)
+
+        assert (dest / "Containerfile").exists()
+        assert (dest / "entrypoint.sh").read_text() == "#!/bin/sh\n"
+
+    def test_skips_config_files(self, tmp_path):
+        """cage.yaml-style configs and .j2 templates are not build inputs."""
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        (src / "cage.yaml").write_text("name: test\n")
+        (src / "other.yml").write_text("x: 1\n")
+        (src / "tpl.j2").write_text("{{ x }}\n")
+
+        _stage_build_context(src, dest)
+
+        assert not (dest / "cage.yaml").exists()
+        assert not (dest / "other.yml").exists()
+        assert not (dest / "tpl.j2").exists()
+
+    def test_filters_build_noise_from_directories(self, tmp_path):
+        """Caches and VCS metadata must not pollute the staged context."""
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        skill = src / "skill"
+        (skill / "__pycache__").mkdir(parents=True)
+        (skill / "__pycache__" / "x.pyc").write_text("junk")
+        (skill / ".git").mkdir()
+        (skill / ".git" / "config").write_text("junk")
+        (skill / "node_modules").mkdir()
+        (skill / "real.py").write_text("ok")
+
+        _stage_build_context(src, dest)
+
+        assert (dest / "skill" / "real.py").exists()
+        assert not (dest / "skill" / "__pycache__").exists()
+        assert not (dest / "skill" / ".git").exists()
+        assert not (dest / "skill" / "node_modules").exists()
+
+    def test_clobber_false_preserves_existing(self, tmp_path):
+        """Scaffold init must not overwrite inputs the operator already has."""
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        (dest / "Containerfile").write_text("USER EDITED\n")
+
+        _stage_build_context(src, dest, clobber=False)
+
+        assert (dest / "Containerfile").read_text() == "USER EDITED\n"
+
+    def test_clobber_true_refreshes_existing_dir(self, tmp_path):
+        """Re-running an update merges fresh files into an already-staged
+        directory rather than failing on the existing path."""
+        src, dest = self._src(tmp_path), tmp_path / "dest"
+        dest.mkdir()
+        (src / "skill").mkdir()
+        (src / "skill" / "v.py").write_text("v2")
+        (dest / "skill").mkdir()
+        (dest / "skill" / "v.py").write_text("v1")
+
+        _stage_build_context(src, dest)
+
+        assert (dest / "skill" / "v.py").read_text() == "v2"


### PR DESCRIPTION
## Summary

Fixes #95 — `cage update` (without `-c`) silently breaks the rebuild for any cage whose Containerfile `COPY`s a **directory** tree (skill bundles, vendored packages).

`cage update` without `-c` rebuilds from the cage state dir. The build-context staging code copied sibling **files** into that dir but filtered out sibling **directories** (`if f.is_file()`). So a Containerfile with `COPY paperless-skill /opt/paperless-skill` rebuilt fine via `cage update -c <config>` (context = original config dir) but failed via bare `cage update`:

```
Error: building at STEP "COPY paperless-skill /opt/paperless-skill":
  copier: stat: "/paperless-skill": no such file or directory
```

Because the cage container is `--rm`'d during the update, a failed rebuild leaves the cage `stopped`.

## Changes

- New shared helper `_stage_build_context(src_dir, dest_dir, *, clobber=True)` — stages both files **and** directory trees, skips `.yaml`/`.yml`/`.j2` config, and filters build noise (`__pycache__`, `*.pyc`, `.git`, `node_modules`, `*.deleted.*`) out of copied directories. `dirs_exist_ok=True` so repeated updates merge into an already-staged dir.
- Replaces the file-only `iterdir()`/`is_file()` loop at **all four** sites that snapshot a build context — the issue named two; there were four:
  - `cage create`
  - `cage update -c`
  - `cage update`'s scaffold-refresh branch (copies from the scaffold dir — scaffolds can ship directory trees too)
  - scaffold init (`clobber=False` preserves inputs the operator already has)
- 6 unit tests covering the directory regression, file staging, config-file skip, build-noise filtering, and both `clobber` modes.

## Scope note

This is **Fix A** from the issue. It fully resolves the failure mode — once the build context is complete, the rebuild succeeds. Fix C ("surface podman's error") was deliberately left out: the `cage update` build path (`podman.py:79`) runs `subprocess.run(check=True)` **without** `capture_output`, so podman's `Error: building at STEP …` is already streamed to the terminal — the issue's "agentcage discards stdout/stderr" premise doesn't hold for this path. A separate clean-error-message PR can be filed if the raw `CalledProcessError` traceback is still a papercut.

## Testing

`uv run pytest tests/` — 1330 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)