### PR TITLE
fix(systemd): skip systemctl calls when unavailable (macOS)

### DIFF
--- a/src/agentcage/systemd.py
+++ b/src/agentcage/systemd.py
@@ -1,8 +1,16 @@
-"""Interact with systemd via systemctl --user."""
+"""Interact with systemd via systemctl --user.
+
+On platforms without systemd (notably macOS), ``systemctl`` is absent from
+``PATH``. The public functions in this module become no-ops in that case so
+that callers running on a host that genuinely has no systemd (e.g. cleaning
+up resources from a container-backed cage on macOS) do not crash with
+``FileNotFoundError``.
+"""
 
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 
@@ -18,17 +26,29 @@ def _systemctl_cmd() -> list[str]:
     return ["systemctl", "--user"]
 
 
+def _systemctl_available() -> bool:
+    return shutil.which("systemctl") is not None
+
+
 def daemon_reload() -> None:
+    if not _systemctl_available():
+        return
     subprocess.run([*_systemctl_cmd(), "daemon-reload"], check=True)
 
 
 def start_unit(name: str) -> None:
+    if not _systemctl_available():
+        return
     subprocess.run([*_systemctl_cmd(), "start", name], check=True)
 
 
 def stop_unit(name: str) -> None:
+    if not _systemctl_available():
+        return
     subprocess.run([*_systemctl_cmd(), "stop", name], check=True)
 
 
 def restart_unit(name: str) -> None:
