### PR TITLE
test(e2e): retry phase 8.1 to tolerate openclaw gateway boot non-monotonicity

### DIFF
--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -127,13 +127,26 @@ fi
 # login HTML on GET / (authentication is per-API-endpoint, not page-level).
 # The signal we care about: something identifiable as openclaw is serving
 # on this port — not a stray reverse-proxy error page.
+#
+# We retry within a 30s window rather than firing a single curl because
+# openclaw 2026.5+ gateway boot is non-monotonic: the upstream wait_ready
+# loop above exits on the first HTTP 200, but openclaw can then internally
+# restart its server one or more times during init before settling. A
+# single curl here can catch the gap and time out (curl: (28) Operation
+# timed out). The recovery idiom mirrors 8.4 below, which already waits
+# for the gateway after a SIGUSR1 restart.
 e2e_timer_start
-body=$(curl -sS --max-time 10 "$BASE/" 2>&1 || true)
+body=""
+for _ in $(seq 1 15); do
+  body=$(curl -sS --max-time 5 "$BASE/" 2>&1 || true)
+  echo "$body" | grep -q "OpenClaw Control" && break
+  sleep 2
+done
 if echo "$body" | grep -q "OpenClaw Control"; then
   e2e_pass "8.1" "gateway serves OpenClaw Control UI"
 else
   e2e_fail "8.1" "gateway serves OpenClaw Control UI" \
-    "expected 'OpenClaw Control' in response; got: $(echo "$body" | head -3)"
+    "expected 'OpenClaw Control' in response within 30s; last got: $(echo "$body" | head -3)"
 fi
 
 # 8.2: openclaw health OK via exec alias. Proves exec_aliases wiring


### PR DESCRIPTION
## Summary

Fix an intermittent CI flake in `tests/e2e/phase8_openclaw.sh` test 8.1
("gateway serves OpenClaw Control UI") by polling for the expected
response body within a 30s window instead of relying on a single 10s curl.

User-visible failure being fixed (from CI run [26367262667](https://github.com/agentcage/agentcage/actions/runs/26367262667/job/77613103469) against PR #126):

```
FAIL  8.1   gateway serves OpenClaw Control UI       10.0s
      expected 'OpenClaw Control' in response; got: curl: (28) Operation timed out after 10001 milliseconds with 0 bytes received
```

## Root cause

OpenClaw 2026.5+ gateway boot is non-monotonic. The control-UI server
comes up briefly, then OpenClaw internally restarts the server one or
more times during init before settling. `wait_ready` (used by the test
harness before 8.1 runs) uses `curl -sf` and short-circuits on the first
HTTP 200, so it can return during the brief gateway-up window before the
internal restart. The next curl (8.1) then catches the gateway during
the restart and the 10s `--max-time` expires.

Evidence this is intrinsic to OpenClaw, not agentcage:

- Test 8.4 explicitly waits for gateway recovery after a SIGUSR1 restart
  with `wait_ready "$BASE/" 60` — it already knows the gateway can be
  transiently unavailable.
- Tests 8.2, 8.4, 8.9 do host-side / cage-side checks and pass in the
  same run where 8.1 failed.
- PR #126 only touched `cage update`, not `cage create` (the phase-8
  entry point); its CI flake on this exact step was confirmed to be the
  same boot-time issue and the job passed on re-run.

The same flake has been observed sporadically against otherwise green
master pushes, so every PR landing during the flake window has to be
rerun. This change eliminates that retry cost.

## Fix

Single-file change to `tests/e2e/phase8_openclaw.sh`. Replace the
single-shot curl with a 15-iteration polling loop (2s sleep, 5s
per-curl `--max-time` -> up to 30s wall-clock window) that breaks
early once `OpenClaw Control` appears in the body. Mirrors the
`for _ in $(seq 1 N); do sleep ...` idiom already used by 8.4 / 8.8b /
8.8c in the same file.

No changes to `wait_ready`, no changes to the 300s readiness budget
before 8.1, no Python source changes.

## Test plan

- [x] `bash -n tests/e2e/phase8_openclaw.sh` (syntax check)
- [x] `uv run pytest tests/` (1346 passed)
- [ ] CI green on this PR
- [ ] No 8.1 flake on subsequent master PRs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>