### PR TITLE
feat(scaffolds): add minimal busybox / alpine / arch / ubuntu / debian

### DIFF
--- a/src/agentcage/scaffolds/alpine/Containerfile
+++ b/src/agentcage/scaffolds/alpine/Containerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/alpine:latest
+
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/alpine/README.md
+++ b/src/agentcage/scaffolds/alpine/README.md
@@ -1,0 +1,33 @@
+# alpine
+
+Minimal Alpine Linux cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+
+Image: `docker.io/library/alpine:latest` (~7 MB, includes `sh`, `apk`, busybox userland).
+
+## Quick start
+
+```bash
+agentcage init mycage --scaffold alpine
+agentcage cage create -c cage.yaml
+agentcage cage exec mycage -- sh
+```
+
+Or one-shot:
+
+```bash
+agentcage run alpine
+```
+
+## What you get
+
+- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
+- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
+- No tools beyond Alpine's base. Need `curl`? `apk add --no-cache curl` (you'll need to allowlist `dl-cdn.alpinelinux.org` first).
+- No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
+
+## Use cases
+
+- Smoke-testing agentcage's proxy / DNS / network policy.
+- Confirming that blocked domains return 403 and allowed domains return 200.
+- Testing apk-based package install flows under the proxy.

--- a/src/agentcage/scaffolds/alpine/cage.yaml.j2
+++ b/src/agentcage/scaffolds/alpine/cage.yaml.j2
@@ -1,0 +1,82 @@
+# agentcage configuration for {{ name }} (alpine scaffold)
+#
+# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# beyond what alpine:latest ships, no outbound network allowed by default.
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Drop into a shell:
+#        agentcage cage exec {{ name }} -- sh
+#   3. Or use the run command:
+#        agentcage run alpine
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 2048
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: alpine
+
+container:
+  image: "localhost/agentcage-scaffold-alpine:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here if you want to poke at it.
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  # Resource limits — test cages are small
+  memory: "1g"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Secret injection (none by default) ──
+# Uncomment for GitHub push over HTTPS or any other host you want to inject to.
+#secret_injection:
+#  - env: GITHUB_TOKEN
+#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    inject_to:
+#      - github.com
+
+# ── Domain allowlist (empty by default) ──
+# Add the hosts you want the cage to reach. Subdomains are matched
+# automatically (e.g. "github.com" also allows "api.github.com").
+domains:
+  allow: []
+    # - example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  sh: ["sh"]
+
+# ── Help ──
+help: |
+  Drop into a shell:
+    agentcage cage exec {{ name }} -- sh
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run alpine

--- a/src/agentcage/scaffolds/alpine/scaffold.yaml
+++ b/src/agentcage/scaffolds/alpine/scaffold.yaml
@@ -1,0 +1,11 @@
+description: "Minimal alpine cage for testing agentcage primitives"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-alpine:latest"
+    containerfile: "Containerfile"
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- sh"
+  - "Or use: agentcage run alpine"

--- a/src/agentcage/scaffolds/arch/Containerfile
+++ b/src/agentcage/scaffolds/arch/Containerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/archlinux:latest
+
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/arch/README.md
+++ b/src/agentcage/scaffolds/arch/README.md
@@ -1,0 +1,33 @@
+# arch
+
+Minimal Arch Linux cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+
+Image: `docker.io/library/archlinux:latest` (~150 MB, includes bash, coreutils, pacman).
+
+## Quick start
+
+```bash
+agentcage init mycage --scaffold arch
+agentcage cage create -c cage.yaml
+agentcage cage exec mycage -- bash
+```
+
+Or one-shot:
+
+```bash
+agentcage run arch
+```
+
+## What you get
+
+- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
+- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
+- No tools beyond what archlinux:latest ships. To `pacman -Syu` you'll need to allowlist the mirror hosts (`geo.mirror.pkgbuild.com` or whatever your `/etc/pacman.d/mirrorlist` resolves to).
+- No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
+
+## Use cases
+
+- Testing agentcage behavior on a larger, more "real" Linux base than alpine/busybox.
+- Confirming that blocked domains return 403 and allowed domains return 200.
+- Testing pacman-based package install flows under the proxy.

