### PR TITLE
fix: VM cage audit/logs return empty due to wrong journal + stale session groups

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1315,16 +1315,21 @@ def _level_grep_pattern(services: tuple, min_level: str | None) -> str:
 def _logs_vm(name, services, lines, no_follow, min_level=None):
     """Show logs from inside the Lima VM via limactl shell."""
     inst = LimaInstance(name)
-    # Inside the VM, journalctl works normally with the quadlet services
+    # Quadlets run as systemd --user units, but conmon writes their logs to
+    # the system journal — so query via --user-unit. Lima's persistent SSH
+    # ControlMaster is established before provisioning runs `usermod -aG
+    # systemd-journal`, so the SSH session lacks the group; `sg` adds it
+    # for the journalctl process.
     units = [f"{name}-{svc}" for svc in services]
-    cmd = ["journalctl", "--user"]
+    inner = ["journalctl"]
     for u in units:
-        cmd += ["-u", u]
-    cmd += ["-n", str(lines), "-o", "cat"]
+        inner += ["--user-unit", u]
+    inner += ["-n", str(lines), "-o", "cat"]
     if not no_follow:
-        cmd.append("-f")
+        inner.append("-f")
 
-    full_cmd = ["limactl", "shell", inst.name, "--"] + cmd
+    full_cmd = ["limactl", "shell", inst.name, "--",
+                "sg", "systemd-journal", "-c", shlex.join(inner)]
     if min_level is None:
         os.execvp("limactl", full_cmd)
     else:
@@ -1465,22 +1470,34 @@ def _build_audit_journal_cmd(
 ) -> list[str]:
     """Build the journalctl command for reading audit entries."""
     if cfg.isolation == "vm":
-        inst = LimaInstance(name)
-        cmd = ["limactl", "shell", inst.name, "--",
-               "journalctl", "--user", "-u", f"{name}-proxy", "-u", f"{name}-dns", "-o", "cat"]
+        # In VM mode the proxy/dns are systemd --user services, but conmon
+        # routes their logs to the system journal — so the right filter is
+        # --user-unit, not "--user -u". And Lima's persistent SSH
+        # ControlMaster is established before provisioning runs `usermod
+        # -aG systemd-journal`, so the SSH session inherits stale groups
+        # and the user can't read system.journal directly. `sg
+        # systemd-journal -c '...'` adds the missing group for the
+        # journalctl process, which works for both existing and new VMs.
+        journal_cmd = ["journalctl", "--user-unit", f"{name}-proxy",
+                       "--user-unit", f"{name}-dns", "-o", "cat"]
     else:
-        cmd = ["journalctl", "--user", "-u", f"{name}-proxy", "-u", f"{name}-dns", "-o", "cat"]
+        journal_cmd = ["journalctl", "--user", "-u", f"{name}-proxy",
+                       "-u", f"{name}-dns", "-o", "cat"]
 
     if since:
-        cmd += ["--since", _normalize_since(since)]
+        journal_cmd += ["--since", _normalize_since(since)]
 
     if follow:
-        cmd.append("-f")
+        journal_cmd.append("-f")
     else:
         # Over-read: many lines aren't audit entries
-        cmd += ["-n", "10000"]
+        journal_cmd += ["-n", "10000"]
 
-    return cmd
+    if cfg.isolation == "vm":
+        inst = LimaInstance(name)
+        return ["limactl", "shell", inst.name, "--",
+                "sg", "systemd-journal", "-c", shlex.join(journal_cmd)]
+    return journal_cmd
 
 
 def _audit_batch(name, cfg, filt, lines, since, as_json, no_color):

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -833,16 +833,15 @@ class TestCageLogs:
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
     def test_logs_vm_default(self, mock_state, mock_execvp, MockLimaInstance):
-        """All services requested → limactl shell + journalctl with all units."""
+        """All services requested → limactl shell + sg systemd-journal -c journalctl --user-unit."""
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("vm")
         MockLimaInstance.return_value.name = "agentcage-basic"
         result = _runner().invoke(main, ["cage", "logs", "basic"])
         mock_execvp.assert_called_once_with("limactl", [
             "limactl", "shell", "agentcage-basic", "--",
-            "journalctl", "--user",
-            "-u", "basic-cage", "-u", "basic-proxy", "-u", "basic-dns",
-            "-n", "50", "-o", "cat",
+            "sg", "systemd-journal", "-c",
+            "journalctl --user-unit basic-cage --user-unit basic-proxy --user-unit basic-dns -n 50 -o cat",
         ])
 
     @patch("agentcage.cli.subprocess.Popen")
