### PR TITLE
feat: add pi.dev scaffold

### DIFF
--- a/src/agentcage/scaffolds/pi/Containerfile
+++ b/src/agentcage/scaffolds/pi/Containerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         python3 \
         ripgrep \
-    && rm -rf /var/lib/apt/lists/*
+        fd-find \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd
 
 # Install Pi coding agent (latest stable).
 # --ignore-scripts mirrors the official install command from

--- a/src/agentcage/scaffolds/pi/Containerfile
+++ b/src/agentcage/scaffolds/pi/Containerfile
@@ -1,0 +1,22 @@
+FROM docker.io/library/node:22-slim
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+        curl \
+        openssh-client \
+        build-essential \
+        python3 \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Pi coding agent (latest stable).
+# --ignore-scripts mirrors the official install command from
+# https://pi.dev/docs/latest — it skips lifecycle hooks that pi does not need.
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+
+# node:22-slim already has user node (1000:1000)
+USER node
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/pi/README.md
+++ b/src/agentcage/scaffolds/pi/README.md
@@ -1,0 +1,165 @@
+# Pi Setup Guide
+
+[Pi](https://pi.dev/docs/latest) is a minimal terminal coding harness — an extensible CLI for AI-assisted coding that supports multiple model providers and is also embeddable as a Node.js SDK. This guide shows how to run it inside an agentcage sandbox -- a rootless Podman container with no direct internet access where all HTTP traffic is inspected by mitmproxy for domain filtering, secret leak detection, and payload analysis.
+
+For the full list of configuration options, see the [Configuration Reference](../../docs/configuration.md).
+
+## Prerequisites
+
+- [Podman](https://podman.io/) (rootless), Python 3.12+, and [uv](https://docs.astral.sh/uv/) -- see [installation instructions](../../README.md#install) for your platform
+- An Anthropic API key (`ANTHROPIC_API_KEY`), an OpenAI API key (`OPENAI_API_KEY`), or a subscription you can `/login` into from inside the cage
+
+## Quick start
+
+There are two ways to run Pi in a cage: a one-command ephemeral session with `agentcage run`, or a persistent cage managed with `agentcage cage` commands.
+
+### Ephemeral session (`agentcage run`)
+
+The fastest way to get started. Builds the image, creates a temporary cage, drops you into an interactive Pi session, and tears down the cage when you exit.
+
+```bash
+# API key auth (Anthropic)
+agentcage run pi -s ANTHROPIC_API_KEY
+
+# OpenAI instead — also uncomment the OPENAI_API_KEY block in cage.yaml
+agentcage run pi -s OPENAI_API_KEY
+
+# With a specific project directory
+agentcage run pi -s ANTHROPIC_API_KEY --project ~/myrepo
+```
+
+You'll be prompted to enter the API key value on first run. The cage is removed on exit; audit logs are preserved.
+
+### Persistent interactive cage (`agentcage cage`)
+
+Use this when you want the cage to survive across sessions -- for example, to keep `/login` credentials, run multiple `cage exec` sessions against the same cage, or inspect traffic after the fact.
+
+#### 1. Scaffold the config
+
+```bash
+agentcage init myagent --scaffold pi
+```
+
+This creates `cage.yaml` with sensible defaults and auto-builds the `agentcage-scaffold-pi:latest` image. Review the config and adjust as needed.
+
+#### 2. Authenticate
+
+**Subscription — log in inside the cage:**
+
+```bash
+agentcage cage create -c cage.yaml
+agentcage cage exec myagent -- pi
+# then type /login at the Pi prompt
+```
+
+Follow the URL to authenticate. Credentials are saved under the `~/.pi` volume mount, so they persist across sessions.
+
+**API key (Anthropic):**
+
+```bash
+agentcage secret set myagent ANTHROPIC_API_KEY
+agentcage cage create -c cage.yaml
+```
+
+The scaffold uses `secret_injection` for the API key. Pi sends the placeholder `{{ANTHROPIC_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
+
+**API key (OpenAI):**
+
+```bash
+agentcage secret set myagent OPENAI_API_KEY
+# uncomment the OPENAI_API_KEY block under secret_injection in cage.yaml
+# uncomment the openai.com line under domains.allow
+agentcage cage create -c cage.yaml
+```
+
+#### 3. Start a session
+
+```bash
+agentcage cage exec myagent -- pi
+```
+
+The cage uses `lifecycle: interactive`, so the container stays up (via `sleep infinity`) but systemd will not auto-restart it if stopped. You can open multiple concurrent `cage exec` sessions against the same cage.
+
+#### 4. Verify
+
+```bash
+# Check containers are running
+agentcage cage list
+
+# View logs
+agentcage cage logs myagent           # cage container
+agentcage cage logs myagent -s proxy  # mitmproxy (traffic inspection)
+agentcage cage logs myagent -s dns    # DNS sidecar
+```
+
+### Running as a service
+
+To run Pi as a long-running service cage (e.g. for a headless agent embedded via Pi's SDK), change the lifecycle and command in `cage.yaml`:
+
+```yaml
+lifecycle: service
+
+container:
+  command: ["node", "/workspace/your-pi-sdk-entry.js"]
+```
+
+With `lifecycle: service`, systemd auto-restarts the container on failure and starts it on boot. Use `cage logs` to follow output instead of `cage exec`.
+
+See [Pi SDK docs](https://pi.dev/docs/latest/sdk) for embedding the agent in a Node.js entrypoint.
+
+## Managing your cage
+
+See [Managing Your Cage](../../docs/cage-management.md) for common operations (edit, update, restart, audit, destroy) and troubleshooting.
+
+## Configuration
+
+### Volumes
+
+The scaffold mounts two paths from the host:
+
+- `${PROJECT_DIR}:/workspace:rw` -- your project directory (set by `agentcage init`)
+- `~/.pi:/home/node/.pi:rw` -- Pi global config, auth, and session state
+
+Remove the `~/.pi` mount to fully isolate the cage from host state. Git config and SSH known hosts mounts are commented out in `cage.yaml` -- uncomment them if you need git push.
+
+### Secret injection
+
+The scaffold pre-configures secret injection for the Anthropic API key. Two more rules ship commented out in `cage.yaml`:
+
+- `OPENAI_API_KEY` — for Pi sessions targeting OpenAI models.
+- `GITHUB_TOKEN` — GitHub push over HTTPS.
+
+Uncomment the block you need and set the secret:
+
+```bash
+agentcage secret set myagent GITHUB_TOKEN
+```
+
+Injected secrets are swapped by the proxy on the wire — the real value never enters the cage, the cage env only ever holds the `{{PLACEHOLDER}}`.
+
+### Domain allowlist
+
+The scaffold organizes domains into tiers:
+
+**AI provider** (Anthropic by default):
+- `anthropic.com`, `claude.com`
+
+**Pi update + auth**:
+- `pi.dev`
+
+**Package registries**:
+- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org`
+
+**Code hosting** (commented out):
+- `github.com`, `githubusercontent.com`
+
+**Other providers** (commented out):
+- `openai.com` — uncomment alongside the matching `secret_injection` rule
+
+Subdomains are matched automatically -- adding `anthropic.com` also allows `api.anthropic.com`. Sibling domains are not matched.
+
+## Troubleshooting
+
+**`/login` fails inside the cage**: make sure `pi.dev` is in the domain allowlist (it is by default in this scaffold) — Pi resolves OAuth flows through `pi.dev`.
+
+**Pi can reach the model provider but not its own update server**: `pi.dev` covers the update + auth endpoints. To suppress update checks entirely, set `PI_SKIP_VERSION_CHECK=1` in the cage env.

--- a/src/agentcage/scaffolds/pi/README.md
+++ b/src/agentcage/scaffolds/pi/README.md
@@ -147,8 +147,8 @@ The scaffold organizes domains into tiers:
 **Pi update + auth**:
 - `pi.dev`
 
-**Package registries**:
-- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org`
+**Package registries** (commented out):
+- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org` — pi's deps are installed at image-build time, so the running cage doesn't need them. Uncomment if your agent runs `npm install` / `pip install` in the workspace.
 
 **Code hosting** (commented out):
 - `github.com`, `githubusercontent.com`

--- a/src/agentcage/scaffolds/pi/cage.yaml.j2
+++ b/src/agentcage/scaffolds/pi/cage.yaml.j2
@@ -1,0 +1,147 @@
+# agentcage configuration for {{ name }} (Pi scaffold)
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Start a session:
+#        agentcage cage exec {{ name }} -- pi
+#   3. Or use the run command:
+#        agentcage run pi
+#
+# Authentication — pick one:
+#   A — Interactive login inside the cage (subscription providers):
+#     agentcage cage exec {{ name }} -- pi
+#     # then type /login at the prompt
+#     # credentials are saved in the ~/.pi volume
+#
+#   B — API key (Anthropic):
+#     agentcage secret set {{ name }} ANTHROPIC_API_KEY
+#     agentcage cage restart {{ name }}
+#
+#   C — API key (OpenAI):
+#     agentcage secret set {{ name }} OPENAI_API_KEY
+#     # also uncomment the OPENAI_API_KEY block under secret_injection
+#     agentcage cage restart {{ name }}
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 4
+  mem_mb: 8192
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: pi
+
+container:
+  image: "localhost/agentcage-scaffold-pi:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+    # Auth & settings — mount host ~/.pi so /login persists across sessions.
+    # Pi stores global config at ~/.pi/agent/settings.json and per-session
+    # state under ~/.pi/ as well. Remove this line to isolate cage state
+    # from the host.
+    - "~/.pi:/home/node/.pi:rw"
+  #  # Git config (uncomment to enable)
+  #  - "~/.gitconfig:/home/node/.gitconfig:ro"
+  #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
+
+  # Map host UID into container so mounted files have correct ownership
+  userns: "keep-id"
+  user: ""
+
+  # Coding agents need to write to various paths in the home directory
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=256M"
+
+  # Resource limits
+  memory: "8g"
+  cpus: "4.0"
+
+  timeout_start_sec: 60
+
+# ── Secret injection ──
+# API keys are swapped by the proxy — the cage only sees placeholders.
+# Create each secret:  agentcage secret set {{ name }} ANTHROPIC_API_KEY
+secret_injection:
+  - env: ANTHROPIC_API_KEY
+    placeholder: "{%raw%}{{ANTHROPIC_API_KEY}}{%endraw%}"
+    inject_to:
+      - anthropic.com
+
+  # Uncomment if you want Pi to talk to OpenAI models:
+  #- env: OPENAI_API_KEY
+  #  placeholder: "{%raw%}{{OPENAI_API_KEY}}{%endraw%}"
+  #  inject_to:
+  #    - openai.com
+
+  # Uncomment for GitHub push via HTTPS:
+  #- env: GITHUB_TOKEN
+  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  inject_to:
+  #    - github.com
+
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "anthropic.com" also allows
+# "api.anthropic.com").
+domains:
+  allow:
+    # ── AI providers ──
+    - anthropic.com
+    - claude.com
+    # Uncomment for OpenAI models:
+    #- openai.com
+
+    # ── Pi update + auth endpoints ──
+    - pi.dev
+
+    # ── Package registries ──
+    - npmjs.org
+    - npmjs.com
+    - pypi.org
+    - files.pythonhosted.org
+    - nodejs.org
+
+    # ── Code hosting (uncomment for git push) ──
+    #- github.com
+    #- githubusercontent.com
+
+    # Add domains your agent needs access to:
+    #- example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+  # Add `- name: entropy` to also flag encrypted/compressed payloads
+  # (off by default — it false-positives on legitimate high-entropy data).
+
+# ── Exec aliases ──
+exec_aliases:
+  pi: ["pi"]
+
+# ── Help ──
+help: |
+  Start a Pi session:
+    agentcage cage exec {{ name }} -- pi
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run pi
+
+  Authentication:
+    Subscription: agentcage cage exec {{ name }} -- pi   (then /login)
+    API key:      agentcage secret set {{ name }} ANTHROPIC_API_KEY

--- a/src/agentcage/scaffolds/pi/cage.yaml.j2
+++ b/src/agentcage/scaffolds/pi/cage.yaml.j2
@@ -105,12 +105,16 @@ domains:
     # ── Pi update + auth endpoints ──
     - pi.dev
 
-    # ── Package registries ──
-    - npmjs.org
-    - npmjs.com
-    - pypi.org
-    - files.pythonhosted.org
-    - nodejs.org
+    # ── Package registries (commented out by default) ──
+    # Pi installs npm + apt deps at image-build time (see Containerfile),
+    # so the running cage doesn't need access to public package indexes.
+    # Uncomment the ones you need if your agent installs packages at
+    # runtime (e.g. `npm install` in /workspace, `pip install`, etc.).
+    #- npmjs.org
+    #- npmjs.com
+    #- pypi.org
+    #- files.pythonhosted.org
+    #- nodejs.org
 
     # ── Code hosting (uncomment for git push) ──
     #- github.com

--- a/src/agentcage/scaffolds/pi/scaffold.yaml
+++ b/src/agentcage/scaffolds/pi/scaffold.yaml
@@ -1,0 +1,12 @@
+description: "Pi.dev terminal coding harness"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-pi:latest"
+    containerfile: "Containerfile"
+    cap_add: [CAP_SETFCAP, CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- pi"
+  - "Or use: agentcage run pi"


### PR DESCRIPTION
## Summary
- Adds a new built-in scaffold for [Pi](https://pi.dev/docs/latest), Earendil's minimal terminal coding harness, mirroring the existing `codex` and `claude-code` patterns.
- Container image installs `@earendil-works/pi-coding-agent` globally on `node:22-slim` via the official `--ignore-scripts` install line.
- `cage.yaml.j2` wires Anthropic by default (placeholder-substituted by the proxy); OpenAI and `GITHUB_TOKEN` rules ship commented out. Allowlist covers `anthropic.com`, `claude.com`, `pi.dev`, and the usual package registries. Mounts `~/.pi` so `/login` credentials and session state persist across runs.
- README adapted from the codex/claude-code guides.

No Python changes required — `list_scaffolds()` auto-discovers the new directory. Verified locally:

```
scaffolds: ['claude-code', 'codex', 'openclaw', 'pi']
```

Rendered config parses through `load_config` + `validate_config` with zero errors in both container and VM modes.

## Test plan
- [ ] `agentcage init myagent --scaffold pi` creates a valid `cage.yaml`
- [ ] `agentcage cage create -c cage.yaml` builds and starts the cage
- [ ] `agentcage cage exec myagent -- pi` drops into an interactive Pi session
- [ ] `/login` flow inside the cage reaches `pi.dev` and persists credentials in the `~/.pi` mount
- [ ] `ANTHROPIC_API_KEY` injection works end-to-end (placeholder swapped on the wire to `anthropic.com`)
- [ ] `agentcage init myagent --scaffold pi --isolation vm` renders the VM block and creates a working Lima cage

🤖 Generated with [Claude Code](https://claude.com/claude-code)