### PR TITLE
refactor(doctor): drop check_cages overlap with cage list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `agentcage doctor` no longer includes a "Cages" section. Per-cage health (running / stopped / orphaned) duplicated `agentcage cage list`, which has richer output; `doctor` now focuses solely on whether the system itself is ready.
+
 ### Removed
 - `agentcage update` self-update command. Use `uv tool upgrade agentcage` or `pipx upgrade agentcage` instead — package managers do PyPI polling, installer detection, and version comparison better than a duplicated CLI surface.
 - `agentcage secret migrate` subcommand. Cross-backend migration was a one-time op for users predating the systemd-creds default; the replacement is the documented "Migrating between secret backends" recipe in `docs/configuration.md` (re-set secrets after editing `secret.backend` in `cage.yaml`).

--- a/src/agentcage/doctor.py
+++ b/src/agentcage/doctor.py
@@ -393,65 +393,6 @@ def check_port(port: int) -> CheckResult:
 
 
 # ---------------------------------------------------------------------------
-# Cage health checks
-# ---------------------------------------------------------------------------
-
-def check_cages() -> list[CheckResult]:
-    """Check health of existing cage deployments."""
-    try:
-        from agentcage import state  # noqa: F811 — deferred import to avoid circular deps
-        from agentcage.backends.container import ContainerBackend  # noqa: F811
-    except Exception as exc:
-        return [CheckResult("warn", f"Could not load cage modules: {exc}")]
-
-    results: list[CheckResult] = []
-    try:
-        deployments = state.list_deployments()
-    except Exception as exc:
-        return [CheckResult("warn", f"Could not list deployments: {exc}")]
-    if not deployments:
-        results.append(CheckResult("pass", "No cages configured"))
-        return results
-
-    for name in deployments:
-        try:
-            cfg = state.load_deployment_config(name)
-        except Exception:
-            results.append(CheckResult("warn", f"{name}: could not load config"))
-            continue
-
-        if cfg.isolation == "vm":
-            # Check Lima VM status
-            try:
-                from agentcage.lima.instance import LimaInstance
-                inst = LimaInstance(name)
-                if inst.is_running():
-                    results.append(CheckResult("pass", f"{name}: running (VM)"))
-                elif inst.exists():
-                    results.append(CheckResult("warn", f"{name}: VM exists but stopped"))
-                else:
-                    results.append(CheckResult("warn",
-                                               f"{name}: state exists, no VM (orphaned)",
-                                               hint=f"agentcage cage destroy {name}"))
-            except Exception:
-                results.append(CheckResult("warn", f"{name}: could not check VM status"))
-        else:
-            # Container mode: check if the main cage container is running
-            try:
-                backend = ContainerBackend()
-                if backend.is_running(name, "cage"):
-                    results.append(CheckResult("pass", f"{name}: running"))
-                else:
-                    results.append(CheckResult("warn",
-                                               f"{name}: stopped (state exists, no container)",
-                                               hint=f"agentcage cage start {name}"))
-            except Exception:
-                results.append(CheckResult("warn", f"{name}: could not check container status"))
-
-    return results
-
-
-# ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------
 
@@ -488,14 +429,6 @@ def _safe_check(fn, *args, label: str = "check") -> CheckResult:
         return fn(*args)
     except Exception as exc:
         return CheckResult("warn", f"{label} crashed: {exc}")
-
-
-def _safe_check_multi(fn, *args, label: str = "check") -> list[CheckResult]:
-    """Run a check function that returns a list, catching any unexpected exception."""
-    try:
-        return fn(*args)
-    except Exception as exc:
-        return [CheckResult("warn", f"{label} crashed: {exc}")]
 
 
 def run_doctor() -> list[CheckResult]:
@@ -545,12 +478,6 @@ def run_doctor() -> list[CheckResult]:
         network.results.append(_safe_check(check_port, port, label=f"port {port}"))
     _print_section(network)
     all_results.extend(network.results)