--- a/src/agentcage/scaffolds/arch/cage.yaml.j2
+++ b/src/agentcage/scaffolds/arch/cage.yaml.j2
@@ -1,0 +1,82 @@
+# agentcage configuration for {{ name }} (arch scaffold)
+#
+# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# beyond what archlinux:latest ships, no outbound network allowed by default.
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Drop into a shell:
+#        agentcage cage exec {{ name }} -- bash
+#   3. Or use the run command:
+#        agentcage run arch
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 2048
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: arch
+
+container:
+  image: "localhost/agentcage-scaffold-arch:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here if you want to poke at it.
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  # Resource limits — test cages are small
+  memory: "1g"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Secret injection (none by default) ──
+# Uncomment for GitHub push over HTTPS or any other host you want to inject to.
+#secret_injection:
+#  - env: GITHUB_TOKEN
+#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    inject_to:
+#      - github.com
+
+# ── Domain allowlist (empty by default) ──
+# Add the hosts you want the cage to reach. Subdomains are matched
+# automatically (e.g. "github.com" also allows "api.github.com").
+domains:
+  allow: []
+    # - example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  bash: ["bash"]
+
+# ── Help ──
+help: |
+  Drop into a shell:
+    agentcage cage exec {{ name }} -- bash
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run arch

--- a/src/agentcage/scaffolds/arch/scaffold.yaml
+++ b/src/agentcage/scaffolds/arch/scaffold.yaml
@@ -1,0 +1,11 @@
+description: "Minimal arch cage for testing agentcage primitives"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-arch:latest"
+    containerfile: "Containerfile"
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- bash"
+  - "Or use: agentcage run arch"

--- a/src/agentcage/scaffolds/busybox/Containerfile
+++ b/src/agentcage/scaffolds/busybox/Containerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/busybox:latest
+
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/busybox/README.md
+++ b/src/agentcage/scaffolds/busybox/README.md
@@ -1,0 +1,32 @@
+# busybox
+
+Minimal busybox cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+
+Image: `docker.io/library/busybox:latest` (single static binary, ~5 MB).
+
+## Quick start
+
+```bash
+agentcage init mycage --scaffold busybox
+agentcage cage create -c cage.yaml
+agentcage cage exec mycage -- sh
+```
+
+Or one-shot:
+
+```bash
+agentcage run busybox
+```
+
+## What you get
+
+- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
+- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
+- No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
+
+## Use cases
+
+- Smoke-testing agentcage's proxy / DNS / network policy without the noise of a coding agent.
+- Confirming that blocked domains return 403 and allowed domains return 200.
+- Quick disposable shells for experimenting with cage features.

--- a/src/agentcage/scaffolds/busybox/cage.yaml.j2
+++ b/src/agentcage/scaffolds/busybox/cage.yaml.j2
@@ -1,0 +1,82 @@
+# agentcage configuration for {{ name }} (busybox scaffold)
+#
+# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# beyond what busybox ships, no outbound network allowed by default.
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Drop into a shell:
+#        agentcage cage exec {{ name }} -- sh
+#   3. Or use the run command:
+#        agentcage run busybox
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 2048
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: busybox
+
+container:
+  image: "localhost/agentcage-scaffold-busybox:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here if you want to poke at it.
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  # Resource limits — test cages are small
+  memory: "1g"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Secret injection (none by default) ──
+# Uncomment for GitHub push over HTTPS or any other host you want to inject to.
+#secret_injection:
+#  - env: GITHUB_TOKEN
+#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    inject_to:
+#      - github.com
+
+# ── Domain allowlist (empty by default) ──
+# Add the hosts you want the cage to reach. Subdomains are matched
+# automatically (e.g. "github.com" also allows "api.github.com").
+domains:
+  allow: []
+    # - example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  sh: ["sh"]
+
+# ── Help ──
+help: |
+  Drop into a shell:
+    agentcage cage exec {{ name }} -- sh
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run busybox

--- a/src/agentcage/scaffolds/busybox/scaffold.yaml
+++ b/src/agentcage/scaffolds/busybox/scaffold.yaml
@@ -1,0 +1,11 @@
+description: "Minimal busybox cage for testing agentcage primitives"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-busybox:latest"
+    containerfile: "Containerfile"
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- sh"
+  - "Or use: agentcage run busybox"

