### PR TITLE
fix(update): preserve existing network octets on cage update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `agentcage cage update <name>` no longer regenerates quadlets with a fresh network octet that doesn't match the existing `<name>-net` podman network. On a single-cage system the hash-based allocator could land on a different octet at update time than at create time (because the cage being updated was excluded from the "used" set, so create-time collision resolution didn't reproduce), causing the DNS sidecar to fail at start with `Error: requested static ip 10.89.X.10 not in any subnet on network <name>-net` and cascading to the cage + proxy as dependency failures. `cage update` now reads the persisted `network_octet` from the cage's `metadata.json` and pins the subnet to the original allocation. The fix threads a new `network_octet` parameter through `build_and_deploy → generate_units → generate_quadlets → cage_network_addrs`; when set, it bypasses hash-based allocation entirely. New regression tests in `test_cage_cli.py` cover the CLI, the renderer, and the `services.build_and_deploy` plumbing.
+
 ## [0.17.5] - 2026-05-24
 
 ### Fixed

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -75,9 +75,18 @@ class ContainerBackend:
         patches_host_dir: str,
         deploy_name: str,
         used_octets: set[int] | None = None,
+        network_octet: int | None = None,
     ) -> dict[str, str]:
         rootless = self._podman.info().get("host", {}).get("security", {}).get("rootless", True)
-        return generate_quadlets(config, config_host_path, patches_host_dir, deploy_name, rootless=rootless, used_octets=used_octets)
+        return generate_quadlets(
+            config,
+            config_host_path,
+            patches_host_dir,
+            deploy_name,
+            rootless=rootless,
+            used_octets=used_octets,
+            network_octet=network_octet,
+        )
 
     def unit_dir(self) -> Path:
         return Path(os.path.expanduser("~/.config/containers/systemd"))

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -139,11 +139,19 @@ class VmBackend:
         patches_host_dir: str,
         deploy_name: str,
         used_octets: set[int] | None = None,
+        network_octet: int | None = None,
     ) -> dict[str, str]:
         """Generate Lima YAML as the primary 'unit', plus quadlet files for inside the VM."""
         lima_yaml = generate_lima_config(config)
         # Also generate quadlets (these will be installed inside the VM)
-        quadlets = generate_quadlets(config, config_host_path, patches_host_dir, deploy_name, used_octets=used_octets)
+        quadlets = generate_quadlets(
+            config,
+            config_host_path,
+            patches_host_dir,
+            deploy_name,
+            used_octets=used_octets,
+            network_octet=network_octet,
+        )
         # Return both: Lima YAML and quadlets bundled together
         result: dict[str, str] = {"lima.yaml": lima_yaml}
         for qname, qcontent in quadlets.items():

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -767,8 +767,26 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
                 err=True,
             )
 
+    # Preserve the cage's existing network octet across updates. The podman
+    # network was created at cage-create time with the originally-assigned
+    # subnet; re-deriving from the hash here (which can land on a different
+    # octet if create-time collision resolution shifted it) would generate
+    # quadlets whose static IPs don't fall in `<name>-net` and the DNS
+    # sidecar would refuse to start with:
+    #   "requested static ip 10.89.X.10 not in any subnet on network <name>-net"
+    # See: https://github.com/agentcage/agentcage/issues/... (cage update
+    # regenerated quadlets with a fresh octet on single-cage systems).
     from agentcage.quadlets import collect_used_octets as _collect_update
-    _build_and_deploy(cfg, config_host_path, name, podman, used_octets=_collect_update(exclude=name))
+    _existing_meta = state.load_metadata(name) or {}
+    _existing_octet = _existing_meta.get("network_octet")
+    _build_and_deploy(
+        cfg,
+        config_host_path,
+        name,
+        podman,
+        used_octets=_collect_update(exclude=name),
+        network_octet=_existing_octet,
+    )
     click.echo(f"Updated cage '{name}'")
 
     if cfg.help:

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -19,6 +19,7 @@ from agentcage.config import Config
 def cage_network_addrs(
     name: str,
     used_octets: set[int] | None = None,
+    network_octet: int | None = None,
 ) -> dict[str, str]:
     """Derive deterministic, unique network addresses for a cage.
 
@@ -29,7 +30,24 @@ def cage_network_addrs(
     If *used_octets* is provided, the function checks for collisions and
     increments the third octet until a free slot is found.  Raises
     ``RuntimeError`` if all 254 slots are taken.
+
+    If *network_octet* is provided, the addresses are derived directly
+    from that octet, bypassing the hash and any collision resolution.
+    This is the correct path for updates to an already-deployed cage
+    whose podman network is pinned to the previously-allocated subnet —
+    re-allocating would produce IPs that fall outside the existing
+    ``<name>-net`` subnet and the DNS/proxy containers would refuse to
+    start with ``requested static ip not in any subnet on network``.
+    *used_octets* is ignored when *network_octet* is set.
     """