-
-    # --- Cages ---
-    cages = Section("Cages")
-    cages.results.extend(_safe_check_multi(check_cages, label="cage health"))
-    _print_section(cages)
-    all_results.extend(cages.results)
 
     # --- Summary ---
     errors = sum(1 for r in all_results if r.level == "error")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,7 +13,6 @@ from agentcage.doctor import (
     _detect_distro,
     _python_version_info,
     _safe_check,
-    _safe_check_multi,
     check_cgroup_v2,
     check_disk_space,
     check_dns,
@@ -25,7 +24,6 @@ from agentcage.doctor import (
     check_qemu,
     check_subnet_conflicts,
     check_systemd_linger,
-    check_cages,
     run_doctor,
 )
 
@@ -259,42 +257,6 @@ class TestCheckPort:
 
 
 # ---------------------------------------------------------------------------
-# Cage health checks
-# ---------------------------------------------------------------------------
-
-class TestCheckCages:
-    def test_no_deployments(self):
-        with patch("agentcage.state.list_deployments", return_value=[]):
-            results = check_cages()
-        assert len(results) == 1
-        assert results[0].level == "pass"
-
-    def test_running_container(self):
-        mock_cfg = MagicMock()
-        mock_cfg.isolation = "container"
-        with patch("agentcage.state.list_deployments", return_value=["test-cage"]):
-            with patch("agentcage.state.load_deployment_config", return_value=mock_cfg):
-                with patch("agentcage.backends.container.ContainerBackend.is_running",
-                           return_value=True):
-                    results = check_cages()
-        assert len(results) == 1
-        assert results[0].level == "pass"
-        assert "running" in results[0].message
-
-    def test_stopped_container(self):
-        mock_cfg = MagicMock()
-        mock_cfg.isolation = "container"
-        with patch("agentcage.state.list_deployments", return_value=["test-cage"]):
-            with patch("agentcage.state.load_deployment_config", return_value=mock_cfg):
-                with patch("agentcage.backends.container.ContainerBackend.is_running",
-                           return_value=False):
-                    results = check_cages()
-        assert len(results) == 1
-        assert results[0].level == "warn"
-        assert "stopped" in results[0].message
-
-
-# ---------------------------------------------------------------------------
 # Integration: run_doctor
 # ---------------------------------------------------------------------------
 
@@ -355,11 +317,6 @@ class TestRunDoctor:
         m = p.start()
         m.return_value.__enter__ = MagicMock(return_value=mock_sock)
         m.return_value.__exit__ = MagicMock(return_value=False)
-        patches.append(p)
-
-        # No cages
-        p = patch("agentcage.state.list_deployments", return_value=[])
-        p.start()
         patches.append(p)
 
         # Distro
@@ -471,22 +428,6 @@ class TestSafeCheck:
         assert "hello" in r.message
 
 
-class TestSafeCheckMulti:
-    def test_passes_through_normal_list(self):
-        def ok():
-            return [CheckResult("pass", "a"), CheckResult("warn", "b")]
-        results = _safe_check_multi(ok, label="test")
-        assert len(results) == 2
-
-    def test_catches_unexpected_exception(self):
-        def boom():
-            raise RuntimeError("kaboom")
-        results = _safe_check_multi(boom, label="cages")
-        assert len(results) == 1
-        assert results[0].level == "warn"
-        assert "crashed" in results[0].message
-
-
 # ---------------------------------------------------------------------------
 # Resilience: individual check error handling
 # ---------------------------------------------------------------------------
@@ -512,14 +453,6 @@ class TestCheckResilience:
                    side_effect=OSError("permission denied")):
             r = check_cgroup_v2()
         assert r.level == "warn"
-
-    def test_cages_list_deployments_failure(self):
-        with patch("agentcage.state.list_deployments",
-                   side_effect=RuntimeError("state dir corrupt")):
-            results = check_cages()
-        assert len(results) == 1
-        assert results[0].level == "warn"
-        assert "corrupt" in results[0].message
 
 
 # ---------------------------------------------------------------------------
@@ -582,7 +515,6 @@ class TestMacOS:
              patch("agentcage.doctor.shutil.disk_usage", return_value=usage), \
              patch("agentcage.doctor.socket.getaddrinfo", return_value=[("ok",)]), \
              patch("agentcage.doctor.socket.socket") as msock, \
-             patch("agentcage.state.list_deployments", return_value=[]), \
              patch("agentcage.doctor._detect_distro", return_value="unknown"):
             msock.return_value.__enter__ = MagicMock(return_value=mock_sock)
             msock.return_value.__exit__ = MagicMock(return_value=False)


### PR DESCRIPTION
## Why

`check_cages` (~55 LOC) duplicated `agentcage cage list` — and `cage list` has richer output one keystroke away. `doctor`'s job is "is your *system* ready to run cages", not "are your existing cages healthy".

## What changed

- `src/agentcage/doctor.py`: removed `check_cages()`, the now-unused `_safe_check_multi()` helper, and the `Cages` section from `run_doctor()`.
- `tests/test_doctor.py`: removed `TestCheckCages`, `TestSafeCheckMulti`, `TestCheckResilience.test_cages_list_deployments_failure`, and the dead `state.list_deployments` patches.
- `CHANGELOG.md`: `[Unreleased]` `### Changed` entry.

## Relationship to #79

This is the **rescoped half of #79** (`refactor/doctor-trim`). That PR bundled two cuts: `check_cages` removal **and** dropping the per-distro install-hint tables. The distro-table removal was dropped on review — those hints are good first-run UX (and were recently fixed for Arch). Only the `check_cages` half — a clean overlap removal — lands here. #79 is closed in favor of this.

## Test plan

- [x] `pytest tests/test_doctor.py` — 53 passed
- [x] `pytest tests/ --ignore=tests/e2e` — 1295 passed
- [x] `agentcage doctor` imports and runs; no `Cages` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)