--- a/src/agentcage/scaffolds/debian/Containerfile
+++ b/src/agentcage/scaffolds/debian/Containerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/debian:stable-slim
+
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/debian/README.md
+++ b/src/agentcage/scaffolds/debian/README.md
@@ -1,0 +1,33 @@
+# debian
+
+Minimal Debian cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+
+Image: `docker.io/library/debian:stable-slim` (~75 MB; includes bash, coreutils, apt).
+
+## Quick start
+
+```bash
+agentcage init mycage --scaffold debian
+agentcage cage create -c cage.yaml
+agentcage cage exec mycage -- bash
+```
+
+Or one-shot:
+
+```bash
+agentcage run debian
+```
+
+## What you get
+
+- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
+- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
+- No tools beyond Debian's slim base. To `apt-get install` you'll need to allowlist `deb.debian.org` and `security.debian.org`.
+- No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
+
+## Use cases
+
+- Testing agentcage on Debian (the upstream of many derivatives, including the node:22-slim image the coding-agent scaffolds use).
+- Confirming that blocked domains return 403 and allowed domains return 200.
+- Testing apt-based package install flows under the proxy.

--- a/src/agentcage/scaffolds/debian/cage.yaml.j2
+++ b/src/agentcage/scaffolds/debian/cage.yaml.j2
@@ -1,0 +1,82 @@
+# agentcage configuration for {{ name }} (debian scaffold)
+#
+# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# beyond what debian:stable-slim ships, no outbound network allowed by default.
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Drop into a shell:
+#        agentcage cage exec {{ name }} -- bash
+#   3. Or use the run command:
+#        agentcage run debian
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 2048
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: debian
+
+container:
+  image: "localhost/agentcage-scaffold-debian:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here if you want to poke at it.
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  # Resource limits — test cages are small
+  memory: "1g"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Secret injection (none by default) ──
+# Uncomment for GitHub push over HTTPS or any other host you want to inject to.
+#secret_injection:
+#  - env: GITHUB_TOKEN
+#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    inject_to:
+#      - github.com
+
+# ── Domain allowlist (empty by default) ──
+# Add the hosts you want the cage to reach. Subdomains are matched
+# automatically (e.g. "github.com" also allows "api.github.com").
+domains:
+  allow: []
+    # - example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  bash: ["bash"]
+
+# ── Help ──
+help: |
+  Drop into a shell:
+    agentcage cage exec {{ name }} -- bash
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run debian

--- a/src/agentcage/scaffolds/debian/scaffold.yaml
+++ b/src/agentcage/scaffolds/debian/scaffold.yaml
@@ -1,0 +1,11 @@
+description: "Minimal debian cage for testing agentcage primitives"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-debian:latest"
+    containerfile: "Containerfile"
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- bash"
+  - "Or use: agentcage run debian"

--- a/src/agentcage/scaffolds/ubuntu/Containerfile
+++ b/src/agentcage/scaffolds/ubuntu/Containerfile
@@ -1,0 +1,3 @@
+FROM docker.io/library/ubuntu:latest
+
+WORKDIR /workspace

--- a/src/agentcage/scaffolds/ubuntu/README.md
+++ b/src/agentcage/scaffolds/ubuntu/README.md
@@ -1,0 +1,33 @@
+# ubuntu
+
+Minimal Ubuntu cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+
+Image: `docker.io/library/ubuntu:latest` (current LTS, ~80 MB; includes bash, coreutils, apt).
+
+## Quick start
+
+```bash
+agentcage init mycage --scaffold ubuntu
+agentcage cage create -c cage.yaml
+agentcage cage exec mycage -- bash
+```
+
+Or one-shot:
+
+```bash
+agentcage run ubuntu
+```
+
+## What you get
+
+- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
+- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
+- No tools beyond Ubuntu's base. To `apt-get install` you'll need to allowlist `archive.ubuntu.com` and `security.ubuntu.com`.
+- No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
+
+## Use cases
+
+- Testing agentcage on the most common Linux base most users target.
+- Confirming that blocked domains return 403 and allowed domains return 200.
+- Testing apt-based package install flows under the proxy.

