### PR TITLE
fix(scaffolds): minimal distros run rootful + package-install ready

### DIFF
--- a/src/agentcage/scaffolds/alpine/README.md
+++ b/src/agentcage/scaffolds/alpine/README.md
@@ -1,6 +1,6 @@
 # alpine
 
-Minimal Alpine Linux cage — no AI agent, no extra tools, no outbound network by default.
+Minimal Alpine Linux cage — no AI agent, no extra tools beyond Alpine's base, package mirror pre-allowlisted so `apk` works out of the box.
 
 Image: `docker.io/library/alpine:latest` (~7 MB, includes `sh`, `apk`, busybox userland).
 
@@ -22,8 +22,9 @@ agentcage run alpine
 
 - `sleep infinity` keeps the container alive; you drop in via `cage exec`.
 - `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
-- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
-- No tools beyond Alpine's base. Need `curl`? `apk add --no-cache curl` (you'll need to allowlist `dl-cdn.alpinelinux.org` first).
+- Domain allowlist pre-allows `alpinelinux.org` (subdomains included → `dl-cdn.alpinelinux.org` works). Everything else is blocked by the proxy until you add it under `domains.allow` in `cage.yaml`.
+- Cage runs as root with the minimum `add_capabilities` for `apk` to install packages (`CHOWN`, `FOWNER`, `DAC_OVERRIDE`, `SETUID`, `SETGID`).
+- `apk update && apk add curl` works out of the box.
 - No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
 
 ## Use cases

--- a/src/agentcage/scaffolds/alpine/README.md
+++ b/src/agentcage/scaffolds/alpine/README.md
@@ -1,6 +1,6 @@
 # alpine
 
-Minimal Alpine Linux cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+Minimal Alpine Linux cage — no AI agent, no extra tools, no outbound network by default.
 
 Image: `docker.io/library/alpine:latest` (~7 MB, includes `sh`, `apk`, busybox userland).
 

--- a/src/agentcage/scaffolds/alpine/cage.yaml.j2
+++ b/src/agentcage/scaffolds/alpine/cage.yaml.j2
@@ -52,6 +52,16 @@ container:
 
   timeout_start_sec: 30
 
+  # Capabilities needed by apk to install packages (chown installed files,
+  # set setuid bits, etc.). The cage drops ALL caps by default; these are
+  # the minimum re-added for `apk add <pkg>` to succeed as root.
+  add_capabilities:
+    - CHOWN
+    - FOWNER
+    - DAC_OVERRIDE
+    - SETUID
+    - SETGID
+
 # ── Secret injection (none by default) ──
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
@@ -60,11 +70,14 @@ container:
 #    inject_to:
 #      - github.com
 
-# ── Domain allowlist (empty by default) ──
-# Add the hosts you want the cage to reach. Subdomains are matched
-# automatically (e.g. "github.com" also allows "api.github.com").
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "github.com" also allows
+# "api.github.com").
 domains:
-  allow: []
+  allow:
+    # ── Alpine package mirrors (apk update / apk add) ──
+    - alpinelinux.org
+    # Add more hosts your test needs:
     # - example.com
 
 # ── Logging ──

--- a/src/agentcage/scaffolds/alpine/cage.yaml.j2
+++ b/src/agentcage/scaffolds/alpine/cage.yaml.j2
@@ -1,6 +1,6 @@
 # agentcage configuration for {{ name }} (alpine scaffold)
 #
-# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# Minimal cage — no AI agent, no tools
 # beyond what alpine:latest ships, no outbound network allowed by default.
 #
 # Quick start:
@@ -33,6 +33,13 @@ container:
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+
+  # Use the image's default USER (root for these base images). The
+  # agentcage default of "1000:1000" doesn't resolve to a real user
+  # in minimal base images, so `whoami` returns nothing and sudo is
+  # uninstallable. Inside the cage you are root; rootless podman maps
+  # that UID to your host user for bind-mounted writes.
+  user: ""
 
   read_only: false
 

--- a/src/agentcage/scaffolds/alpine/scaffold.yaml
+++ b/src/agentcage/scaffolds/alpine/scaffold.yaml
@@ -1,4 +1,4 @@
-description: "Minimal alpine cage for testing agentcage primitives"
+description: "Minimal alpine cage"
 lifecycle: interactive
 
 build:

--- a/src/agentcage/scaffolds/arch/README.md
+++ b/src/agentcage/scaffolds/arch/README.md
@@ -1,6 +1,6 @@
 # arch
 
-Minimal Arch Linux cage — no AI agent, no extra tools, no outbound network by default.
+Minimal Arch Linux cage — no AI agent, no extra tools beyond what archlinux:latest ships, package mirrors pre-allowlisted so `pacman` works out of the box.
 
 Image: `docker.io/library/archlinux:latest` (~150 MB, includes bash, coreutils, pacman).
 
@@ -20,10 +20,11 @@ agentcage run arch
 
 ## What you get
 
-- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- The cage's startup command installs the agentcage MITM proxy CA into Arch's system trust store (`trust extract-compat`) so pacman trusts the intercepted TLS to the mirrors. Then `sleep infinity` keeps the container alive; you drop in via `cage exec`.
 - `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
-- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
-- No tools beyond what archlinux:latest ships. To `pacman -Syu` you'll need to allowlist the mirror hosts (`geo.mirror.pkgbuild.com` or whatever your `/etc/pacman.d/mirrorlist` resolves to).
+- Domain allowlist pre-allows `pkgbuild.com` (covers `fastly.mirror.pkgbuild.com` and `geo.mirror.pkgbuild.com` via subdomain matching) and `archlinux.org`. Everything else is blocked by the proxy until you add it under `domains.allow` in `cage.yaml`.
+- Cage runs as root with the minimum `add_capabilities` for `pacman` to install packages (`CHOWN`, `FOWNER`, `DAC_OVERRIDE`, `SETUID`, `SETGID`).
+- `pacman -Sy && pacman -S curl` works out of the box.
 - No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
 
 ## Use cases

--- a/src/agentcage/scaffolds/arch/README.md
+++ b/src/agentcage/scaffolds/arch/README.md
@@ -1,6 +1,6 @@
 # arch
 
-Minimal Arch Linux cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+Minimal Arch Linux cage — no AI agent, no extra tools, no outbound network by default.
 
 Image: `docker.io/library/archlinux:latest` (~150 MB, includes bash, coreutils, pacman).
 

--- a/src/agentcage/scaffolds/arch/cage.yaml.j2
+++ b/src/agentcage/scaffolds/arch/cage.yaml.j2
@@ -1,6 +1,6 @@
 # agentcage configuration for {{ name }} (arch scaffold)
 #
-# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# Minimal cage — no AI agent, no tools
 # beyond what archlinux:latest ships, no outbound network allowed by default.
 #
 # Quick start:
@@ -33,6 +33,13 @@ container:
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+
+  # Use the image's default USER (root for these base images). The
+  # agentcage default of "1000:1000" doesn't resolve to a real user
+  # in minimal base images, so `whoami` returns nothing and sudo is
+  # uninstallable. Inside the cage you are root; rootless podman maps
+  # that UID to your host user for bind-mounted writes.
+  user: ""
 
   read_only: false
 

--- a/src/agentcage/scaffolds/arch/cage.yaml.j2
+++ b/src/agentcage/scaffolds/arch/cage.yaml.j2
@@ -28,7 +28,13 @@ container:
   image: "localhost/agentcage-scaffold-arch:latest"
   build:
     containerfile: "Containerfile"
-  command: ["sleep", "infinity"]
+  # Install the agentcage MITM proxy CA into the system trust store at
+  # startup so pacman (and any other tool that doesn't read SSL_CERT_FILE)
+  # can talk to the package mirrors over the intercepted TLS connection.
+  command:
+    - "sh"
+    - "-c"
+    - "cp /certs/mitmproxy-ca-cert.pem /etc/ca-certificates/trust-source/anchors/agentcage-proxy.crt && trust extract-compat && exec sleep infinity"
 
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
@@ -52,6 +58,16 @@ container:
 
   timeout_start_sec: 30
 
