### PR TITLE
fix(output): pause active spinner while child writes to stderr

### DIFF
--- a/src/agentcage/apple_container/cli.py
+++ b/src/agentcage/apple_container/cli.py
@@ -13,6 +13,8 @@ import shutil
 import subprocess
 from subprocess import CompletedProcess
 
+from agentcage import output
+
 
 _CANDIDATE_PATHS = (
     "/usr/local/bin/container",
@@ -46,13 +48,27 @@ def run(
             "Apple `container` CLI not found; install from "
             "https://github.com/apple/container/releases"
         )
-    return subprocess.run(
-        [binary, *args],
-        check=check,
-        capture_output=capture_output,
-        text=text,
-        input=input,
-    )
+    if capture_output:
+        return subprocess.run(
+            [binary, *args],
+            check=check,
+            capture_output=capture_output,
+            text=text,
+            input=input,
+        )
+    # Streaming case: Apple's `container` CLI writes its own progress
+    # (e.g. "[1/2] Fetching image [13s]") to stderr. If an agentcage
+    # Spinner is currently running it would fight for the same line,
+    # producing a flickering double-spinner. Pause our spinner for the
+    # duration of the child process so its output is unobstructed.
+    with output.pause_active_spinner():
+        return subprocess.run(
+            [binary, *args],
+            check=check,
+            capture_output=capture_output,
+            text=text,
+            input=input,
+        )
 
 
 def system_running() -> bool:

--- a/src/agentcage/output.py
+++ b/src/agentcage/output.py
@@ -6,10 +6,12 @@ compact info lines, and a braille-dot spinner for in-progress steps.
 
 from __future__ import annotations
 
+import contextlib
 import itertools
 import sys
 import threading
 import time
+from typing import Iterator
 
 import click
 
@@ -65,6 +67,14 @@ def red(text: str) -> str:
     return click.style(text, fg="red")
 
 
+# Module-level reference to the currently-active Spinner, if any.
+# Used by ``pause_active_spinner`` so subprocess wrappers that stream their
+# own progress to stderr (e.g. Apple's ``container`` CLI) can temporarily
+# silence our braille spinner to avoid two writers fighting for the same
+# terminal line.
+_active: "Spinner | None" = None
+
+
 class Spinner:
     """Context manager that shows a braille spinner on the current line.
 
@@ -79,6 +89,8 @@ class Spinner:
         self._thread: threading.Thread | None = None
 
     def __enter__(self) -> Spinner:
+        global _active
+        _active = self
         if not sys.stderr.isatty():
             click.echo(f"  \u2026 {self.msg}", err=True)
             return self
@@ -87,11 +99,43 @@ class Spinner:
         return self
 
     def __exit__(self, *exc: object) -> None:
+        global _active
         self._stop.set()
         if self._thread:
             self._thread.join()
+            self._thread = None
         if sys.stderr.isatty():
             click.echo("\r\033[K", nl=False, err=True)
+        # Defensive: only clear _active if it still points at us, so a
+        # hypothetical nested spinner can't accidentally unset its parent.
+        if _active is self:
+            _active = None
+
+    def pause(self) -> None:
+        """Stop the spin thread and clear the current line.
+
+        ``self.msg`` is preserved so ``resume()`` can restart cleanly.
+        No-op when stderr is not a TTY (the static "… msg" line stays).
+        """
+        if not sys.stderr.isatty():
+            return
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+            self._thread = None
+        click.echo("\r\033[K", nl=False, err=True)
+
+    def resume(self) -> None:
+        """Re-spawn the spin thread after a ``pause()``.
+
+        No-op when stderr is not a TTY.
+        """
+        if not sys.stderr.isatty():
+            return
+        # Recreate the stop event since the old one is already set.
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
 
     def _spin(self) -> None:
         for frame in itertools.cycle(self._FRAMES):
@@ -99,3 +143,22 @@ class Spinner:
                 break
             click.echo(f"\r  {frame} {self.msg}", nl=False, err=True)
             time.sleep(0.08)
+
+
+@contextlib.contextmanager
+def pause_active_spinner() -> Iterator[None]:
+    """Pause the active Spinner for the duration of the ``with`` block.
+
+    Use this around subprocess calls that stream their own progress to
+    stderr (e.g. Apple's ``container`` CLI), so two writers don't fight
+    over the same terminal line. No-op if no Spinner is currently active.
+    """
+    spinner = _active
+    if spinner is None:
+        yield
+        return
+    spinner.pause()
+    try:
+        yield
+    finally:
+        spinner.resume()

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -389,3 +389,57 @@ def test_build_artifacts_no_cmd_anywhere_raises_helpful_error():
          patch.object(ac_wrapper, "build_wrapper", new=MagicMock()):
         with pytest.raises(RuntimeError, match="cannot determine cage entrypoint"):
             AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
+
+
+def test_run_streaming_pauses_active_spinner():
+    """``ac_cli.run(capture_output=False)`` must wrap subprocess.run in
+    ``output.pause_active_spinner()`` so Apple's CLI progress doesn't fight
+    our braille spinner for the same terminal line.
+    """
+    from agentcage import output as ac_output
+
+    events: list[str] = []
+
+    fake_spinner = type(
+        "FakeSpinner", (), {
+            "pause": lambda self: events.append("pause"),
+            "resume": lambda self: events.append("resume"),
+        },
+    )()
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        events.append("subprocess.run")
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "container_binary", return_value="/usr/local/bin/container"), \
+         patch.object(ac_output, "_active", fake_spinner), \
+         patch("agentcage.apple_container.cli.subprocess.run", side_effect=fake_subprocess_run):
+        ac_cli.run(["image", "pull", "alpine"], check=False, capture_output=False)
+
+    # pause must happen before the subprocess starts, resume after it returns.
+    assert events == ["pause", "subprocess.run", "resume"]
+
+
+def test_run_capturing_does_not_pause_active_spinner():
+    """The capturing path is silent on stderr -- no need to pause the spinner."""
+    from agentcage import output as ac_output
+
+    events: list[str] = []
+
+    fake_spinner = type(
+        "FakeSpinner", (), {
+            "pause": lambda self: events.append("pause"),
+            "resume": lambda self: events.append("resume"),
+        },
+    )()
+
+    def fake_subprocess_run(*_args, **_kwargs):
+        events.append("subprocess.run")
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "container_binary", return_value="/usr/local/bin/container"), \
+         patch.object(ac_output, "_active", fake_spinner), \
+         patch("agentcage.apple_container.cli.subprocess.run", side_effect=fake_subprocess_run):
+        ac_cli.run(["inspect", "x"], check=False, capture_output=True)
+
+    assert events == ["subprocess.run"]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,128 @@
+"""Unit tests for ``agentcage.output``.
+
+These exercise the spinner pause/resume mechanism that prevents
+agentcage's braille spinner from fighting with subprocess-owned
+progress writers (Apple's ``container`` CLI) for the same terminal line.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from agentcage import output
+
+
+# ---------------------------------------------------------------------------
+# pause_active_spinner
+# ---------------------------------------------------------------------------
+
+def test_pause_active_spinner_noop_when_no_active():
+    """No active spinner -> the context manager is a silent no-op."""
+    # Sanity: nothing else in the test process should have left an active
+    # spinner behind. If it has, we want to know.
+    assert output._active is None
+    with output.pause_active_spinner():
+        pass  # Should not raise.
+    assert output._active is None
+
+
+def test_pause_active_spinner_calls_pause_and_resume_on_active():
+    """When _active is set, the CM should call pause() then resume()."""
+    fake = MagicMock(spec=output.Spinner)
+    with patch.object(output, "_active", fake):
+        with output.pause_active_spinner():
+            fake.pause.assert_called_once_with()
+            fake.resume.assert_not_called()
+        fake.pause.assert_called_once_with()
+        fake.resume.assert_called_once_with()
+
+
+def test_pause_active_spinner_resumes_even_on_exception():
+    """resume() must be called even if the body raises."""
+    fake = MagicMock(spec=output.Spinner)
+    with patch.object(output, "_active", fake):
+        try:
+            with output.pause_active_spinner():
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+    fake.pause.assert_called_once_with()
+    fake.resume.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Spinner.pause / Spinner.resume (non-TTY branch)
+# ---------------------------------------------------------------------------
+
+def test_spinner_pause_resume_noop_when_not_a_tty():
+    """No thread is ever spawned in non-TTY mode; pause/resume must not crash."""
+    with patch("sys.stderr.isatty", return_value=False):
+        s = output.Spinner("hello")
+        with s:
+            assert s._thread is None  # No thread in non-TTY mode.
+            s.pause()  # Must not raise / must not spawn a thread.
+            assert s._thread is None
+            s.resume()  # Must not raise / must not spawn a thread.
+            assert s._thread is None
+
+
+# ---------------------------------------------------------------------------
+# Spinner.pause / Spinner.resume (TTY branch)
+# ---------------------------------------------------------------------------
+
+def test_spinner_pause_stops_thread_and_resume_restarts_it():
+    """In TTY mode, pause() must stop the thread and resume() must start a new one."""
+    with patch("sys.stderr.isatty", return_value=True):
+        s = output.Spinner("hello")
+        with s:
+            t1 = s._thread
+            assert t1 is not None
+            assert t1.is_alive()
+            s.pause()
+            assert s._thread is None
+            # The original thread should have exited.
+            assert not t1.is_alive()
+            s.resume()
+            t2 = s._thread
+            assert t2 is not None
+            assert t2.is_alive()
+            assert t2 is not t1  # Must be a freshly spawned thread.
+        # After __exit__, no thread should be running.
+        assert not t2.is_alive()
+
+
+def test_spinner_enter_sets_active_and_exit_clears():
+    """The active reference must track the spinner lifecycle."""
+    with patch("sys.stderr.isatty", return_value=False):
+        assert output._active is None
+        s = output.Spinner("hello")
+        with s:
+            assert output._active is s
+        assert output._active is None
+
+
+def test_spinner_pause_preserves_msg_for_resume():
+    """pause() must not destroy ``self.msg`` -- resume relies on it."""
+    with patch("sys.stderr.isatty", return_value=True):
+        s = output.Spinner("the-message")
+        with s:
+            s.pause()
+            assert s.msg == "the-message"
+            s.resume()
+            assert s.msg == "the-message"
+
+
+def test_spinner_pause_uses_a_fresh_stop_event_after_resume():
+    """resume() must give us a fresh Event so a later __exit__ stops the thread."""
+    with patch("sys.stderr.isatty", return_value=True):
+        s = output.Spinner("hello")
+        with s:
+            s.pause()
+            old_stop = s._stop
+            assert old_stop.is_set()
+            s.resume()
+            # New stop event after resume.
+            assert s._stop is not old_stop
+            assert isinstance(s._stop, threading.Event)
+            assert not s._stop.is_set()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

`agentcage run <image>` on the `apple-container` backend currently shows two
spinners racing on the same terminal line while pulling an image:

```
  ⠼ Starting cage...⠹ [1/2] Fetching image [13s]
```

Apple's `container` CLI streams its own progress to stderr during
`image pull` (and other long-running operations), and agentcage's
braille `Spinner` (in `output.py`) writes `\r  <frame> <msg>` to the
same line every 80 ms. With no `\033[K` between them, the two writers
overdraw each other and flicker. Apple's progress is the informative
one — users want to keep seeing that — so the right fix is for our
spinner to step aside.

This PR introduces a small pause/resume mechanism on `Spinner` and a
`pause_active_spinner()` context manager. The streaming branch of
`apple_container.cli.run` (i.e. `capture_output=False`) wraps the
child `subprocess.run` in that context manager, so Apple's CLI owns
the terminal line for the duration of the call and our spinner
resumes after it returns.

Scope: this PR only fixes the apple-container backend. The same
pattern would help `limactl create` / `limactl start` (VM backend) —
filing as a separate follow-up so this PR stays small.

## Test plan

- [x] `uv run pytest tests/test_output.py` (5 new tests — pause/resume
  state transitions, no-op when no spinner active, pause/resume
  invoked on the live `_active` reference)
- [x] `uv run pytest tests/test_apple_container.py` (2 new tests —
  streaming `ac_cli.run` enters the pause context around
  `subprocess.run`; capturing `ac_cli.run` does not)
- [x] Full suite: `uv run pytest` — 1353 passing; the 32 failing
  tests are pre-existing environment-specific failures (lima/podman
  doctor checks, secrets backend, vm config defaults on a macOS 26
  Apple Silicon host where `default_isolation()` now returns
  `apple-container`). Verified identical failure set on `origin/master`
  prior to applying this change.
- [ ] Manual: run `agentcage run ubuntu` on a fresh apple-container
  host where the image is not cached; confirm Apple's `[1/2] Fetching
  image [Ns]` progress renders without a competing braille spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)