### PR TITLE
feat(scaffolds): unify claude-code + codex with pi defaults

### DIFF
--- a/src/agentcage/scaffolds/claude-code/Containerfile
+++ b/src/agentcage/scaffolds/claude-code/Containerfile
@@ -10,10 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         python3 \
         ripgrep \
-    && rm -rf /var/lib/apt/lists/*
+        fd-find \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd
 
-# Install Claude Code CLI (latest stable)
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude Code CLI (latest stable).
+# --ignore-scripts skips npm postinstall hooks (defense-in-depth — the
+# package's runtime code still runs, only postinstall is skipped).
+RUN npm install -g --ignore-scripts @anthropic-ai/claude-code
 
 # node:22-slim already has user node (1000:1000)
 USER node

--- a/src/agentcage/scaffolds/claude-code/README.md
+++ b/src/agentcage/scaffolds/claude-code/README.md
@@ -120,13 +120,12 @@ See [Managing Your Cage](../../docs/cage-management.md) for common operations (e
 
 ### Volumes
 
-The scaffold mounts three paths from the host:
+The scaffold mounts two paths from the host:
 
 - `${PROJECT_DIR}:/workspace:rw` -- your project directory (set by `agentcage init`)
-- `~/.claude:/home/node/.claude:rw` -- Claude auth tokens and settings
-- `~/.claude.json:/home/node/.claude.json:rw` -- Claude global config
+- `~/.claude:/home/node/.claude:rw` -- Claude auth tokens and settings (credentials at `~/.claude/.credentials.json` live here)
 
-Remove the `~/.claude` mounts to fully isolate the cage from host state. Git config and SSH known hosts mounts are commented out in `cage.yaml` -- uncomment them if you need git push.
+`~/.claude.json` (Claude Code's global UX config — model choice, theme, etc.) is **not** mounted by default; uncomment the line in `cage.yaml` if you want host preferences to follow you into the cage. Git config and SSH known hosts mounts are commented out -- uncomment them if you need git push. Remove the `~/.claude` mount to fully isolate the cage from host state.
 
 ### Secret injection
 
@@ -153,11 +152,11 @@ The scaffold organizes domains into tiers:
 **AI provider** (required):
 - `anthropic.com`, `claude.com`
 
-**Telemetry** (Claude Code hangs on startup if these are blocked):
-- `datadoghq.com`, `githubusercontent.com`, `sentry.io`
+**Telemetry** (commented out):
+- `datadoghq.com`, `githubusercontent.com`, `sentry.io` — Claude Code may hang at the splash screen if telemetry is enabled AND these are blocked. Preferred fix: set `"telemetry": "disabled"` in `~/.claude/settings.json`. Fallback: uncomment these in `cage.yaml`.
 
-**Package registries**:
-- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org`
+**Package registries** (commented out):
+- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org` — Claude Code's deps are installed at image-build time, so the running cage doesn't need them. Uncomment if your agent runs `npm install` / `pip install` in the workspace.
 
 **Code hosting** (commented out):
 - `github.com`, `githubusercontent.com`
@@ -166,5 +165,5 @@ Subdomains are matched automatically -- adding `anthropic.com` also allows `api.
 
 ## Troubleshooting
 
-**Claude Code hangs on startup**: The telemetry domains (`datadoghq.com`, `sentry.io`) must be in the allowlist. Claude Code blocks on telemetry init if these are unreachable.
+**Claude Code hangs on startup**: telemetry is enabled and the telemetry domains are blocked. Either set `"telemetry": "disabled"` in `~/.claude/settings.json` (recommended for sandbox use) or uncomment the `datadoghq.com` / `githubusercontent.com` / `sentry.io` lines under `domains.allow` in `cage.yaml`.
 

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -45,14 +45,14 @@ container:
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
     # Auth & settings — mount host ~/.claude so login persists across sessions.
-    # Remove these lines to isolate cage state from the host.
+    # Remove this line to isolate cage state from the host.
     - "~/.claude:/home/node/.claude:rw"
-    # ~/.claude.json carries Claude Code's global config. The container
-    # backend bind-mounts it directly; the VM backend stages a copy into
-    # the cage's data dir and mounts that (Lima virtiofs can't share a
-    # single file). On the VM backend the staged copy is one-way — cage
-    # edits do not flow back to the host file.
-    - "~/.claude.json:/home/node/.claude.json:rw"
+    # ~/.claude.json (Claude Code's global UX config) is intentionally NOT
+    # mounted by default. Uncomment if you want your host preferences (model
+    # choice, theme, etc.) to follow you into the cage. Auth tokens live in
+    # ~/.claude/.credentials.json and are already covered by the mount above.
+    # Note: the VM backend stages a one-way copy (cage edits don't flow back).
+    #- "~/.claude.json:/home/node/.claude.json:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"
@@ -109,17 +109,25 @@ domains:
     - anthropic.com
     - claude.com
 
-    # ── Telemetry (Claude Code hangs on startup if these are blocked) ──
-    - datadoghq.com
-    - githubusercontent.com
-    - sentry.io
+    # ── Telemetry (commented out by default) ──
+    # Claude Code may hang on startup if these are blocked AND it's
+    # configured to report telemetry. If `claude` hangs at the splash
+    # screen, uncomment these (or disable telemetry in `~/.claude/settings.json`
+    # with `"telemetry": "disabled"` — preferred for sandbox use).
+    #- datadoghq.com
+    #- githubusercontent.com
+    #- sentry.io
 
-    # ── Package registries ──
-    - npmjs.org
-    - npmjs.com
-    - pypi.org
-    - files.pythonhosted.org
-    - nodejs.org
+    # ── Package registries (commented out by default) ──
+    # Claude Code's deps are installed at image-build time (see Containerfile),
+    # so the running cage doesn't need access to public package indexes.
+    # Uncomment the ones you need if your agent installs packages at
+    # runtime (e.g. `npm install` in /workspace, `pip install`, etc.).
+    #- npmjs.org
+    #- npmjs.com
+    #- pypi.org
+    #- files.pythonhosted.org
+    #- nodejs.org
 
     # ── Code hosting (uncomment for git push) ──
     #- github.com

--- a/src/agentcage/scaffolds/codex/Containerfile
+++ b/src/agentcage/scaffolds/codex/Containerfile
@@ -10,10 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         python3 \
         ripgrep \
-    && rm -rf /var/lib/apt/lists/*
+        fd-find \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd
 
-# Install OpenAI Codex CLI (latest stable)
-RUN npm install -g @openai/codex
+# Install OpenAI Codex CLI (latest stable).
+# --ignore-scripts skips npm postinstall hooks (defense-in-depth — the
+# package's runtime code still runs, only postinstall is skipped).
+RUN npm install -g --ignore-scripts @openai/codex
 
 # node:22-slim already has user node (1000:1000)
 USER node

--- a/src/agentcage/scaffolds/codex/README.md
+++ b/src/agentcage/scaffolds/codex/README.md
@@ -118,8 +118,8 @@ The scaffold organizes domains into tiers:
 **AI provider** (required):
 - `openai.com`
 
-**Package registries**:
-- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org`
+**Package registries** (commented out):
+- `npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org` — Codex's deps are installed at image-build time, so the running cage doesn't need them. Uncomment if your agent runs `npm install` / `pip install` in the workspace.
 
 **Code hosting** (commented out):
 - `github.com`, `githubusercontent.com`

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -17,8 +17,8 @@ name: {{ name }}
 isolation: vm
 
 vm:
-  vcpus: 2
-  mem_mb: 4096
+  vcpus: 4
+  mem_mb: 8192
 {% endif %}
 
 lifecycle: interactive
@@ -52,8 +52,8 @@ container:
     - "/tmp:rw,noexec,nosuid,size=256M"
 
   # Resource limits
-  memory: "2g"
-  cpus: "2.0"
+  memory: "8g"
+  cpus: "4.0"
 
   timeout_start_sec: 60
 
@@ -73,17 +73,23 @@ secret_injection:
   #    - github.com
 
 # ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "openai.com" also allows
+# "api.openai.com").
 domains:
   allow:
     # ── AI provider ──
     - openai.com
 
-    # ── Package registries ──
-    - npmjs.org
-    - npmjs.com
-    - pypi.org
-    - files.pythonhosted.org
-    - nodejs.org
+    # ── Package registries (commented out by default) ──
+    # Codex's deps are installed at image-build time (see Containerfile),
+    # so the running cage doesn't need access to public package indexes.
+    # Uncomment the ones you need if your agent installs packages at
+    # runtime (e.g. `npm install` in /workspace, `pip install`, etc.).
+    #- npmjs.org
+    #- npmjs.com
+    #- pypi.org
+    #- files.pythonhosted.org
+    #- nodejs.org
 
     # ── Code hosting (uncomment for git push) ──
     #- github.com


### PR DESCRIPTION
## Summary
Bring claude-code and codex scaffolds in line with the pi scaffold (open in #124) so all three coding-agent scaffolds share the same defaults and structure.

### Containerfile changes (claude-code + codex)
- Pre-install `fd-find` and symlink `fdfind` → `fd`. All three agents look for `fd` on PATH at startup and otherwise fetch it from `api.github.com/repos/sharkdp/fd/releases/latest` (blocked by the default allowlist; observed during pi cage testing).
- Add `--ignore-scripts` to `npm install -g`. Defense-in-depth: skips npm postinstall hooks at image-build time. Runtime package code is unaffected.

### cage.yaml.j2 — applied to all three scaffolds
- **Package registries commented out by default** (`npmjs.org`, `npmjs.com`, `pypi.org`, `files.pythonhosted.org`, `nodejs.org`). Agent deps are baked in at image-build time, so the running cage doesn't need them. Users who run `npm install` in `/workspace` uncomment what they need.

### claude-code-specific
- **Telemetry block commented out** (`datadoghq.com`, `githubusercontent.com`, `sentry.io`). The preferred fix for the "claude hangs at splash" issue is `"telemetry": "disabled"` in `~/.claude/settings.json`; the allowlist entries become an opt-in fallback. Troubleshooting section in the README updated accordingly.
- **`~/.claude.json` mount removed.** Auth tokens live in `~/.claude/.credentials.json` and are still covered by the `~/.claude` mount; only the global UX config (model choice, theme, etc.) was carried by the file mount. Commented-out so users can re-enable if they want host preferences to follow them into the cage.

### codex-specific
- **Bump container resources** from 2g/2cpus to 8g/4cpus, VM from 2vcpu/4GiB to 4vcpu/8GiB. Matches claude-code + pi. Coding agents are memory-hungry; old defaults pushed real workloads against the limit.
- Add the "Subdomains are matched automatically" header comment that claude-code + pi already carry above `domains:`.

Renders parse + validate cleanly across container and VM isolation for both scaffolds.

## Test plan
- [ ] `agentcage init myagent --scaffold claude-code` produces a working cage with the new defaults
- [ ] `agentcage init myagent --scaffold codex` produces a working cage with the new defaults
- [ ] Existing claude-code cages keep working after upgrade (their cage.yaml is unchanged — this only affects new inits)
- [ ] If claude hangs at splash on a fresh cage, the troubleshooting note's `"telemetry": "disabled"` fix works

## Related
- #124 introduces the pi scaffold these defaults are modeled on.
- After both PRs land, all three scaffolds share the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)