### PR TITLE
fix(vm): enable linger by sentinel file, not loginctl

### DIFF
--- a/src/agentcage/templates/lima/provision.sh.j2
+++ b/src/agentcage/templates/lima/provision.sh.j2
@@ -41,7 +41,17 @@ mkdir -p /var/log/journal
 systemd-tmpfiles --create --prefix /var/log/journal
 chmod -R g+rX /var/log/journal
 
-# Enable lingering for the cage user so systemd user services persist
-loginctl enable-linger "$lima_user"
+# Enable lingering for the cage user so systemd user services persist.
+# Touch the sentinel file directly rather than running
+# `loginctl enable-linger`: the latter goes through systemd-logind over
+# D-Bus, and during cloud-init that call has been observed to deadlock
+# (the preceding `usermod -aG` on the user who already has an active
+# SSH session leaves logind unresponsive — its dbus calls then time out
+# at 25 s). Once wedged, every subsequent ssh login fails with
+# `pam_systemd: Failed to create session: Connection timed out`, which
+# wedges the entire agentcage flow. The sentinel file is logind's own
+# state, so writing it has the same effect without round-tripping dbus.
+mkdir -p /var/lib/systemd/linger
+touch "/var/lib/systemd/linger/$lima_user"
 
 echo "agentcage provisioning complete"

--- a/tests/test_lima_provisioning.py
+++ b/tests/test_lima_provisioning.py
@@ -185,8 +185,27 @@ class TestGenerateLimaConfig:
         output = generate_lima_config(cfg)
         expected_user = pwd.getpwuid(os.getuid()).pw_name
         assert f'lima_user="{expected_user}"' in output
-        assert 'enable-linger "$lima_user"' in output
+        # Linger is enabled by touching the sentinel file directly (the
+        # loginctl/dbus path was observed to deadlock during cloud-init).
+        assert '/var/lib/systemd/linger/$lima_user' in output
         assert "LIMA_CIDATA" not in output
+
+    def test_provision_does_not_call_loginctl_enable_linger(self):
+        """`loginctl enable-linger` goes through systemd-logind over D-Bus.
+        During cloud-init that call has been observed to deadlock for the
+        rest of the boot (the preceding `usermod -aG` on a user with an
+        active SSH session can leave logind unresponsive). The provision
+        script must instead write logind's own linger sentinel file."""
+        cfg = MockConfig(name="test-cage")
+        output = generate_lima_config(cfg)
+        # An actual command invocation always sits at the start of a line
+        # (possibly after whitespace). Ignore matches inside comments.
+        code_lines = [
+            ln for ln in output.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        assert not any("loginctl" in ln for ln in code_lines)
+        assert "/var/lib/systemd/linger" in output
 
     def test_name_in_comment(self):
         cfg = MockConfig(name="my-agent")


### PR DESCRIPTION
## Summary

`loginctl enable-linger` goes through systemd-logind over D-Bus. During cloud-init that call has been observed to deadlock for the rest of the boot, wedging the entire agentcage flow.

## What I observed

For an `agentcage run claude-code` against a fresh Lima VM (Ubuntu 24.04, systemd 255), the cage stalled after Lima reported READY. Inside the VM:

```
15:04:08  usermod -aG systemd-journal luca
15:04:08  usermod -aG adm luca
15:04:33  cloud-init: Could not enable linger: Connection timed out
15:04:33  cloud-final.service: Failed with result 'exit-code'
15:05:04  sshd: pam_systemd(sshd:session): Failed to create session: Connection timed out
15:07:04  sshd: pam_systemd(sshd:session): Failed to create session: Connection timed out
```

`systemd-logind` was burning ~100% CPU. New SSH logins still got a shell but no working user D-Bus / XDG_RUNTIME_DIR, so the agentcage `bridge_secrets` step's `podman secret rm` (over SSH) fell back to the system bus and futex-deadlocked for ~24 minutes before returning. The `usermod -aG` against a user with an already-active SSH session (the one Lima opened to drive provisioning) appears to leave logind in a state where the dbus call from `loginctl` deadlocks; after that, sessions can't be created for the rest of the boot.

## Fix

Write logind's own linger sentinel file directly instead of round-tripping the D-Bus call. `/var/lib/systemd/linger/<user>` is what `loginctl enable-linger` ultimately creates — touching it has the same effect and has no dependency on logind being responsive.

## Test plan

- [x] `pytest tests/test_lima_provisioning.py` (41 passed) — including a new `test_provision_does_not_call_loginctl_enable_linger`
- [x] Full e2e: destroy a wedged cage, reinstall from this branch, create a fresh `claude-code` cage and confirm it reaches READY without the bridge_secrets hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)