### PR TITLE
fix(cli): route cage subcommands through apple-container CLI instead of host podman

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -61,6 +61,45 @@ def _podman_for_cage(name: str) -> Podman:
     return Podman()
 
 
+def _is_apple_container(cfg) -> bool:
+    """True if the cage uses the apple-container isolation backend."""
+    return getattr(cfg, "isolation", None) == "apple-container"
+
+
+def _exit_apple_container_unsupported(command: str) -> None:
+    """Exit cleanly when a subcommand isn't implemented on apple-container.
+
+    The apple-container backend does not yet support every cage subcommand
+    that container/vm do. Rather than fall through to host podman (which
+    crashes on macOS without podman installed), we exit non-zero with a
+    helpful message. Tracked as a follow-up in issue #120.
+    """
+    click.echo(
+        f"error: 'cage {command}' is not yet implemented for the "
+        f"apple-container backend (see issue #120)",
+        err=True,
+    )
+    sys.exit(1)
+
+
+def _require_cage_service_on_apple_container(service: str, command: str) -> None:
+    """Reject --service proxy|dns on apple-container with a clear message.
+
+    On apple-container the cage is a single Apple microVM (one container)
+    with mitmproxy and dnsmasq running inside it as supervised processes,
+    not as separate Apple containers. Targeted proxy/dns exec/shell access
+    isn't wired up yet; the only addressable target today is `cage`.
+    """
+    if service != "cage":
+        click.echo(
+            f"error: 'cage {command} --service {service}' is not yet "
+            f"supported on the apple-container backend; only --service cage "
+            f"is addressable (proxy and dnsmasq run inside the same microVM)",
+            err=True,
+        )
+        sys.exit(1)
+
+
 def _build_container_image(cfg, config_dir: Path, podman: Podman,
                            no_cache: bool = False,
                            pull: bool = False) -> None:
@@ -957,6 +996,17 @@ def cage_verify(name: str):
 
     if cfg.isolation == "container":
         _verify_container(name, _pass, _fail, _warn)
+    elif _is_apple_container(cfg):
+        # The apple-container backend does service-level checks via
+        # `backend.is_running` (already run above). Deeper inside-the-cage
+        # probes (proxy CA, egress block, nested podman) aren't wired up
+        # yet on this backend — keep verify a no-crash one-liner rather
+        # than shelling out to host podman.
+        click.echo()
+        click.echo(
+            "  [INFO] deeper checks (CA / egress / nested) are not yet "
+            "implemented for apple-container; service-status checks only"
+        )
     else:
         _verify_vm(name, _pass, _fail)
 
@@ -1137,8 +1187,14 @@ def cage_restart(name: str):
 
     cfg = state.load_deployment_config(name)
 
-    # Re-copy patch files from package data to overwrite any tampering
-    _ensure_patches(Podman())
+    # Re-copy patch files from package data to overwrite any tampering.
+    # The apple-container backend doesn't use host-side nested-container
+    # patch files (the cage runs as a single Apple microVM with no
+    # bind-mounted podman shim), so skip this on apple-container —
+    # instantiating Podman() would crash later when its methods shell
+    # out to a missing host podman.
+    if not _is_apple_container(cfg):
+        _ensure_patches(Podman())
 
     _restart_cage(name, cfg)
     click.echo(f"Restarted cage '{name}'")
@@ -1167,20 +1223,26 @@ def cage_start(name: str):
         sys.exit(1)
 
     cfg = state.load_deployment_config(name)
-    podman = Podman()
-    _ensure_patches(podman)
 
-    # Refresh env:/cmd: secrets before starting (they may have changed)
-    from agentcage.secret_resolver import resolve_and_populate
-    resolve_and_populate(podman, cfg, name, state.deployment_dir(name))
+    # Host-podman-backed steps are skipped on apple-container: there's
+    # no host podman to instantiate, no host-side patches to refresh,
+    # and no host podman secret store to (re)populate. Secrets for the
+    # apple-container backend are env-passed by `start` itself.
+    if not _is_apple_container(cfg):
+        podman = Podman()
+        _ensure_patches(podman)
 
