### PR TITLE
fix(init): skip host-podman scaffold build for vm/apple-container isolation

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -264,7 +264,7 @@ def init(name: str | None, output: str, image: str, isolation: str | None,
 
     meta = load_scaffold_meta(scaffold) if scaffold else None
     if scaffold and meta:
-        run_scaffold_setup(scaffold, name, str(dest))
+        run_scaffold_setup(scaffold, name, str(dest), isolation=isolation)
         # Copy Containerfile and sibling build context files from scaffold
         scaffold_dir_path = resolve_scaffold(scaffold)
         if scaffold_dir_path is not None:

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -222,16 +222,21 @@ def load_scaffold_meta(scaffold: str) -> dict | None:
 
 def run_scaffold_setup(
     scaffold: str, name: str, dest: str, *, quiet: bool = False,
+    isolation: str | None = None,
 ) -> None:
-    """Execute build/provision steps from scaffold.yaml."""
+    """Execute build/provision steps from scaffold.yaml.
+
+    The host-podman build path is only meaningful for the ``container``
+    isolation backend. For ``vm`` and ``apple-container``, images are built
+    by the backend itself (inside the Lima VM or via Apple's ``container``
+    CLI) at cage create time, so we skip the host build loop entirely.
+    When *isolation* is ``None`` we preserve the legacy behavior (run the
+    build loop) for existing callers that don't pass isolation.
+    """
     meta = load_scaffold_meta(scaffold)
     if meta is None:
         return
 
-    from agentcage.podman import Podman
-    from agentcage.registry import resolve_build_args
-
-    podman = Podman()
     scaffold_dir = resolve_scaffold(scaffold)
     if scaffold_dir is None:
         return
@@ -240,43 +245,53 @@ def run_scaffold_setup(
         if not quiet:
             click.echo(msg)
 
-    # 1. Process build entries
-    for entry in meta.get("build", []):
-        image = entry["image"]
-        if podman.image_exists(image):
-            _echo(f"Image {image} already exists, skipping build.")
-            continue
+    # 1. Process build entries — host podman only relevant for container isolation
+    if isolation in (None, "container"):
+        from agentcage.podman import Podman
+        from agentcage.registry import resolve_build_args
 
-        # Resolve tags for scaffold-declared build args.
-        declared = entry.get("build_args") or {}
-        build_args, changes = resolve_build_args(declared, declared)
-        for key, _old, new in changes:
-            _echo(f"Build arg {key}: {new}")
+        podman = Podman()
+        for entry in meta.get("build", []):
+            image = entry["image"]
+            if podman.image_exists(image):
+                _echo(f"Image {image} already exists, skipping build.")
+                continue
 
-        if "containerfile" in entry:
-            containerfile = str(scaffold_dir / entry["containerfile"])
-            _echo(f"Building {image}...")
-            podman.build_image(
-                image, containerfile, str(scaffold_dir),
-                cap_add=entry.get("cap_add"), build_args=build_args,
-                quiet=quiet,
-            )
-        elif "git" in entry:
-            git_url = entry["git"]
-            depth = entry.get("depth", 1)
-            with tempfile.TemporaryDirectory() as tmpdir:
-                _echo(f"Cloning {git_url}...")
-                cmd = ["git", "clone", f"--depth={depth}", git_url, tmpdir]
-                if quiet:
-                    subprocess.run(cmd, check=True, capture_output=True)
-                else:
-                    subprocess.run(cmd, check=True)
+            # Resolve tags for scaffold-declared build args.
+            declared = entry.get("build_args") or {}
+            build_args, changes = resolve_build_args(declared, declared)
+            for key, _old, new in changes:
+                _echo(f"Build arg {key}: {new}")
+
+            if "containerfile" in entry:
+                containerfile = str(scaffold_dir / entry["containerfile"])
                 _echo(f"Building {image}...")
                 podman.build_image(
-                    image, None, tmpdir,
+                    image, containerfile, str(scaffold_dir),
                     cap_add=entry.get("cap_add"), build_args=build_args,
                     quiet=quiet,
                 )
+            elif "git" in entry:
+                git_url = entry["git"]
+                depth = entry.get("depth", 1)
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    _echo(f"Cloning {git_url}...")
+                    cmd = ["git", "clone", f"--depth={depth}", git_url, tmpdir]
+                    if quiet:
+                        subprocess.run(cmd, check=True, capture_output=True)
+                    else:
+                        subprocess.run(cmd, check=True)
+                    _echo(f"Building {image}...")
+                    podman.build_image(
+                        image, None, tmpdir,
+                        cap_add=entry.get("cap_add"), build_args=build_args,
+                        quiet=quiet,
+                    )
+    elif meta.get("build"):
+        _echo(
+            f"Skipping host image build for {isolation} isolation; "
+            f"images will be built by the backend at cage create."
+        )
 
     # 2. Process provision entries
     for entry in meta.get("provision", []):

--- a/tests/test_custom_scaffolds.py
+++ b/tests/test_custom_scaffolds.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -17,6 +17,7 @@ from agentcage.init import (
     list_scaffolds,
     load_scaffold_meta,
     resolve_scaffold,
+    run_scaffold_setup,
     scaffold_source,
 )
 
@@ -362,3 +363,111 @@ class TestScaffoldMetadataFields:
             assert "lifecycle" in meta, f"{name} missing lifecycle"
             assert meta["lifecycle"] in ("interactive", "service"), \
                 f"{name} has invalid lifecycle: {meta['lifecycle']}"
+
+
+# ── run_scaffold_setup isolation gating ─────────────────────────
+
+
+class TestRunScaffoldSetupIsolation:
+    """Verify host-podman build path is skipped on non-container isolation.
+
+    On macOS users have ``vm`` or ``apple-container`` isolation and host
+    podman is not installed; invoking it would crash with FileNotFoundError.
+    Both backends build images themselves at cage create time.
+    """
+
+    def _make_scaffold(self, tmp_path: Path) -> Path:
+        """Create a user scaffold with a build entry and a provision entry."""
+        user_dir = tmp_path / "scaffolds"
+        scaffold = user_dir / "test-iso"
+        scaffold.mkdir(parents=True)
+        (scaffold / "cage.yaml.j2").write_text("name: {{ name }}\n")
+        (scaffold / "Containerfile").write_text("FROM scratch\n")
+        provision_src = scaffold / "provision-file.txt"
+        provision_src.write_text("hello\n")
+        (scaffold / "scaffold.yaml").write_text(yaml.safe_dump({
+            "description": "test",
+            "lifecycle": "interactive",
+            "build": [{
+                "image": "localhost/agentcage-scaffold-test-iso:latest",
+                "containerfile": "Containerfile",
+            }],
+            "provision": [{
+                "src": "provision-file.txt",
+                "dest": str(tmp_path / "out" / "provision-file.txt"),
+            }],
+        }))
+        return user_dir
+
+    @patch("agentcage.init._project_scaffolds_dir", return_value=None)
+    def test_apple_container_isolation_skips_podman(self, _mock_proj, tmp_path):
+        user_dir = self._make_scaffold(tmp_path)
+
+        with patch("agentcage.init._USER_SCAFFOLDS_DIR", user_dir), \
+             patch("agentcage.podman.Podman") as mock_podman_cls:
+            # Any podman instantiation would raise — but we shouldn't get here
+            mock_podman_cls.side_effect = FileNotFoundError(
+                "[Errno 2] No such file or directory: 'podman'"
+            )
+            # Must not raise
+            run_scaffold_setup(
+                "test-iso", "cage1", str(tmp_path / "cage.yaml"),
+                isolation="apple-container",
+            )
+            assert mock_podman_cls.call_count == 0
+            # Provision still ran
+            assert (tmp_path / "out" / "provision-file.txt").is_file()
+
+    @patch("agentcage.init._project_scaffolds_dir", return_value=None)
+    def test_vm_isolation_skips_podman(self, _mock_proj, tmp_path):
+        user_dir = self._make_scaffold(tmp_path)
+
+        with patch("agentcage.init._USER_SCAFFOLDS_DIR", user_dir), \
+             patch("agentcage.podman.Podman") as mock_podman_cls:
+            mock_podman_cls.side_effect = FileNotFoundError(
+                "[Errno 2] No such file or directory: 'podman'"
+            )
+            run_scaffold_setup(
+                "test-iso", "cage1", str(tmp_path / "cage.yaml"),
+                isolation="vm",
+            )
+            assert mock_podman_cls.call_count == 0
+            assert (tmp_path / "out" / "provision-file.txt").is_file()
+
+    @patch("agentcage.init._project_scaffolds_dir", return_value=None)
+    def test_container_isolation_invokes_podman(self, _mock_proj, tmp_path):
+        user_dir = self._make_scaffold(tmp_path)
+
+        with patch("agentcage.init._USER_SCAFFOLDS_DIR", user_dir), \
+             patch("agentcage.podman.Podman") as mock_podman_cls:
+            mock_podman = MagicMock()
+            mock_podman.image_exists.return_value = False
+            mock_podman_cls.return_value = mock_podman
+
+            run_scaffold_setup(
+                "test-iso", "cage1", str(tmp_path / "cage.yaml"),
+                isolation="container",
+            )
+            mock_podman_cls.assert_called_once()
+            mock_podman.image_exists.assert_called_once_with(
+                "localhost/agentcage-scaffold-test-iso:latest"
+            )
+            mock_podman.build_image.assert_called_once()
+            assert (tmp_path / "out" / "provision-file.txt").is_file()
+
+    @patch("agentcage.init._project_scaffolds_dir", return_value=None)
+    def test_isolation_none_preserves_legacy_behavior(self, _mock_proj, tmp_path):
+        """Callers that don't pass isolation still hit the build loop."""
+        user_dir = self._make_scaffold(tmp_path)
+
+        with patch("agentcage.init._USER_SCAFFOLDS_DIR", user_dir), \
+             patch("agentcage.podman.Podman") as mock_podman_cls:
+            mock_podman = MagicMock()
+            mock_podman.image_exists.return_value = True  # short-circuit build
+            mock_podman_cls.return_value = mock_podman
+
+            run_scaffold_setup(
+                "test-iso", "cage1", str(tmp_path / "cage.yaml"),
+            )
+            mock_podman_cls.assert_called_once()
+            mock_podman.image_exists.assert_called_once()


### PR DESCRIPTION
## Summary

On macOS with no host podman, `agentcage init <name> --scaffold <scaffold>` crashed because `run_scaffold_setup` unconditionally invoked `Podman().image_exists(...)` before delegating to backends that do their own image builds inside the Lima VM or via Apple's `container` CLI.

- `src/agentcage/init.py` — `run_scaffold_setup` now accepts an `isolation` kwarg; the host-podman build loop runs only when `isolation in (None, "container")`. For `vm`/`apple-container` it prints one explanation line and skips. Provision loop always runs.
- `src/agentcage/cli.py` — `agentcage init` passes the resolved isolation through.
- `tests/test_custom_scaffolds.py` — adds `TestRunScaffoldSetupIsolation` covering all four cases (apple-container/vm skip podman, container hits podman, `None` preserves legacy behavior).

### User-visible traceback (before this fix)

```
File ".../agentcage/init.py", line 246, in run_scaffold_setup
    if podman.image_exists(image):
...
FileNotFoundError: [Errno 2] No such file or directory: 'podman'
```

## Test plan

- [x] `uv run pytest tests/test_custom_scaffolds.py` — 38 tests pass (4 new).
- [x] `agentcage init ubuntu01 --scaffold ubuntu --isolation apple-container` on macOS with no host podman completes successfully and prints the skip notice.
- [x] `agentcage init ubuntu02 --scaffold ubuntu --isolation vm` on macOS with no host podman completes successfully and prints the skip notice.
- [ ] On Linux with host podman, `agentcage init <name> --scaffold <scaffold>` (default isolation = container) still builds scaffold images as before.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>