--- a/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
+++ b/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
@@ -1,0 +1,82 @@
+# agentcage configuration for {{ name }} (ubuntu scaffold)
+#
+# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# beyond what ubuntu:latest ships, no outbound network allowed by default.
+#
+# Quick start:
+#   1. Deploy:  agentcage cage create -c cage.yaml
+#   2. Drop into a shell:
+#        agentcage cage exec {{ name }} -- bash
+#   3. Or use the run command:
+#        agentcage run ubuntu
+
+name: {{ name }}
+{% if isolation == "vm" %}
+
+isolation: vm
+
+vm:
+  vcpus: 2
+  mem_mb: 2048
+{% endif %}
+
+lifecycle: interactive
+
+scaffold: ubuntu
+
+container:
+  image: "localhost/agentcage-scaffold-ubuntu:latest"
+  build:
+    containerfile: "Containerfile"
+  command: ["sleep", "infinity"]
+
+  # Project directory — mount your repo here if you want to poke at it.
+  volumes:
+    - "${PROJECT_DIR}:/workspace:rw"
+
+  read_only: false
+
+  tmpfs:
+    - "/tmp:rw,noexec,nosuid,size=64M"
+
+  # Resource limits — test cages are small
+  memory: "1g"
+  cpus: "1.0"
+
+  timeout_start_sec: 30
+
+# ── Secret injection (none by default) ──
+# Uncomment for GitHub push over HTTPS or any other host you want to inject to.
+#secret_injection:
+#  - env: GITHUB_TOKEN
+#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    inject_to:
+#      - github.com
+
+# ── Domain allowlist (empty by default) ──
+# Add the hosts you want the cage to reach. Subdomains are matched
+# automatically (e.g. "github.com" also allows "api.github.com").
+domains:
+  allow: []
+    # - example.com
+
+# ── Logging ──
+logging:
+  level: info
+  dns: warning
+
+# ── Inspectors ──
+inspectors:
+  - name: content-type
+
+# ── Exec aliases ──
+exec_aliases:
+  bash: ["bash"]
+
+# ── Help ──
+help: |
+  Drop into a shell:
+    agentcage cage exec {{ name }} -- bash
+
+  Or use the run command (creates ephemeral cage):
+    agentcage run ubuntu

--- a/src/agentcage/scaffolds/ubuntu/scaffold.yaml
+++ b/src/agentcage/scaffolds/ubuntu/scaffold.yaml
@@ -1,0 +1,11 @@
+description: "Minimal ubuntu cage for testing agentcage primitives"
+lifecycle: interactive
+
+build:
+  - image: "localhost/agentcage-scaffold-ubuntu:latest"
+    containerfile: "Containerfile"
+
+next_steps:
+  - "agentcage cage create -c {dest}"
+  - "agentcage cage exec {name} -- bash"
+  - "Or use: agentcage run ubuntu"


### PR DESCRIPTION
## Summary

Five minimal base-image scaffolds for testing agentcage primitives without the noise of a coding agent.

| Scaffold | Base image | Shell |
|---|---|---|
| `busybox` | `docker.io/library/busybox:latest` | `sh` |
| `alpine` | `docker.io/library/alpine:latest` | `sh` |
| `arch` | `docker.io/library/archlinux:latest` | `bash` |
| `ubuntu` | `docker.io/library/ubuntu:latest` | `bash` |
| `debian` | `docker.io/library/debian:stable-slim` | `bash` |

### Common shape

Same 4-file layout (`scaffold.yaml` + `Containerfile` + `cage.yaml.j2` + `README.md`) as the existing scaffolds. The Containerfiles are deliberately the shortest possible:

```
FROM docker.io/library/<base>:latest
WORKDIR /workspace
```

No apt/apk installs, no extra tools. The point is to provide a known-clean baseline so the user can see exactly what the proxy/DNS/network policy is doing.

### Notable defaults

- **Empty `domains.allow`** — every outbound request is blocked by the proxy. Users add what they need (e.g. `archive.ubuntu.com` to test `apt-get install` under the proxy).
- **No `secret_injection` rules active** — commented-out `GITHUB_TOKEN` example for parity with the coding-agent scaffolds.
- **No `cap_add` in `scaffold.yaml`** — these builds do no chown / setuid / setfcap, so no extra build-time caps are needed. (Coding-agent scaffolds keep their `cap_add` list because `apt-get install` + `npm install -g` genuinely need it.)
- **1 GiB / 1 CPU** container limits, **2 vcpu / 2 GiB** VM. These are test cages, not workloads.
- `${PROJECT_DIR}:/workspace:rw` is the only volume mount, for parity with siblings.

### Auto-discovery

`agentcage init <name> --scaffold <busybox|alpine|arch|ubuntu|debian>` works out of the box — no Python changes, the scaffolds are picked up by `list_scaffolds()` automatically. All five renders parse + validate clean across container and VM isolation.

## Test plan
- [ ] `agentcage init mycage --scaffold busybox` → `agentcage cage create -c cage.yaml` → `agentcage cage exec mycage -- sh` drops into a busybox shell
- [ ] Same for alpine / arch / ubuntu / debian
- [ ] `curl http://example.com` from inside any cage returns HTTP 403 (allowlist is empty)
- [ ] Adding `- example.com` under `domains.allow` and recreating allows the request through
- [ ] `agentcage scaffold list` shows all five as `built-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)