-    # Regenerate derived files from cage.yaml so any edits made while
-    # the cage was stopped are applied on the next start. The dns
-    # allowlist is a sidecar file mounted into dnsmasq; the quadlet
-    # itself only needs rewriting on the (rare) migration case.
-    state.save_proxy_config(name)
-    state.save_dns_allowlist(name)
-    _ensure_dns_quadlet_current(cfg)
+        # Refresh env:/cmd: secrets before starting (they may have changed)
+        from agentcage.secret_resolver import resolve_and_populate
+        resolve_and_populate(podman, cfg, name, state.deployment_dir(name))
+
+        # Regenerate derived files from cage.yaml so any edits made while
+        # the cage was stopped are applied on the next start. The dns
+        # allowlist is a sidecar file mounted into dnsmasq; the quadlet
+        # itself only needs rewriting on the (rare) migration case.
+        state.save_proxy_config(name)
+        state.save_dns_allowlist(name)
+        _ensure_dns_quadlet_current(cfg)
 
     backend = get_backend(cfg)
     backend.start(name)
@@ -1229,20 +1291,26 @@ def cage_show(name: str):
     except Exception:
         pass
 
-    # Secrets
-    podman = _podman_for_cage(name)
-    secrets = podman.secret_list(prefix=f"{name}.")
-    expected = _expected_secrets(cfg)
-    present_keys = {
-        s.get("Name", "").removeprefix(f"{name}.")
-        for s in secrets
-    }
-    missing = [k for k in expected if k not in present_keys]
-    if expected:
-        if missing:
-            click.echo(f"Secrets:    {len(present_keys)}/{len(expected)} ({len(missing)} missing)")
-        else:
-            click.echo(f"Secrets:    {len(expected)}/{len(expected)}")
+    # Secrets — host podman is the secret store, so skip the count on
+    # apple-container (which has no host podman) rather than crash.
+    if _is_apple_container(cfg):
+        expected = _expected_secrets(cfg)
+        if expected:
+            click.echo(f"Secrets:    {len(expected)} expected (status not tracked on apple-container)")
+    else:
+        podman = _podman_for_cage(name)
+        secrets = podman.secret_list(prefix=f"{name}.")
+        expected = _expected_secrets(cfg)
+        present_keys = {
+            s.get("Name", "").removeprefix(f"{name}.")
+            for s in secrets
+        }
+        missing = [k for k in expected if k not in present_keys]
+        if expected:
+            if missing:
+                click.echo(f"Secrets:    {len(present_keys)}/{len(expected)} ({len(missing)} missing)")
+            else:
+                click.echo(f"Secrets:    {len(expected)}/{len(expected)}")
 
 
 @cage.command("logs")
@@ -1269,6 +1337,8 @@ def cage_logs(name, services, lines, follow, no_follow, min_level):
 
     if cfg.isolation == "vm":
         _logs_vm(name, selected, lines, no_follow_effective, min_level)
+    elif _is_apple_container(cfg):
+        _logs_apple_container(name, selected, lines, no_follow_effective, min_level)
     else:
         _logs_container(name, selected, lines, no_follow_effective, min_level)
 
@@ -1400,6 +1470,32 @@ def _logs_vm(name, services, lines, no_follow, min_level=None):
             proc.terminate()
 
 
