### PR TITLE
feat(scaffold): bigger default resources for the claude-code cage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The `claude-code` scaffold now defaults to larger resources: the Lima VM gets 4 vCPUs / 8 GiB (was 2 / 4 GiB) and the cage container limits are raised to 4 CPUs / 8 GiB (was 2.0 / 2 GiB). Coding agents are memory-hungry — builds, language servers, and large repos pushed the old 2 GiB container limit. Both values are still plain scaffold defaults; edit `cage.yaml` to tune them per cage.
+
 ### Fixed
 - Claude Code (and any interactive cage TUI) on the VM backend no longer needs every keystroke pressed twice. The proxy-log monitor spawned `podman logs -f` without detaching stdin; on the VM backend that command is wrapped in `limactl shell` → `ssh`, and `ssh` reads its inherited stdin to forward to the remote side. With the interactive `podman exec -it` session sharing the same controlling terminal, two `ssh` processes raced for the user's keystrokes and roughly half were swallowed by the log monitor. The monitor's subprocess now runs with `stdin=subprocess.DEVNULL`. The container backend was unaffected because `podman logs` runs there directly, with no `ssh` in the path.
 

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -22,8 +22,8 @@ name: {{ name }}
 isolation: vm
 
 vm:
-  vcpus: 2
-  mem_mb: 4096
+  vcpus: 4
+  mem_mb: 8192
 {% endif %}
 
 lifecycle: interactive
@@ -60,8 +60,8 @@ container:
     - "/tmp:rw,noexec,nosuid,size=256M"
 
   # Resource limits
-  memory: "2g"
-  cpus: "2.0"
+  memory: "8g"
+  cpus: "4.0"
 
   timeout_start_sec: 60
 


### PR DESCRIPTION
## What

Bump the default resources in the `claude-code` scaffold:

| | Before | After |
|---|---|---|
| VM | 2 vCPU / 4 GiB | **4 vCPU / 8 GiB** |
| Container limit | 2.0 CPU / 2 GiB | **4.0 CPU / 8 GiB** |

## Why

Coding agents are memory-hungry. Builds, language servers, test runners, and large repos routinely pushed past the old 2 GiB container limit, leading to OOM kills mid-task. 8 GiB / 4 cores is a saner floor for real work.

## Note on sizing

The Lima VM also hosts the proxy and DNS containers, so the cage container's 8 GiB limit equals the whole VM. The limit is a *cap*, not a reservation — normal sessions stay well under it, and the proxy + dns + guest OS need under ~1 GiB. If a cage genuinely saturates 8 GiB you'd want to bump `vm.mem_mb` higher than the container limit. Both are plain scaffold defaults in the generated `cage.yaml`, editable per cage.

Only the `claude-code` scaffold changes. Existing cages are unaffected — this is the template for newly created cages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)