### PR TITLE
fix: skip single-file volume sources on the Lima VM backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `agentcage run claude-code` (and any VM-isolation cage with a single-file volume) no longer aborts with `limactl create` fatal `field mounts[N].location refers to a non-directory path`. The claude-code scaffold mounts `~/.claude.json` — a single file — but Lima's virtiofs can only share directories. The Lima-config generator emitted the file as a `mounts[].location` anyway, so `limactl create` rejected the whole config and the cage never built. `_extra_mounts_for_volumes` now skips volume sources that are not directories (with a warning), and `generate_quadlets` drops the matching bind-mount on the VM backend so the cage still starts without it. The container backend is unaffected — podman bind-mounts single files directly, so `~/.claude.json` is still shared there.
+
 ## [0.17.0] - 2026-05-21
 
 ### Changed

--- a/src/agentcage/lima/provisioning.py
+++ b/src/agentcage/lima/provisioning.py
@@ -103,6 +103,20 @@ def _extra_mounts_for_volumes(volumes: list[str]) -> list[dict]:
             )
             continue
 
+        # Lima only virtiofs-shares directories. A volume whose host
+        # source is a single file (e.g. the claude-code scaffold's
+        # ~/.claude.json) makes `limactl create` fail fatally with
+        # "field mounts[N].location refers to a non-directory path".
+        # Skip it — the quadlet layer drops the matching bind-mount so
+        # the cage still starts, just without that file shared in.
+        if not os.path.isdir(host_path):
+            click.echo(
+                f"warning: not mounting {host_part!r} into the VM "
+                f"(Lima can only share directories, not single files)",
+                err=True,
+            )
+            continue
+
         if host_path in seen:
             continue
         seen.add(host_path)

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -280,6 +280,16 @@ def generate_quadlets(
             )
             continue
 
+        # VM backend: Lima only virtiofs-shares directories, so a
+        # file-source volume (e.g. ~/.claude.json) is never surfaced
+        # inside the VM. Emitting the bind-mount anyway makes podman
+        # auto-create an empty directory at the source — the agent then
+        # sees a directory where it expects a file. Drop it; the
+        # Lima-config layer already warned the user. Container mode
+        # bind-mounts files directly, so it keeps them.
+        if config.isolation == "vm" and not os.path.isdir(real):
+            continue
+
         expanded_volumes.append(expanded)
     expanded_env = {k: os.path.expandvars(str(v)) for k, v in cc.env.items()}
 

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -42,6 +42,8 @@ container:
     # Auth & settings — mount host ~/.claude so login persists across sessions.
     # Remove these lines to isolate cage state from the host.
     - "~/.claude:/home/node/.claude:rw"
+    # ~/.claude.json is a single file: shared on the container backend, but
+    # skipped on the VM backend (Lima virtiofs can only share directories).
     - "~/.claude.json:/home/node/.claude.json:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"

--- a/tests/test_lima_provisioning.py
+++ b/tests/test_lima_provisioning.py
@@ -332,6 +332,15 @@ class TestExtraMountsForVolumes:
         missing = tmp_path / "does-not-exist"
         assert _extra_mounts_for_volumes([f"{missing}:/x:rw"]) == []
 
+    def test_skips_file_host_path(self, tmp_path):
+        """A volume whose host source is a single file must not become a
+        Lima mount — `limactl create` fatals with "refers to a
+        non-directory path" because virtiofs only shares directories.
+        This is the claude-code scaffold's ~/.claude.json case."""
+        f = tmp_path / "config.json"
+        f.write_text("{}")
+        assert _extra_mounts_for_volumes([f"{f}:/home/node/.claude.json:rw"]) == []
+
     def test_expands_env_var_in_host_path(self, tmp_path, monkeypatch):
         """${PROJECT_DIR} (and friends) must be expanded, not passed
         through to Lima as a literal path."""

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -955,6 +955,44 @@ class TestCageQuadlet:
         content = files["test-cage.container"]
         assert "/home/node/.claude" not in content
 
+    def test_cage_skips_file_volume_on_vm(self, tmp_path, monkeypatch):
+        """On the VM backend a file-source volume is skipped — Lima only
+        virtiofs-shares directories, so the file is never inside the VM
+        and podman would auto-create an empty dir at the target."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".claude.json").write_text("{}")
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+              volumes:
+                - "~/.claude.json:/home/node/.claude.json:rw"
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-cage.container"]
+        assert "/home/node/.claude.json" not in content
+
+    def test_cage_keeps_file_volume_on_container(self, tmp_path, monkeypatch):
+        """Container mode bind-mounts a single file directly — podman
+        supports it, so a file-source volume must be preserved."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".claude.json").write_text("{}")
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+              volumes:
+                - "~/.claude.json:/home/node/.claude.json:rw"
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-cage.container"]
+        assert "/home/node/.claude.json" in content
+
     def test_cage_volume_outside_home_rejected(self, tmp_path):
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\


### PR DESCRIPTION
## Problem

`agentcage run claude-code` aborts on macOS at VM creation:

```
FATA[0000] field mounts[4].location refers to a non-directory path: "/Users/luca/.claude.json"
✗ Build failed
```

The claude-code scaffold declares a volume for `~/.claude.json` — a single file. Lima's virtiofs can only share **directories**. `_extra_mounts_for_volumes` filtered out blocked dirs, config-dir overlaps, and non-existent paths, but never checked whether an existing path was a file. So `.claude.json` got rendered into `lima.yaml` as `mounts[].location` and `limactl create` rejected the entire config — the cage never built.

This is the same fresh-Mac first-run class of bug as #101 and #107.

## Fix

- **`lima/provisioning.py`** — `_extra_mounts_for_volumes` skips volume sources that are not directories, with a warning. Stops the `limactl create` crash for any file-source volume, not just `.claude.json`.
- **`quadlets.py`** — `generate_quadlets` drops the matching bind-mount on the VM backend. Without this, podman inside the VM would auto-create an empty directory at the missing path and the agent would see a dir where it expects a file. Container mode is untouched — podman bind-mounts single files fine, so `~/.claude.json` is still shared there.
- **`scaffolds/claude-code/cage.yaml.j2`** — comment noting `~/.claude.json` is container-backend-only.

## Trade-off

On the VM backend `~/.claude.json` (Claude's global config) is no longer shared into the cage. Login still persists — the auth token lives in `~/.claude/.credentials.json` and the `~/.claude` directory still mounts fine. Lima genuinely cannot share a single file without mounting its parent (`$HOME`), which would defeat the security model. Skipping with a warning is the only non-regressing option.

## Tests

- `test_lima_provisioning.py::test_skips_file_host_path`
- `test_quadlets.py::test_cage_skips_file_volume_on_vm` + `test_cage_keeps_file_volume_on_container`
- Full suite: 1302 passed.
- Verified end-to-end: rendered the real claude-code VM scaffold — Lima mounts are now all directories, quadlet drops the `.claude.json` bind-mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)