+def _logs_apple_container(name, services, lines, no_follow, min_level=None):  # noqa: ARG001
+    """Stream logs from the per-cage Apple container.
+
+    Apple's `container logs` reads the supervisor's stdout/stderr for the
+    one microVM that backs the cage. There are no separate proxy/dns
+    journal units to filter on — those run as processes inside the same
+    container — so the ``services`` and ``min_level`` arguments are
+    accepted for parity with the other backends but currently don't
+    sub-filter output. The user gets the full combined stream.
+    """
+    from agentcage.apple_container import cli as ac_cli
+    binary = ac_cli.container_binary()
+    if binary is None:
+        click.echo(
+            "error: Apple `container` CLI not found; install from "
+            "https://github.com/apple/container/releases",
+            err=True,
+        )
+        sys.exit(1)
+    argv = [binary, "logs"]
+    if not no_follow:
+        argv.append("-f")
+    argv.append(name)
+    os.execvp(binary, argv)
+
+
 @cage.command("exec", context_settings={"ignore_unknown_options": True})
 @click.argument("name")
 @click.option("-s", "--service", default="cage",
@@ -1433,6 +1529,22 @@ def cage_exec(name: str, service: str, command: tuple[str, ...]):
         exec_flags = ["-it"] if sys.stdin.isatty() else []
         os.execvp("limactl", ["limactl", "shell", inst.name, "--",
                   "podman", "exec", *exec_flags, f"{name}-{service}", *cmd])
+
+    if _is_apple_container(cfg):
+        _require_cage_service_on_apple_container(service, "exec")
+        from agentcage.apple_container import cli as ac_cli
+        binary = ac_cli.container_binary()
+        if binary is None:
+            click.echo(
+                "error: Apple `container` CLI not found; install from "
+                "https://github.com/apple/container/releases",
+                err=True,
+            )
+            sys.exit(1)
+        exec_flags = ["-it"] if sys.stdin.isatty() else []
+        # The cage is one Apple container named after the cage itself
+        # (see backends.apple_container — no -cage/-proxy/-dns suffix split).
+        os.execvp(binary, [binary, "exec", *exec_flags, name, *cmd])
 
     container = f"{name}-{service}"
     exec_flags = []
@@ -1474,6 +1586,29 @@ def cage_shell(name: str, service: str):
         exec_flags = ["-it"] if sys.stdin.isatty() else []
         os.execvp("limactl", ["limactl", "shell", inst.name, "--",
                   "podman", "exec", *exec_flags, container, "/bin/sh"])
+
+    if _is_apple_container(cfg):
+        _require_cage_service_on_apple_container(service, "shell")
+        from agentcage.apple_container import cli as ac_cli
+        binary = ac_cli.container_binary()
+        if binary is None:
+            click.echo(
+                "error: Apple `container` CLI not found; install from "
+                "https://github.com/apple/container/releases",
+                err=True,
+            )
+            sys.exit(1)
+        # Auto-detect bash, fall back to sh.
+        for shell in ("/bin/bash", "/bin/sh"):
+            result = subprocess.run(
+                [binary, "exec", name, "test", "-x", shell],
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                exec_flags = ["-it"] if sys.stdin.isatty() else []
+                os.execvp(binary, [binary, "exec", *exec_flags, name, shell])
+        exec_flags = ["-it"] if sys.stdin.isatty() else []
+        os.execvp(binary, [binary, "exec", *exec_flags, name, "/bin/sh"])
 
     container = f"{name}-{service}"
     # Auto-detect bash or fall back to sh
@@ -1670,6 +1805,13 @@ def cage_audit(name, decisions, directions, hosts, inspectors, severity,
 
     cfg = state.load_deployment_config(name)
 
+    # Audit on apple-container needs a different log path (mitmproxy
+    # writes /var/log/proxy.log inside the microVM, not the host
+    # journal). Not wired up yet — exit cleanly instead of running
+    # journalctl on a missing host.
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("audit")
+
     filt = AuditFilter(
         decisions=list(decisions),
         directions=list(directions),
@@ -1737,6 +1879,13 @@ def cage_har(name, view, decisions, hosts, methods, directions, since,
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+
+    cfg = state.load_deployment_config(name)
+    # HAR export depends on the proxy's capture.jsonl being bind-mounted
+    # to a host path; that's not wired up for apple-container yet (the
+    # capture file lives inside the microVM).
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("har")
 
     from agentcage.har import CaptureFilter, capture_to_har, parse_since
 
@@ -1822,6 +1971,12 @@ def cage_backup(name: str, output: str | None, include_secrets: bool):
         sys.exit(1)
 
     cfg = state.load_deployment_config(name)
+    # Backup pulls secrets out of host podman's secret store and exports
+    # named volumes via `podman volume export` — neither is available on
+    # apple-container today. Exit cleanly rather than crash on the first
+    # podman call.
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("backup")
     podman = _podman_for_cage(name)
 
     # Determine output path
@@ -1954,6 +2109,12 @@ def cage_restore(tarball: str, new_name: str | None, force: bool, no_start: bool
             err=True,
         )
         sys.exit(1)
+
+    # The apple-container backend has no host-podman secret store /
+    # named volume export, which `restore` relies on. Exit cleanly
+    # rather than crash on the first podman call.
+    if manifest.get("isolation") == "apple-container":
+        _exit_apple_container_unsupported("restore")
 
     target_name = new_name or manifest["cage_name"]
 
@@ -2350,6 +2511,12 @@ def _ensure_dns_quadlet_current(cfg) -> bool:
     first run under the new code rewrites the unit and does one daemon-reload;
     every subsequent call is a no-op.
     """
+    # The apple-container backend has no per-cage DNS quadlet — dnsmasq
+    # runs as a process inside the single microVM, supervised in-band by
+    # the cage's PID 1. Nothing on the host to render or daemon-reload.
+    if _is_apple_container(cfg):
+        return False
+
     from agentcage.quadlets import render_dns_quadlet
 
     backend = get_backend(cfg)
@@ -2427,6 +2594,19 @@ def _update_dns_quadlet(cfg) -> None:
                           check=False)
             for svc in reversed(services):
                 inst.exec(["systemctl", "--user", "start", f"{name}-{svc}.service"])
+    elif _is_apple_container(cfg):
+        # On apple-container the proxy/dns allowlist is baked into the
+        # wrapper image at build time, so the new allowlist only takes
+        # effect after a `cage update`. Restart the cage so the user at
+        # least sees a fresh container; warn that a rebuild is required
+        # for the change to apply.
+        if backend.is_running(name, "cage"):
+            backend.restart(name)
+        click.echo(
+            "note: apple-container bakes the allowlist into the wrapper "
+            "image; run `agentcage cage update " + name + "` to apply.",
+            err=True,
+        )
     else:
         if backend.is_running(name, "dns"):
             # Stop most-dependent first, start dependencies first.

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -1,0 +1,293 @@
+"""Tests for `agentcage cage <subcommand>` on apple-container isolation.
+
+Regression coverage for the bug where every `cage <subcommand>` other
+than `cage create`/`update`/`list`/`destroy` fell through to host
+``podman`` on apple-container, crashing with FileNotFoundError on
+macOS hosts without podman installed.
+
+Each test patches the apple-container ``container_binary`` resolver and
+asserts the subprocess argv routes through ``container ...`` (not
+``podman ...``), or that the command exits cleanly with a helpful
+message instead of crashing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from agentcage.cli import main
+
+
+def _runner():
+    return CliRunner()
+
+
+def _mock_config(isolation="apple-container", lifecycle="service", scaffold=""):
+    cfg = MagicMock()
+    cfg.isolation = isolation
+    cfg.lifecycle = lifecycle
+    cfg.scaffold = scaffold
+    cfg.container.nested_containers = False
+    cfg.exec_aliases = {}
+    cfg.name = "demo"
+    return cfg
+
+
+# ── cage exec ────────────────────────────────────────────
+
+
+class TestCageExecAppleContainer:
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_exec_calls_container_exec(self, mock_state, mock_execvp, mock_binary):
+        """exec on apple-container goes through `container exec`, not podman."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        _runner().invoke(main, ["cage", "exec", "demo", "--", "ls", "-la"])
+
+        # Routed through the apple `container` CLI on the resolved path.
+        mock_execvp.assert_called_once_with(
+            "/usr/local/bin/container",
+            ["/usr/local/bin/container", "exec", "demo", "ls", "-la"],
+        )
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_exec_rejects_proxy_service(self, mock_state, mock_execvp, mock_binary):
+        """--service proxy is rejected with a clear message (not a crash)."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        result = _runner().invoke(
+            main, ["cage", "exec", "demo", "-s", "proxy", "--", "ls"],
+        )
+        assert result.exit_code != 0
+        assert "proxy" in result.output
+        assert "apple-container" in result.output
+        mock_execvp.assert_not_called()
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_exec_errors_when_binary_missing(
+        self, mock_state, mock_execvp, mock_binary,
+    ):
+        """A missing Apple `container` CLI exits with a clean message."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = None
+
+        result = _runner().invoke(main, ["cage", "exec", "demo", "--", "ls"])
+        assert result.exit_code != 0
+        assert "container" in result.output.lower()
+        mock_execvp.assert_not_called()
+
+
+# ── cage shell ──────────────────────────────────────────
+
+
+class TestCageShellAppleContainer:
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.subprocess.run")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_shell_autodetects_bash(
+        self, mock_state, mock_execvp, mock_run, mock_binary,
+    ):
+        """shell probes /bin/bash via `container exec test -x` then execs it.
+
+        ``os.execvp`` is mocked so it doesn't actually replace the
+        process; the test asserts on the first call (what would have
+        happened on a real host).
+        """
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+        # First probe (bash) succeeds.
+        mock_run.return_value = MagicMock(returncode=0)
+
+        _runner().invoke(main, ["cage", "shell", "demo"])
+
+        # Bash probe goes through `container exec`.
+        first_probe = mock_run.call_args_list[0]
+        assert first_probe.args[0] == [
+            "/usr/local/bin/container", "exec", "demo", "test", "-x", "/bin/bash",
+        ]
+        # And the *first* execvp call is the bash that probed OK.
+        # (Without a real exec, control falls through to a host-podman
+        # fallback in container mode — but on apple-container we never
+        # reach that fallthrough; first call must already be /bin/bash.)
+        first_exec = mock_execvp.call_args_list[0]
+        assert first_exec.args == (
+            "/usr/local/bin/container",
+            ["/usr/local/bin/container", "exec", "demo", "/bin/bash"],
+        )
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.subprocess.run")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_shell_falls_back_to_sh_via_container(
+        self, mock_state, mock_execvp, mock_run, mock_binary,
+    ):
+        """Neither /bin/bash nor /bin/sh probes match → fall back to
+        `container exec ... /bin/sh`, never to host `podman`."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+        # All probes fail.
+        mock_run.return_value = MagicMock(returncode=1)
+
+        _runner().invoke(main, ["cage", "shell", "demo"])
+
+        # First execvp call is the apple-container /bin/sh fallback.
+        # CRITICAL: it must NOT be `podman`. (The post-apple-container
+        # fall-through path in cage_shell only runs because os.execvp is
+        # mocked in tests; on a real host it would have replaced the
+        # process already.)
+        first_exec = mock_execvp.call_args_list[0]
+        assert first_exec.args == (
+            "/usr/local/bin/container",
+            ["/usr/local/bin/container", "exec", "demo", "/bin/sh"],
+        )
+
+
+# ── cage logs ───────────────────────────────────────────
+
+
+class TestCageLogsAppleContainer:
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_logs_streams_container_logs(
+        self, mock_state, mock_execvp, mock_binary,
+    ):
+        """cage logs runs `container logs <name>`, not journalctl/podman."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        _runner().invoke(main, ["cage", "logs", "demo"])
+
+        mock_execvp.assert_called_once_with(
+            "/usr/local/bin/container",
+            ["/usr/local/bin/container", "logs", "demo"],
+        )
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_logs_follow_passes_f(
+        self, mock_state, mock_execvp, mock_binary,
+    ):
+        """`-f` propagates to `container logs -f <name>`."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        _runner().invoke(main, ["cage", "logs", "demo", "-f"])
+
+        mock_execvp.assert_called_once_with(
+            "/usr/local/bin/container",
+            ["/usr/local/bin/container", "logs", "-f", "demo"],
+        )
+
+
+# ── cage verify ─────────────────────────────────────────
+
+
+class TestCageVerifyAppleContainer:
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_verify_short_circuits_with_notice(
+        self, mock_state, mock_get_backend,
+    ):
+        """verify on apple-container reports service status only and never
+        shells out to host podman."""
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        backend = MagicMock()
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+
+        result = _runner().invoke(main, ["cage", "verify", "demo"])
+
+        # No crash and the info banner mentions the limitation.
+        assert "PASS" in result.output
+        assert "apple-container" in result.output
+
+
+# ── cage audit / har / backup / restore: gated on apple-container ──
+
+
+class TestCageGatedCommandsAppleContainer:
+    @patch("agentcage.cli.state")
+    def test_audit_exits_unsupported(self, mock_state):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        result = _runner().invoke(main, ["cage", "audit", "demo"])
+        assert result.exit_code != 0
+        assert "apple-container" in result.output
+        assert "not yet implemented" in result.output
+
+    @patch("agentcage.cli.state")
+    def test_backup_exits_unsupported(self, mock_state):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        result = _runner().invoke(main, ["cage", "backup", "demo"])
+        assert result.exit_code != 0
+        assert "apple-container" in result.output
+        assert "not yet implemented" in result.output
+
+
+# ── cage start / restart: do not instantiate host Podman ──
+
+
+class TestCageStartRestartAppleContainer:
+    """Regression: `cage start` / `cage restart` on apple-container must not
+    call _ensure_patches(Podman()) — instantiating and using host podman
+    fails on macOS hosts where podman isn't installed. The backend's own
+    start/restart are the only thing that should run."""
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._ensure_patches")
+    @patch("agentcage.cli.state")
+    def test_start_skips_ensure_patches(
+        self, mock_state, mock_ensure_patches, mock_get_backend,
+    ):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        backend = MagicMock()
+        mock_get_backend.return_value = backend
+
+        result = _runner().invoke(main, ["cage", "start", "demo"])
+
+        # The host-podman patches step must not run on apple-container.
+        mock_ensure_patches.assert_not_called()
+        # The backend's start() is still what brings the cage up.
+        backend.start.assert_called_once_with("demo")
+        assert result.exit_code == 0
+
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli._ensure_patches")
+    @patch("agentcage.cli.state")
+    def test_restart_skips_ensure_patches(
+        self, mock_state, mock_ensure_patches, mock_restart, mock_get_backend,
+    ):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_get_backend.return_value = MagicMock()
+
+        result = _runner().invoke(main, ["cage", "restart", "demo"])
+
+        mock_ensure_patches.assert_not_called()
+        mock_restart.assert_called_once()
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary

On macOS 26 / Apple Silicon with no host podman, every `cage <subcommand>` other than `create`/`update`/`list`/`destroy` falls through to host `podman` and crashes:

```
luca@F0HP39W35N ubuntu01 % agentcage cage exec ubuntu01 -- bash
...
  File ".../agentcage/cli.py", line 1441, in cage_exec
    result = subprocess.run(
        ["podman", "exec"] + exec_flags + [container] + cmd,
    )
FileNotFoundError: [Errno 2] No such file or directory: 'podman'
```

Almost every `cage <subcommand>` had the same shape: a `cfg.isolation == "vm"` branch that returned, then a fall-through that assumed host `podman` exists. This PR adds apple-container branches everywhere it matters and exits cleanly (non-zero, helpful message) where the feature isn't wired up yet. No `Backend` protocol lift — that's tracked separately in `backends/apple_container.py:21-23`.

Per command (apple-container behavior):

- **`cage exec`** — execs `container exec [-it] <name> <cmd...>` via the resolved Apple `container` binary
- **`cage shell`** — auto-detects `/bin/bash` via `container exec test -x`, falls back to `/bin/sh`, all through Apple's `container` CLI
- **`cage logs`** — execs `container logs [-f] <name>`
- **`cage verify`** — keeps the backend-agnostic service-status checks (which already work via `backend.is_running`) and prints a one-line notice that deeper probes (CA / egress / nested) aren't wired up
- **`cage show`** — keeps the basic info; replaces the host-podman-backed secret count with an "X expected (status not tracked)" line
- **`cage start`** — skips `_ensure_patches(Podman())` and `resolve_and_populate`, lets `backend.start()` do the work
- **`cage restart`** — skips `_ensure_patches(Podman())`, lets `backend.restart()` do the work
- **`--service proxy|dns`** on `exec`/`shell` — rejected with a clear message (the apple-container backend runs proxy and dnsmasq as processes inside the one per-cage Apple container; there's no separate target to address)
- **`cage audit`** — exits with `not yet implemented for apple-container backend (see issue #120)` (mitmproxy writes `proxy.log` inside the microVM; the host bridge isn't built yet)
- **`cage har`** — same exit (the `capture.jsonl` bind-mount isn't wired up on apple-container yet)
- **`cage backup`** / **`cage restore`** — same exit (host podman secret store and `podman volume export` aren't reachable)

Also gates `_ensure_dns_quadlet_current` and `_update_dns_quadlet` so `cage start`/`restart` and `domain add`/`rm` don't try to render a host DNS quadlet or call `systemd.daemon_reload()` on macOS.

Container and vm branches are unchanged.

## Test plan

- [x] `tests/test_apple_container_cli.py` covers argv routing for `exec` / `shell` / `logs`, the `--service proxy` rejection, the missing-binary error path, and that `start`/`restart` skip `_ensure_patches` on apple-container — 12 new tests, all green.
- [x] No new failures in `uv run pytest`: 32 pre-existing platform-dependent failures unchanged (test_doctor, test_vm_config, test_cage_cli's lima cases, test_secret_cli, test_lima_prerequisites), 1355 pass.
- [ ] `agentcage cage exec ubuntu01 -- bash` on macOS without host podman — should drop into a bash inside the cage instead of FileNotFoundError.
- [ ] `agentcage cage shell ubuntu01` — same.
- [ ] `agentcage cage logs ubuntu01` — should stream the supervisor's stdout/stderr via `container logs`.
- [ ] `agentcage cage verify ubuntu01` — should print service-status PASS/FAIL plus the "deeper checks not implemented" notice; never crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)