+    if network_octet is not None:
+        prefix = f"10.89.{network_octet}"
+        return {
+            "subnet": f"{prefix}.0/24",
+            "ip_cage": f"{prefix}.2",
+            "ip_dns": f"{prefix}.10",
+            "ip_proxy": f"{prefix}.11",
+        }
     h = hashlib.md5(name.encode()).hexdigest()
     octet = (int(h[:8], 16) % 254) + 1
     if used_octets is not None:
@@ -200,16 +218,9 @@ def render_dns_quadlet(
     """
     env = _make_env()
     name = config.name
-    if network_octet is not None:
-        prefix = f"10.89.{network_octet}"
-        addrs = {
-            "subnet": f"{prefix}.0/24",
-            "ip_cage": f"{prefix}.2",
-            "ip_dns": f"{prefix}.10",
-            "ip_proxy": f"{prefix}.11",
-        }
-    else:
-        addrs = cage_network_addrs(name, used_octets=used_octets)
+    addrs = cage_network_addrs(
+        name, used_octets=used_octets, network_octet=network_octet,
+    )
     from agentcage.state import dns_allowlist_path
     return env.get_template("dns.container.j2").render(
         name=name,
@@ -250,6 +261,7 @@ def generate_quadlets(
     deploy_name: str = "",
     rootless: bool = True,
     used_octets: set[int] | None = None,
+    network_octet: int | None = None,
 ) -> dict[str, str]:
     """Return {filename: content} for all 5 quadlet files.
 
@@ -260,6 +272,12 @@ def generate_quadlets(
         deploy_name: Deployment name for secret prefixing.  When set, podman
             secret references become ``{deploy_name}.{key}`` with
             ``target={key}`` so the container still sees the original env name.
+        network_octet: When set, pins the cage to a specific ``10.89.<octet>.0/24``
+            subnet, bypassing hash-based allocation. Used by ``cage update`` to
+            preserve the already-allocated subnet of an existing cage — the
+            podman network is created once at cage-create time and re-deriving
+            a different octet on update would generate quadlets whose static
+            IPs don't fall in the existing ``<name>-net`` subnet.
     """
     env = _make_env()
     name = config.name
@@ -382,7 +400,9 @@ def generate_quadlets(
             "publish_spec": f"{host_bind}:{host_port}:{container_port}",
         })
 
-    addrs = cage_network_addrs(name, used_octets=used_octets)
+    addrs = cage_network_addrs(
+        name, used_octets=used_octets, network_octet=network_octet,
+    )
     common = {"name": name, **addrs}
 
     # Network

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -230,9 +230,19 @@ def build_and_deploy(
     deploy_name: str,
     podman: Podman,
     used_octets: set[int] | None = None,
+    network_octet: int | None = None,
     quiet: bool = False,
 ):
-    """Build images, generate quadlets, install, and start."""
+    """Build images, generate quadlets, install, and start.
+
+    When *network_octet* is provided the cage's subnet is pinned to
+    ``10.89.<network_octet>.0/24`` instead of being re-derived from
+    the cage name hash.  This is the path ``cage update`` takes so an
+    existing cage keeps the subnet its podman network was created
+    with — re-allocating would generate quadlets whose static IPs
+    fall outside the existing ``<name>-net`` and the DNS/proxy
+    sidecars would refuse to start.
+    """
     from agentcage.quadlets import cage_network_addrs
 
     backend = get_backend(cfg)
@@ -240,14 +250,23 @@ def build_and_deploy(
     patches_work = ensure_patches(podman)
 
     # Write per-cage resolv.conf pointing to this cage's dnsmasq sidecar
-    addrs = cage_network_addrs(cfg.name, used_octets=used_octets)
+    addrs = cage_network_addrs(
+        cfg.name, used_octets=used_octets, network_octet=network_octet,
+    )
     resolv_path = os.path.join(patches_work, f"resolv-{cfg.name}.conf")
     with open(resolv_path, "w") as f:
         f.write(f"nameserver {addrs['ip_dns']}\n")
 
     backend.build_artifacts(cfg, deploy_name, quiet=quiet)
 
-    units = backend.generate_units(cfg, config_host_path, patches_work, deploy_name, used_octets=used_octets)
+    units = backend.generate_units(
+        cfg,
+        config_host_path,
+        patches_work,
+        deploy_name,
+        used_octets=used_octets,
+        network_octet=network_octet,
+    )
     backend.install_units(units, quiet=quiet)
 
     # Persist the actual assigned network octet so collect_used_octets()

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -418,6 +418,210 @@ class TestCageUpdateBuildArgs:
         assert "could not resolve latest tag" not in result.output
 
 
+class TestCageUpdatePreservesNetworkOctet:
+    """`agentcage cage update` must reuse the cage's already-allocated network
+    octet instead of re-deriving it from the cage-name hash.
+
+    Regression test for the bug where `cage update` regenerated quadlets with
+    a fresh octet that didn't match the existing ``<name>-net`` podman network,
+    causing the DNS sidecar to fail at start with::
+
+        Error: requested static ip 10.89.X.10 not in any subnet on network <name>-net
+
+    The fix reads ``network_octet`` from the cage's persisted metadata and
+    threads it through ``build_and_deploy`` so the renderer pins the subnet
+    to the existing one instead of re-allocating.
+    """
+
+    def _setup(self, mock_state, MockPodman, tmp_path, *, persisted_octet):
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        # The cage was already created and its network octet was persisted
+        # to metadata.json. cage_update must read this and pass it through.
+        mock_state.load_metadata.return_value = {
+            "network_octet": persisted_octet,
+            "agentcage_version": "0.0.0",
+        }
+        mock_state.load_raw_config.return_value = {
+            "name": "test",
+            "container": {"image": "test:latest", "build": {"args": {}}},
+        }
+        mock_state.load_deployment_config.return_value = Config(
+            name="test",
+            isolation="container",
+            container=ContainerConfig(
+                image="test:latest",
+                build=BuildConfig(containerfile="Containerfile", args={}),
+            ),
+        )
+        podman = MockPodman.return_value
+        podman.pull.return_value = True
+        return podman
+
+    @patch("agentcage.cli._build_and_deploy")
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli._check_secrets", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._build_container_image")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_update_passes_persisted_octet(
+        self, mock_state, MockPodman, mock_systemd,
+        mock_build_img, mock_backend, _check_secrets,
+        _check_ports, _build_deploy, tmp_path,
+    ):
+        # An existing cage whose network was allocated octet 174 at
+        # cage-create time. The hash for "test" can land on a different
+        # octet — the point is that `update` must honor what's persisted.
+        self._setup(mock_state, MockPodman, tmp_path, persisted_octet=174)
+        result = _runner().invoke(main, ["cage", "update", "test"])
+        assert result.exit_code == 0, result.output
+        assert _build_deploy.called
+        # The persisted octet must be passed through unchanged.
+        assert _build_deploy.call_args.kwargs.get("network_octet") == 174
+
+    @patch("agentcage.cli._build_and_deploy")
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli._check_secrets", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._build_container_image")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_update_passes_none_when_metadata_missing(
+        self, mock_state, MockPodman, mock_systemd,
+        mock_build_img, mock_backend, _check_secrets,
+        _check_ports, _build_deploy, tmp_path,
+    ):
+        """Legacy cages with no ``network_octet`` in metadata fall back to the
+        hash-based allocator (network_octet=None). Update must not crash."""
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.load_metadata.return_value = {}  # legacy: no octet persisted
+        mock_state.load_raw_config.return_value = {
+            "name": "test",
+            "container": {"image": "test:latest", "build": {"args": {}}},
+        }
+        mock_state.load_deployment_config.return_value = Config(
+            name="test",
+            isolation="container",
+            container=ContainerConfig(
+                image="test:latest",
+                build=BuildConfig(containerfile="Containerfile", args={}),
+            ),
+        )
+        MockPodman.return_value.pull.return_value = True
+
+        result = _runner().invoke(main, ["cage", "update", "test"])
+        assert result.exit_code == 0, result.output
+        assert _build_deploy.called
+        assert _build_deploy.call_args.kwargs.get("network_octet") is None
+
+
+class TestCageUpdateNetworkOctetEndToEnd:
+    """Verify the renderer honors network_octet through the full
+    ``build_and_deploy`` → ``generate_quadlets`` chain.
+
+    This is the "did the plumbing actually work" check: even if cli.py reads
+    the octet and passes it down, the quadlet content has to reflect the
+    pinned subnet."""
+
+    def test_pinned_octet_appears_in_generated_quadlets(self):
+        """generate_quadlets with network_octet must produce IPs in that subnet."""
+        from agentcage.config import Config, ContainerConfig
+        from agentcage.quadlets import generate_quadlets
+
+        cfg = Config(
+            name="pi01",
+            isolation="container",
+            container=ContainerConfig(image="x:latest"),
+            domains=__import__(
+                "agentcage.config", fromlist=["DomainConfig"],
+            ).DomainConfig(mode="allowlist", allow=["example.com"]),
+        )
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="pi01", network_octet=174,
+        )
+        # The network subnet must be 10.89.174.0/24
+        net = files["pi01-net.network"]
+        assert "10.89.174.0/24" in net, net
+        # DNS sidecar must request 10.89.174.10 (in the subnet)
+        dns = files["pi01-dns.container"]
+        assert "10.89.174.10" in dns, dns
+        # Proxy must request 10.89.174.11
+        proxy = files["pi01-proxy.container"]
+        assert "10.89.174.11" in proxy, proxy
+        # Cage gets 10.89.174.2
+        cage = files["pi01-cage.container"]
+        assert "10.89.174.2" in cage, cage
+
+    def test_pinned_octet_overrides_hash(self):
+        """When network_octet is given, the hash-derived octet is ignored —
+        the renderer trusts the caller's pin. This is what makes
+        ``cage update`` preserve the existing subnet."""
+        from agentcage.config import Config, ContainerConfig
+        from agentcage.quadlets import cage_network_addrs, generate_quadlets
+
+        # Pick a cage name whose hash octet is NOT 7 (almost any name).
+        natural = cage_network_addrs("pi01")
+        natural_octet = int(natural["subnet"].split(".")[2])
+        pinned_octet = 1 if natural_octet != 1 else 2
+        assert pinned_octet != natural_octet
+
+        cfg = Config(
+            name="pi01",
+            isolation="container",
+            container=ContainerConfig(image="x:latest"),
+            domains=__import__(
+                "agentcage.config", fromlist=["DomainConfig"],
+            ).DomainConfig(mode="allowlist", allow=["example.com"]),
+        )
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches",
+            deploy_name="pi01", network_octet=pinned_octet,
+        )
+        assert f"10.89.{pinned_octet}.0/24" in files["pi01-net.network"]
+        assert f"10.89.{natural_octet}." not in files["pi01-net.network"]
+
+    def test_build_and_deploy_threads_network_octet_to_backend(self):
+        """services.build_and_deploy must hand network_octet to the backend
+        (which forwards it to generate_quadlets) — verifies the plumbing
+        between cli.py and the renderer."""
+        from agentcage.config import Config, ContainerConfig
+        from agentcage.services import build_and_deploy
+
+        cfg = Config(
+            name="pi01",
+            isolation="container",
+            container=ContainerConfig(image="x:latest"),
+        )
+
+        with patch("agentcage.services.get_backend") as mock_get_backend, \
+             patch("agentcage.services.ensure_patches", return_value="/tmp"), \
+             patch("agentcage.services.state") as mock_state, \
+             patch("builtins.open", MagicMock()):
+            mock_backend = MagicMock()
+            mock_backend.generate_units.return_value = {}
+            mock_get_backend.return_value = mock_backend
+            mock_state.load_metadata.return_value = {}
+
+            build_and_deploy(
+                cfg, "/cfg.yaml", "pi01", MagicMock(), network_octet=174,
+            )
+
+        # The backend must receive the same network_octet.
+        kwargs = mock_backend.generate_units.call_args.kwargs
+        assert kwargs.get("network_octet") == 174
+        # And the persisted octet must be the pinned one, not a hash.
+        saved = mock_state.save_metadata.call_args[0][1]
+        assert saved["network_octet"] == 174
+
+
 class TestCageDestroy:
     @patch("agentcage.cli._destroy_cage")
     def test_destroy_with_yes(self, mock_destroy, tmp_path):

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -99,7 +99,14 @@ class TestGenerateUnits:
             units = backend.generate_units(config, "/path/config.yaml", "/path/patches", "testcage")
 
         mock_lima.assert_called_once_with(config)
-        mock_quadlets.assert_called_once_with(config, "/path/config.yaml", "/path/patches", "testcage", used_octets=None)
+        mock_quadlets.assert_called_once_with(
+            config,
+            "/path/config.yaml",
+            "/path/patches",
+            "testcage",
+            used_octets=None,
+            network_octet=None,
+        )
 
         assert "lima.yaml" in units
         assert units["lima.yaml"] == "lima: yaml content"


### PR DESCRIPTION
## Summary

`agentcage cage update <name>` regenerated podman quadlet files with a fresh network octet that didn't match the existing `<name>-net` podman network. The DNS sidecar then asked for a static IP outside the network's subnet, failed, and cascaded to the cage + proxy as dependency failures.

The user-visible error in `journalctl --user -u <name>-dns.service`:

```
Error: requested static ip 10.89.173.10 not in any subnet on network pi01-net
```

## Repro (observed on 0.17.4 against a fresh `pi` scaffold)

1. `agentcage init pi01 --scaffold pi`
2. `agentcage cage create -c cage.yaml -s OPENROUTER_API_KEY=anything` — cage healthy, allocated subnet `10.89.174.x` (dns `10.89.174.10`, proxy `10.89.174.11`, cage `10.89.174.2`)
3. Edit `cage.yaml` (any meaningful edit)
4. `agentcage cage update -c cage.yaml pi01` — systemd start fails; the regenerated `pi01-dns.container` wants `10.89.173.10` but `pi01-net` is still `10.89.174.0/24`.

## Root cause

`cli.cage_update` ([src/agentcage/cli.py:770-771 on master](https://github.com/agentcage/agentcage/blob/master/src/agentcage/cli.py#L770-L771)) calls:

```python
_build_and_deploy(cfg, config_host_path, name, podman, used_octets=_collect_update(exclude=name))
```

Down the chain in [`services.build_and_deploy`](https://github.com/agentcage/agentcage/blob/master/src/agentcage/services.py#L243) the renderer re-derives the cage's third octet from the cage-name hash. On a **single-cage** system that hash can land on a different octet than was actually allocated at create time:

- On **create**, `state.save_deployment(name, ...)` is called *before* `collect_used_octets()` ([cli.py:406, then cli.py:515](https://github.com/agentcage/agentcage/blob/master/src/agentcage/cli.py#L406-L515)). The cage being created is therefore in `list_deployments()` with no `network_octet` metadata yet, so [`collect_used_octets()`](https://github.com/agentcage/agentcage/blob/master/src/agentcage/quadlets.py#L62) falls back to `cage_network_addrs(cfg.name)` (the hash). The hash octet is now in the "used" set, so [`cage_network_addrs(..., used_octets=...)`](https://github.com/agentcage/agentcage/blob/master/src/agentcage/quadlets.py#L34-L38) sees a collision against itself and bumps to the next octet. The bumped octet is what gets persisted in `metadata.json["network_octet"]` and what the podman network is created with.
- On **update**, `_collect_update(exclude=name)` returns `{}` (no other cages). The allocator picks the natural hash octet — one less than what `<name>-net` was actually created with.

`metadata.json["network_octet"]` is the source of truth, but `cage update` wasn't reading it.

## Fix

Read the persisted `network_octet` from the cage's metadata in `cli.cage_update` and thread it through `build_and_deploy → backend.generate_units → generate_quadlets → cage_network_addrs`. When `network_octet` is set, hash-based allocation is bypassed entirely and the subnet is pinned to the original allocation.

This mirrors the existing `render_dns_quadlet(network_octet=…)` contract that `domain add/rm` already uses for the same reason ([cli.py:2352-2353 on master](https://github.com/agentcage/agentcage/blob/master/src/agentcage/cli.py#L2352-L2353)).

`collect_used_octets(exclude=name)` stays in place as a sanity check for the legacy path where no `network_octet` is persisted yet.

## Test plan

- [x] `uv run pytest tests/` — 1346 passed (was 1341 + 5 new regression tests)
- [x] `TestCageUpdatePreservesNetworkOctet::test_update_passes_persisted_octet` — CLI reads `metadata.network_octet` and passes it as `network_octet=` to `_build_and_deploy`
- [x] `TestCageUpdatePreservesNetworkOctet::test_update_passes_none_when_metadata_missing` — legacy cages with no persisted octet fall back to hash allocator (no crash)
- [x] `TestCageUpdateNetworkOctetEndToEnd::test_pinned_octet_appears_in_generated_quadlets` — renderer emits IPs inside the pinned subnet in all four quadlets (`net`, `dns`, `proxy`, `cage`)
- [x] `TestCageUpdateNetworkOctetEndToEnd::test_pinned_octet_overrides_hash` — pinned octet wins even when the hash would pick something different (the actual bug condition)
- [x] `TestCageUpdateNetworkOctetEndToEnd::test_build_and_deploy_threads_network_octet_to_backend` — `services.build_and_deploy` forwards `network_octet` to the backend
- [ ] End-to-end repro from the bug report on a real podman host (not runnable from a worktree — needs maintainer verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>