### PR TITLE
fix(claude-code): run install.cjs after --ignore-scripts npm install

### DIFF
--- a/src/agentcage/scaffolds/claude-code/Containerfile
+++ b/src/agentcage/scaffolds/claude-code/Containerfile
@@ -15,9 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -s /usr/bin/fdfind /usr/local/bin/fd
 
 # Install Claude Code CLI (latest stable).
-# --ignore-scripts skips npm postinstall hooks (defense-in-depth — the
-# package's runtime code still runs, only postinstall is skipped).
-RUN npm install -g --ignore-scripts @anthropic-ai/claude-code
+# --ignore-scripts skips npm postinstall hooks for ALL packages in the
+# dependency tree (defense-in-depth against malicious transitive
+# postinstalls). Then run claude-code's own install.cjs explicitly —
+# it's required to wire `/usr/local/bin/claude` (which is a symlink to
+# `bin/claude.exe`) to the platform-native binary downloaded into
+# `node_modules/@anthropic-ai/claude-code-linux-<arch>/claude`. Without
+# this step the symlinked `claude.exe` is a no-shebang error stub that
+# exec()s with ENOEXEC (issue #132).
+RUN npm install -g --ignore-scripts @anthropic-ai/claude-code \
+    && node /usr/local/lib/node_modules/@anthropic-ai/claude-code/install.cjs
 
 # node:22-slim already has user node (1000:1000)
 USER node


### PR DESCRIPTION
Closes #132.

## Summary
- `--ignore-scripts` correctly skips postinstall hooks for the whole dep tree (defense-in-depth) but ALSO skips claude-code's own `install.cjs`, which is what wires `claude.exe` to the platform-native binary
- Without it, `/usr/local/bin/claude` → `claude.exe` is a no-shebang error stub that exec()s with ENOEXEC
- Fix: keep `--ignore-scripts` for the broad install, then run claude-code's `install.cjs` explicitly. The error stub itself documents this as the right move

## Why this surfaced on 0.20.0 and apple-container

- Recent `@anthropic-ai/claude-code` versions switched from a JS-with-shebang `claude.exe` to a platform-native binary architecture (separate `claude-code-linux-arm64` / `-x64` packages). The stub is the new normal — install.cjs is now required
- apple-container backend exec'd `claude` after a strict cap-drop + NoNewPrivs, so the kernel returned ENOEXEC without falling back to the error stub's stderr output. Reproduces on any backend that exec()s the symlinked file directly

## Test plan
- [x] Built a wrapper image on macOS 26 + Apple Silicon with the patched Containerfile
- [x] Verified `claude.exe` is now an ELF executable: `head -c 4 | od -c` → `177 E L F`
- [x] `claude --version` prints `2.1.150 (Claude Code)`
- [x] Existing 14 claude-code unit tests still pass; 1375 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)