@@ -863,11 +862,12 @@ class TestCageLogs:
             "cage", "logs", "basic", "-s", "proxy", "--no-follow", "-l", "warning",
         ])
 
-        # Should call Popen with limactl shell
+        # Should call Popen with limactl shell wrapping journalctl in sg systemd-journal -c
         call_args = mock_popen.call_args[0][0]
         assert call_args[0] == "limactl"
         assert "agentcage-basic" in call_args
-        assert "basic-proxy" in call_args
+        assert "sg" in call_args and "systemd-journal" in call_args
+        assert "basic-proxy" in call_args[-1]
         mock_execvp.assert_not_called()
 
     @patch("agentcage.cli.subprocess.Popen")
@@ -882,11 +882,12 @@ class TestCageLogs:
         result = _runner().invoke(main, [
             "cage", "logs", "basic", "-s", "proxy", "-s", "dns",
         ])
-        # execvp called with limactl and both units
+        # execvp called with limactl wrapping journalctl in sg systemd-journal -c
         mock_execvp.assert_called_once()
         call_args = mock_execvp.call_args[0][1]
-        assert "basic-proxy" in call_args
-        assert "basic-dns" in call_args
+        assert "sg" in call_args and "systemd-journal" in call_args
+        assert "basic-proxy" in call_args[-1]
+        assert "basic-dns" in call_args[-1]
 
 
 # ── sample audit JSON lines ──────────────────────────────
@@ -969,11 +970,12 @@ class TestCageAudit:
         assert result.exit_code == 0
         assert "evil.com" in result.output
 
-        # Verify command uses limactl shell with proxy unit
+        # Verify command uses limactl shell + sg systemd-journal -c wrapping journalctl
         cmd = mock_popen.call_args[0][0]
         assert cmd[0] == "limactl"
         assert "agentcage-myvm" in cmd
-        assert "myvm-proxy" in cmd
+        assert "sg" in cmd and "systemd-journal" in cmd
+        assert "myvm-proxy" in cmd[-1]
 
     @patch("agentcage.cli.subprocess.Popen")
     @patch("agentcage.cli.state")


### PR DESCRIPTION
## Summary

`agentcage cage audit <vm-cage>` (and `cage logs`) prints

```
No journal files were opened due to insufficient permissions.
```

and returns nothing, on every running VM cage on macOS.

Two root causes, both addressed in `cli.py`:

1. **Wrong journal queried.** The proxy/dns services run under `systemctl --user`, but `conmon` writes their container output to the *system* journal — there is no `user-<uid>.journal` on disk. The existing `journalctl --user -u <unit>` therefore returns nothing. The correct filter is `--user-unit <unit>`, which matches user-scoped units regardless of which journal they were written to.
2. **Stale supplementary groups in the SSH session.** Provisioning runs `usermod -aG systemd-journal $lima_user`, but Lima establishes its persistent SSH ControlMaster *before* the system-mode provision step runs, so every `limactl shell` reuses an SSH session whose process groups don't include `systemd-journal` (visible via `id`). `bash -l` doesn't refresh that — only a real group-switch does. Wrapping the inner command in `sg systemd-journal -c '…'` re-fetches the group via NSS for the journalctl process.

The fix combines both — VM-mode `audit` and `logs` now invoke:

```
limactl shell <inst> -- sg systemd-journal -c "journalctl --user-unit <name>-proxy --user-unit <name>-dns -o cat …"
```

No provisioning change is required, so this works on already-running VM cages without re-provisioning.

## Test plan

- [x] Unit tests for `cage audit` and `cage logs` in `tests/test_cage_cli.py` updated to assert the new `sg systemd-journal -c` wrapping; all 10 affected tests pass.
- [x] End-to-end verified on a fresh VM cage (`isolation: vm`) on macOS:
  - `cage audit <name>` returns both allowed and blocked entries.
  - `cage audit <name> --summary` returns correct aggregates.
  - `cage audit <name> --since 1h` and `cage audit <name> -d blocked` filters work.
  - `cage logs <name>` returns service output.
- [x] No change in container-isolation mode.