+  # Capabilities needed by pacman to install packages (chown installed
+  # files, set setuid bits, etc.). The cage drops ALL caps by default;
+  # these are the minimum re-added for `pacman -S <pkg>` to succeed as root.
+  add_capabilities:
+    - CHOWN
+    - FOWNER
+    - DAC_OVERRIDE
+    - SETUID
+    - SETGID
+
 # ── Secret injection (none by default) ──
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
@@ -60,11 +76,15 @@ container:
 #    inject_to:
 #      - github.com
 
-# ── Domain allowlist (empty by default) ──
-# Add the hosts you want the cage to reach. Subdomains are matched
-# automatically (e.g. "github.com" also allows "api.github.com").
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "github.com" also allows
+# "api.github.com").
 domains:
-  allow: []
+  allow:
+    # ── Arch package mirrors (pacman -Syu / pacman -S) ──
+    - pkgbuild.com
+    - archlinux.org
+    # Add more hosts your test needs:
     # - example.com
 
 # ── Logging ──

--- a/src/agentcage/scaffolds/arch/scaffold.yaml
+++ b/src/agentcage/scaffolds/arch/scaffold.yaml
@@ -1,4 +1,4 @@
-description: "Minimal arch cage for testing agentcage primitives"
+description: "Minimal arch cage"
 lifecycle: interactive
 
 build:

--- a/src/agentcage/scaffolds/busybox/README.md
+++ b/src/agentcage/scaffolds/busybox/README.md
@@ -1,6 +1,6 @@
 # busybox
 
-Minimal busybox cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+Minimal busybox cage — no AI agent, no extra tools, no outbound network by default.
 
 Image: `docker.io/library/busybox:latest` (single static binary, ~5 MB).
 

--- a/src/agentcage/scaffolds/busybox/README.md
+++ b/src/agentcage/scaffolds/busybox/README.md
@@ -25,8 +25,12 @@ agentcage run busybox
 - Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
 - No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
 
+## Limitations
+
+**No package manager.** `busybox:latest` ships only the busybox static binary — no `apk`, `apt`, `pacman`, or `opkg`. You cannot install additional tools at runtime. If you need to test package installs or pull in something like `curl`, use the [alpine scaffold](../alpine/README.md) instead (also tiny, but with `apk`).
+
 ## Use cases
 
-- Smoke-testing agentcage's proxy / DNS / network policy without the noise of a coding agent.
-- Confirming that blocked domains return 403 and allowed domains return 200.
-- Quick disposable shells for experimenting with cage features.
+- Smoke-testing agentcage's proxy / DNS / network policy without the noise of a coding agent or even a package manager.
+- Confirming that blocked domains return 403 and allowed domains return 200, using busybox's built-in `wget`.
+- The absolute floor for "what's the smallest cage I can spin up to poke at agentcage".

--- a/src/agentcage/scaffolds/busybox/cage.yaml.j2
+++ b/src/agentcage/scaffolds/busybox/cage.yaml.j2
@@ -1,6 +1,6 @@
 # agentcage configuration for {{ name }} (busybox scaffold)
 #
-# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# Minimal cage — no AI agent, no tools
 # beyond what busybox ships, no outbound network allowed by default.
 #
 # Quick start:
@@ -33,6 +33,13 @@ container:
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+
+  # Use the image's default USER (root for these base images). The
+  # agentcage default of "1000:1000" doesn't resolve to a real user
+  # in minimal base images, so `whoami` returns nothing and sudo is
+  # uninstallable. Inside the cage you are root; rootless podman maps
+  # that UID to your host user for bind-mounted writes.
+  user: ""
 
   read_only: false
 

--- a/src/agentcage/scaffolds/busybox/scaffold.yaml
+++ b/src/agentcage/scaffolds/busybox/scaffold.yaml
@@ -1,4 +1,4 @@
-description: "Minimal busybox cage for testing agentcage primitives"
+description: "Minimal busybox cage"
 lifecycle: interactive
 
 build:

--- a/src/agentcage/scaffolds/debian/Containerfile
+++ b/src/agentcage/scaffolds/debian/Containerfile
@@ -1,3 +1,11 @@
 FROM docker.io/library/debian:stable-slim
 