+    if not _systemctl_available():
+        return
     subprocess.run([*_systemctl_cmd(), "restart", name], check=True)

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,82 @@
+"""Unit tests for agentcage.systemd."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agentcage import systemd
+
+
+# ---------------------------------------------------------------------------
+# _systemctl_cmd — preserve existing behavior
+# ---------------------------------------------------------------------------
+
+class TestSystemctlCmd:
+    def test_default_command(self):
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("agentcage.systemd.os.geteuid", return_value=1000):
+            assert systemd._systemctl_cmd() == ["systemctl", "--user"]
+
+    def test_runuser_when_sudo(self):
+        with patch.dict("os.environ", {"SUDO_USER": "alice"}, clear=True), \
+             patch("agentcage.systemd.os.geteuid", return_value=0):
+            assert systemd._systemctl_cmd() == [
+                "runuser", "-u", "alice", "--", "systemctl", "--user",
+            ]
+
+    def test_no_runuser_when_sudo_user_unset(self):
+        """Root without SUDO_USER (e.g. real root shell) should not wrap."""
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("agentcage.systemd.os.geteuid", return_value=0):
+            assert systemd._systemctl_cmd() == ["systemctl", "--user"]
+
+
+# ---------------------------------------------------------------------------
+# Public functions — invoke systemctl when available, no-op when not
+# ---------------------------------------------------------------------------
+
+PUBLIC_FUNCS = [
+    pytest.param(
+        lambda: systemd.daemon_reload(),
+        ["systemctl", "--user", "daemon-reload"],
+        id="daemon_reload",
+    ),
+    pytest.param(
+        lambda: systemd.start_unit("foo.service"),
+        ["systemctl", "--user", "start", "foo.service"],
+        id="start_unit",
+    ),
+    pytest.param(
+        lambda: systemd.stop_unit("foo.service"),
+        ["systemctl", "--user", "stop", "foo.service"],
+        id="stop_unit",
+    ),
+    pytest.param(
+        lambda: systemd.restart_unit("foo.service"),
+        ["systemctl", "--user", "restart", "foo.service"],
+        id="restart_unit",
+    ),
+]
+
+
+@pytest.mark.parametrize("invoke,expected_cmd", PUBLIC_FUNCS)
+def test_invokes_systemctl_when_available(invoke, expected_cmd):
+    with patch("agentcage.systemd.shutil.which", return_value="/usr/bin/systemctl"), \
+         patch("agentcage.systemd.subprocess.run") as mock_run, \
+         patch("agentcage.systemd.os.geteuid", return_value=1000), \
+         patch.dict("os.environ", {}, clear=True):
+        invoke()
+
+    mock_run.assert_called_once_with(expected_cmd, check=True)
+
+
+@pytest.mark.parametrize("invoke,expected_cmd", PUBLIC_FUNCS)
+def test_noop_when_systemctl_missing(invoke, expected_cmd):
+    """On hosts without systemctl (e.g. macOS), calls must not raise."""
+    with patch("agentcage.systemd.shutil.which", return_value=None), \
+         patch("agentcage.systemd.subprocess.run") as mock_run:
+        invoke()  # must not raise
+
+    mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

`agentcage cage rm` aborts mid-cleanup on macOS with `FileNotFoundError: 'systemctl'`. The container backend's `destroy_resources()` removes quadlet files, then calls `systemd.daemon_reload()` unconditionally — but macOS has no `systemctl`. The earlier `stop_unit` calls are wrapped in try/except (`backends/container.py:106-109`); `daemon_reload` is not.

Reproduction (on macOS):

```
$ agentcage cage rm -y claude-code-fast-elm
Stopping services...
warning: failed to stop claude-code-fast-elm-cage: [Errno 2] No such file or directory: 'systemctl'
warning: failed to stop claude-code-fast-elm-proxy: [Errno 2] No such file or directory: 'systemctl'
warning: failed to stop claude-code-fast-elm-dns: [Errno 2] No such file or directory: 'systemctl'
Removing resources...
Traceback (most recent call last):
  ...
  File ".../agentcage/backends/container.py", line 137, in destroy_resources
    systemd.daemon_reload()
  File ".../agentcage/systemd.py", line 22, in daemon_reload
    subprocess.run([*_systemctl_cmd(), "daemon-reload"], check=True)
  ...
FileNotFoundError: [Errno 2] No such file or directory: 'systemctl'
```

Effect: podman network, volumes, and scoped secrets are leaked because the destroy short-circuits before reaching the podman cleanup at `container.py:140-152`.

## Unguarded sites this affects

| File:Line | Call |
|---|---|
| `backends/container.py:79` | `daemon_reload` (install path) |
| `backends/container.py:137` | `daemon_reload` (destroy — the crash) |
| `backends/container.py:100` | `start_unit` (install path) |
| `cli.py:2332` | `daemon_reload` (dns quadlet update) |

## Fix

Make `systemd.py` platform-aware: each public function checks `shutil.which("systemctl")` and returns silently if absent. One localized change covers all four callers consistently.

## Trade-off worth flagging at review

`start_unit` becoming a silent no-op means `ContainerBackend.install_units()` on macOS will print `Started {name}-cage` while nothing actually started. Acceptable in practice because:

- The default backend on macOS is already VM (lima) — see `run.py:291`.
- The container backend on macOS is opt-in via `--isolation container`.
- Earlier failures (podman/quadlet availability) would already surface in that flow.

A stricter alternative would be to keep `start_unit` raising and only neutralize the idempotent calls (`daemon_reload`, `stop_unit`, `restart_unit`). Happy to switch if preferred.

## Test plan

- [x] New `tests/test_systemd.py` (11 cases) covers each public function under both branches (systemctl present → calls `subprocess.run` with expected args; systemctl missing → no call, no exception). Plus regression coverage on `_systemctl_cmd()` for the `SUDO_USER`/root branch.
- [x] `uv run pytest tests/test_systemd.py tests/test_container_backend.py` — 29 passed.
- [x] Full `uv run pytest` on this branch vs `master` — no regressions; one pre-existing macOS-environment failure (`test_secret_cli.py::test_set_reloads_running_deployment`) now passes thanks to this fix.
- [x] End-to-end: reinstalled patched build via `uv tool install --reinstall`, ran `agentcage cage rm -y claude-code-fast-elm` — cleanup now completes without traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)