### PR TITLE
fix: detach log-monitor stdin so VM cages don't double keystrokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Claude Code (and any interactive cage TUI) on the VM backend no longer needs every keystroke pressed twice. The proxy-log monitor spawned `podman logs -f` without detaching stdin; on the VM backend that command is wrapped in `limactl shell` → `ssh`, and `ssh` reads its inherited stdin to forward to the remote side. With the interactive `podman exec -it` session sharing the same controlling terminal, two `ssh` processes raced for the user's keystrokes and roughly half were swallowed by the log monitor. The monitor's subprocess now runs with `stdin=subprocess.DEVNULL`. The container backend was unaffected because `podman logs` runs there directly, with no `ssh` in the path.
+
 ## [0.17.1] - 2026-05-21
 
 ### Fixed

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -156,6 +156,15 @@ def _monitor_proxy(
     try:
         proc = subprocess.Popen(
             (podman_prefix or []) + ["podman", "logs", "-f", proxy_container],
+            # Detach stdin from the controlling terminal. On the VM
+            # backend the command is wrapped in `limactl shell` → ssh,
+            # and ssh reads its stdin to forward it to the remote side.
+            # If it inherits the terminal it races the interactive
+            # `podman exec -it` session for the user's keystrokes —
+            # roughly half are stolen, so every key has to be pressed
+            # twice. The monitor never reads stdin (the interactive
+            # domain prompt opens /dev/tty directly), so DEVNULL is safe.
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_interactive_domains.py
+++ b/tests/test_interactive_domains.py
@@ -1,6 +1,7 @@
 """Tests for interactive domain prompts in agentcage run."""
 
 import json
+import subprocess
 import threading
 from io import StringIO
 from unittest.mock import MagicMock, patch
@@ -158,6 +159,37 @@ class TestMonitorProxyInteractive:
         assert "blocked" in output
         assert "stripe.com" in output
         assert "Add stripe.com to allowlist?" in output
+
+    @patch("agentcage.run.subprocess.run")
+    @patch("agentcage.run.subprocess.Popen")
+    def test_log_monitor_detaches_stdin(self, mock_popen, mock_run):
+        """The proxy-log monitor must not let its subprocess inherit the
+        terminal. On the VM backend the command is wrapped in `limactl
+        shell` → ssh; ssh reads the controlling terminal and would steal
+        keystrokes from the interactive `podman exec -it` session — the
+        user ends up pressing every key twice. stdin must be DEVNULL."""
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([])
+        mock_proc.wait.return_value = 0
+        mock_popen.return_value = mock_proc
+
+        tty_output = _NoCloseStringIO()
+        stop = threading.Event()
+
+        with patch("builtins.open") as mock_open:
+            def open_side_effect(path, mode="r"):
+                if path == "/dev/tty" and mode == "w":
+                    return tty_output
+                raise OSError("no tty_r")
+            mock_open.side_effect = open_side_effect
+
+            _monitor_proxy(
+                "test-proxy", stop,
+                cage_name="test-cage", interactive=False,
+                podman_prefix=["limactl", "shell", "agentcage-test", "--"],
+            )
+
+        assert mock_popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
 
     @patch("agentcage.run.subprocess.run")
     @patch("agentcage.run.subprocess.Popen")


### PR DESCRIPTION
## Problem

Running Claude Code (or any interactive TUI) inside a Lima VM cage — `agentcage run claude-code` on macOS — every keystroke had to be pressed twice. The first press of each key was swallowed.

## Root cause

`_monitor_proxy` in `run.py` tails the proxy log by spawning `podman logs -f` with `subprocess.Popen`, but never set `stdin`. So the subprocess inherited the controlling terminal as its stdin.

On the VM backend the command is prefixed with `limactl shell <vm> --`, so it actually runs:

```
limactl shell agentcage-<cage> -- podman logs -f <cage>-proxy
```

`limactl shell` runs `ssh`. `ssh` reads its stdin to forward bytes to the remote side — and here that stdin is the user's iTerm2 terminal. Meanwhile the interactive session runs:

```
limactl shell agentcage-<cage> -- podman exec -it <cage>-cage claude
```

...which is a *second* `ssh` reading the *same* terminal. Two `ssh` processes racing for the same controlling terminal. The kernel hands each typed byte to exactly one reader, so roughly half the keystrokes were forwarded to `podman logs` (which ignores stdin) and lost. Hence "press every key twice."

The container backend never hit this — `podman_prefix` is empty there, so `podman logs` runs directly with no `ssh` in the path.

## Fix

One line: the log-monitor `Popen` now runs with `stdin=subprocess.DEVNULL`. The monitor never reads stdin — the interactive domain prompt (`-i`) opens `/dev/tty` directly on its own fd — so detaching stdin is safe and has no behavior change other than stopping `ssh` from stealing the terminal.

## Tests

- New `test_log_monitor_detaches_stdin` asserts the monitor's `Popen` is called with `stdin=subprocess.DEVNULL`.
- `tests/test_interactive_domains.py`: 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)