+# ca-certificates provides /etc/ssl/certs + the `update-ca-certificates`
+# helper. Needed so the cage's startup script can install the agentcage
+# MITM proxy CA into the system trust store and apt/curl/etc. trust the
+# intercepted TLS handshake to the package mirrors.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace

--- a/src/agentcage/scaffolds/debian/README.md
+++ b/src/agentcage/scaffolds/debian/README.md
@@ -1,6 +1,6 @@
 # debian
 
-Minimal Debian cage — no AI agent, no extra tools, no outbound network by default.
+Minimal Debian cage — no AI agent, only `ca-certificates` added on top of the base image so `apt` trusts the agentcage MITM proxy, package mirrors pre-allowlisted so `apt-get` works out of the box.
 
 Image: `docker.io/library/debian:stable-slim` (~75 MB; includes bash, coreutils, apt).
 
@@ -20,10 +20,11 @@ agentcage run debian
 
 ## What you get
 
-- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- The cage's startup command installs the agentcage MITM proxy CA into Debian's system trust store (`update-ca-certificates`) so apt trusts the intercepted TLS to the mirrors. Then `sleep infinity` keeps the container alive; you drop in via `cage exec`.
 - `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
-- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
-- No tools beyond Debian's slim base. To `apt-get install` you'll need to allowlist `deb.debian.org` and `security.debian.org`.
+- Domain allowlist pre-allows `deb.debian.org` and `security.debian.org`. Everything else is blocked by the proxy until you add it under `domains.allow` in `cage.yaml`.
+- Cage runs as root with the minimum `add_capabilities` for `apt` to install packages (`CHOWN`, `FOWNER`, `DAC_OVERRIDE`, `SETUID`, `SETGID`).
+- `apt-get update && apt-get install -y curl` works out of the box.
 - No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
 
 ## Use cases

--- a/src/agentcage/scaffolds/debian/README.md
+++ b/src/agentcage/scaffolds/debian/README.md
@@ -1,6 +1,6 @@
 # debian
 
-Minimal Debian cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+Minimal Debian cage — no AI agent, no extra tools, no outbound network by default.
 
 Image: `docker.io/library/debian:stable-slim` (~75 MB; includes bash, coreutils, apt).
 

--- a/src/agentcage/scaffolds/debian/cage.yaml.j2
+++ b/src/agentcage/scaffolds/debian/cage.yaml.j2
@@ -28,7 +28,13 @@ container:
   image: "localhost/agentcage-scaffold-debian:latest"
   build:
     containerfile: "Containerfile"
-  command: ["sleep", "infinity"]
+  # Install the agentcage MITM proxy CA into the system trust store at
+  # startup so apt (and any other tool that doesn't read SSL_CERT_FILE)
+  # can talk to the package mirrors over the intercepted TLS connection.
+  command:
+    - "sh"
+    - "-c"
+    - "cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/agentcage-proxy.crt && update-ca-certificates >/dev/null 2>&1 && exec sleep infinity"
 
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
@@ -52,6 +58,16 @@ container:
 
   timeout_start_sec: 30
 
+  # Capabilities needed by apt to install packages (chown installed files,
+  # set setuid bits, etc.). The cage drops ALL caps by default; these are
+  # the minimum re-added for `apt-get install <pkg>` to succeed as root.
+  add_capabilities:
+    - CHOWN
+    - FOWNER
+    - DAC_OVERRIDE
+    - SETUID
+    - SETGID
+
 # ── Secret injection (none by default) ──
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
@@ -60,11 +76,15 @@ container:
 #    inject_to:
 #      - github.com
 
-# ── Domain allowlist (empty by default) ──
-# Add the hosts you want the cage to reach. Subdomains are matched
-# automatically (e.g. "github.com" also allows "api.github.com").
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "github.com" also allows
+# "api.github.com").
 domains:
-  allow: []
+  allow:
+    # ── Debian package mirrors (apt-get update / apt-get install) ──
+    - deb.debian.org
+    - security.debian.org
+    # Add more hosts your test needs:
     # - example.com
 
 # ── Logging ──

--- a/src/agentcage/scaffolds/debian/cage.yaml.j2
+++ b/src/agentcage/scaffolds/debian/cage.yaml.j2
@@ -1,6 +1,6 @@
 # agentcage configuration for {{ name }} (debian scaffold)
 #
-# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# Minimal cage — no AI agent, no tools
 # beyond what debian:stable-slim ships, no outbound network allowed by default.
 #
 # Quick start:
@@ -33,6 +33,13 @@ container:
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+
+  # Use the image's default USER (root for these base images). The
+  # agentcage default of "1000:1000" doesn't resolve to a real user
+  # in minimal base images, so `whoami` returns nothing and sudo is
+  # uninstallable. Inside the cage you are root; rootless podman maps
+  # that UID to your host user for bind-mounted writes.
+  user: ""
 
   read_only: false
 

--- a/src/agentcage/scaffolds/debian/scaffold.yaml
+++ b/src/agentcage/scaffolds/debian/scaffold.yaml
@@ -4,6 +4,9 @@ lifecycle: interactive
 build:
   - image: "localhost/agentcage-scaffold-debian:latest"
     containerfile: "Containerfile"
+    # Required for `apt-get install` to drop from root to the `_apt`
+    # user during the build of the scaffold image.
+    cap_add: [CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]
 
 next_steps:
   - "agentcage cage create -c {dest}"

--- a/src/agentcage/scaffolds/debian/scaffold.yaml
+++ b/src/agentcage/scaffolds/debian/scaffold.yaml
@@ -1,4 +1,4 @@
-description: "Minimal debian cage for testing agentcage primitives"
+description: "Minimal debian cage"
 lifecycle: interactive
 
 build:

--- a/src/agentcage/scaffolds/ubuntu/Containerfile
+++ b/src/agentcage/scaffolds/ubuntu/Containerfile
@@ -1,3 +1,11 @@
 FROM docker.io/library/ubuntu:latest
 
+# ca-certificates provides /etc/ssl/certs + the `update-ca-certificates`
+# helper. Needed so the cage's startup script can install the agentcage
+# MITM proxy CA into the system trust store and apt/curl/etc. trust the
+# intercepted TLS handshake to the package mirrors.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace

--- a/src/agentcage/scaffolds/ubuntu/README.md
+++ b/src/agentcage/scaffolds/ubuntu/README.md
@@ -1,6 +1,6 @@
 # ubuntu
 
-Minimal Ubuntu cage — no AI agent, no extra tools, no outbound network by default.
+Minimal Ubuntu cage — no AI agent, only `ca-certificates` added on top of the base image so `apt` trusts the agentcage MITM proxy, package mirrors pre-allowlisted so `apt-get` works out of the box.
 
 Image: `docker.io/library/ubuntu:latest` (current LTS, ~80 MB; includes bash, coreutils, apt).
 
@@ -20,10 +20,11 @@ agentcage run ubuntu
 
 ## What you get
 
-- `sleep infinity` keeps the container alive; you drop in via `cage exec`.
+- The cage's startup command installs the agentcage MITM proxy CA into Ubuntu's system trust store (`update-ca-certificates`) so apt trusts the intercepted TLS to the mirrors. Then `sleep infinity` keeps the container alive; you drop in via `cage exec`.
 - `${PROJECT_DIR}:/workspace:rw` is the only volume mount.
-- Domain allowlist is empty — every outbound request is blocked by the proxy. Add hosts under `domains.allow` in `cage.yaml` to test specific paths.
-- No tools beyond Ubuntu's base. To `apt-get install` you'll need to allowlist `archive.ubuntu.com` and `security.ubuntu.com`.
+- Domain allowlist pre-allows `archive.ubuntu.com` and `security.ubuntu.com`. Everything else is blocked by the proxy until you add it under `domains.allow` in `cage.yaml`.
+- Cage runs as root with the minimum `add_capabilities` for `apt` to install packages (`CHOWN`, `FOWNER`, `DAC_OVERRIDE`, `SETUID`, `SETGID`).
+- `apt-get update && apt-get install -y curl` works out of the box.
 - No secrets pre-injected. A commented-out `GITHUB_TOKEN` block is left in `cage.yaml` as a starting point.
 
 ## Use cases

--- a/src/agentcage/scaffolds/ubuntu/README.md
+++ b/src/agentcage/scaffolds/ubuntu/README.md
@@ -1,6 +1,6 @@
 # ubuntu
 
-Minimal Ubuntu cage for testing agentcage primitives — no AI agent, no extra tools, no outbound network by default.
+Minimal Ubuntu cage — no AI agent, no extra tools, no outbound network by default.
 
 Image: `docker.io/library/ubuntu:latest` (current LTS, ~80 MB; includes bash, coreutils, apt).
 

--- a/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
+++ b/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
@@ -28,7 +28,13 @@ container:
   image: "localhost/agentcage-scaffold-ubuntu:latest"
   build:
     containerfile: "Containerfile"
-  command: ["sleep", "infinity"]
+  # Install the agentcage MITM proxy CA into the system trust store at
+  # startup so apt (and any other tool that doesn't read SSL_CERT_FILE)
+  # can talk to the package mirrors over the intercepted TLS connection.
+  command:
+    - "sh"
+    - "-c"
+    - "cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/agentcage-proxy.crt && update-ca-certificates >/dev/null 2>&1 && exec sleep infinity"
 
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
@@ -52,6 +58,16 @@ container:
 
   timeout_start_sec: 30
 
+  # Capabilities needed by apt to install packages (chown installed files,
+  # set setuid bits, etc.). The cage drops ALL caps by default; these are
+  # the minimum re-added for `apt-get install <pkg>` to succeed as root.
+  add_capabilities:
+    - CHOWN
+    - FOWNER
+    - DAC_OVERRIDE
+    - SETUID
+    - SETGID
+
 # ── Secret injection (none by default) ──
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
@@ -60,11 +76,15 @@ container:
 #    inject_to:
 #      - github.com
 
-# ── Domain allowlist (empty by default) ──
-# Add the hosts you want the cage to reach. Subdomains are matched
-# automatically (e.g. "github.com" also allows "api.github.com").
+# ── Domain allowlist ──
+# Subdomains are matched automatically (e.g. "github.com" also allows
+# "api.github.com").
 domains:
-  allow: []
+  allow:
+    # ── Ubuntu package mirrors (apt-get update / apt-get install) ──
+    - archive.ubuntu.com
+    - security.ubuntu.com
+    # Add more hosts your test needs:
     # - example.com
 
 # ── Logging ──

--- a/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
+++ b/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
@@ -1,6 +1,6 @@
 # agentcage configuration for {{ name }} (ubuntu scaffold)
 #
-# Minimal cage for testing agentcage primitives — no AI agent, no tools
+# Minimal cage — no AI agent, no tools
 # beyond what ubuntu:latest ships, no outbound network allowed by default.
 #
 # Quick start:
@@ -33,6 +33,13 @@ container:
   # Project directory — mount your repo here if you want to poke at it.
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
+
+  # Use the image's default USER (root for these base images). The
+  # agentcage default of "1000:1000" doesn't resolve to a real user
+  # in minimal base images, so `whoami` returns nothing and sudo is
+  # uninstallable. Inside the cage you are root; rootless podman maps
+  # that UID to your host user for bind-mounted writes.
+  user: ""
 
   read_only: false
 

--- a/src/agentcage/scaffolds/ubuntu/scaffold.yaml
+++ b/src/agentcage/scaffolds/ubuntu/scaffold.yaml
@@ -1,4 +1,4 @@
-description: "Minimal ubuntu cage for testing agentcage primitives"
+description: "Minimal ubuntu cage"
 lifecycle: interactive
 
 build:

--- a/src/agentcage/scaffolds/ubuntu/scaffold.yaml
+++ b/src/agentcage/scaffolds/ubuntu/scaffold.yaml
@@ -4,6 +4,9 @@ lifecycle: interactive
 build:
   - image: "localhost/agentcage-scaffold-ubuntu:latest"
     containerfile: "Containerfile"
+    # Required for `apt-get install` to drop from root to the `_apt`
+    # user during the build of the scaffold image.
+    cap_add: [CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]
 
 next_steps:
   - "agentcage cage create -c {dest}"


### PR DESCRIPTION
## Summary

Make the five minimal distro scaffolds shipped in #129 actually usable: they now run as root inside the cage, and the four with package managers (alpine, arch, ubuntu, debian) can `update + install curl` out of the box. Tested locally one by one against each distro.

### 1. Default to root inside the cage (all five)

agentcage's container schema defaults `container.user` to `"1000:1000"` (`config.py:67`). Minimal base images have no UID-1000 user, so `whoami` returned nothing useful, `sudo` was uninstallable, and the shell prompt only showed `luca` because `\$USER` bleeds through `podman exec`.

Fix: `user: ""` in each `cage.yaml.j2` falls back to the image's USER directive (root for all five base images). Inside the cage you're now UID 0 with a real `/etc/passwd` entry; rootless podman still maps that to your host UID for bind-mounted writes — same on-host behavior, sensible inside.

### 2. Package install works out of the box (alpine, arch, ubuntu, debian)

| Distro | Install command | Verified version |
|---|---|---|
| alpine | `apk update && apk add curl` | curl 8.19.0 |
| arch | `pacman -Sy && pacman -S curl` | curl 8.20.0 |
| ubuntu | `apt-get update && apt-get install -y curl` | curl 8.18.0-1ubuntu2.1 |
| debian | `apt-get update && apt-get install -y curl` | curl 8.14.1-2+deb13u3 |

What each scaffold needed:

- **Capabilities** (`add_capabilities` in `cage.yaml.j2`): `CHOWN`, `FOWNER`, `DAC_OVERRIDE`, `SETUID`, `SETGID`. The cage drops ALL caps by default; these are the minimum re-added for the package manager to chown installed files, set setuid bits, and drop from root to the helper user (`_apt` etc.).
- **Mirrors pre-allowlisted** under `domains.allow`:
  - alpine → `alpinelinux.org` (covers `dl-cdn.alpinelinux.org`)
  - arch → `pkgbuild.com` (covers `fastly.mirror.pkgbuild.com` + `geo.mirror.pkgbuild.com`) and `archlinux.org`
  - ubuntu → `archive.ubuntu.com`, `security.ubuntu.com`
  - debian → `deb.debian.org`, `security.debian.org`
- **MITM proxy CA trust at startup** (arch, ubuntu, debian): the cage's `command:` now copies `/certs/mitmproxy-ca-cert.pem` into the system trust store before exec'ing `sleep infinity`. pacman / apt read the system trust store, not `SSL_CERT_FILE`, so without this they fail with "unable to get local issuer certificate" on every mirror hit. Alpine's `apk` respects `SSL_CERT_FILE` via libtls, so its `command:` is unchanged.
- **ubuntu + debian Containerfile**: add `apt-get install -y ca-certificates` at build time so the `update-ca-certificates` helper exists at runtime. This new build step needs `cap_add: [CAP_SETUID, CAP_SETGID, CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_FOWNER]` restored to `scaffold.yaml` (the original cap set I removed in #129, now justified by an actual apt install). Alpine and arch Containerfiles still only do `FROM + WORKDIR` so they need no build-time caps.

### 3. busybox unchanged (deliberately)

`busybox:latest` ships only the busybox static binary — no `apk`, `apt`, `pacman`, or any package manager. It can't install curl no matter what we do. README updated to document this and point users to the alpine scaffold for tiny + installable.

### 4. Tightened copy

Dropped "for testing agentcage primitives" from all 15 description sites (3 per scaffold × 5).

## Test plan
- [x] alpine: `apk add curl` from inside cage installs curl 8.19.0
- [x] arch: `pacman -S curl` from inside cage reinstalls curl 8.20.0
- [x] ubuntu: `apt-get install -y curl` from inside cage installs curl 8.18.0-1ubuntu2.1
- [x] debian: `apt-get install -y curl` from inside cage installs curl 8.14.1-2+deb13u3
- [x] All cages: `whoami` returns `root`, `id` returns `uid=0(root)`
- [x] All five `cage.yaml` renders parse + validate clean in container and VM isolation
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)