### PR TITLE
fix(apple-container): resolve cage user by uid + tolerate scaffold CA cp EACCES

### DIFF
--- a/src/agentcage/data/apple-container/Containerfile.wrapper.j2
+++ b/src/agentcage/data/apple-container/Containerfile.wrapper.j2
@@ -60,11 +60,13 @@ RUN getent passwd 200 >/dev/null && { echo "uid 200 already taken" >&2; exit 79;
     && useradd --uid 200 --system --no-create-home --shell /usr/sbin/nologin --home-dir /var/empty acproxy \
     && useradd --uid 201 --system --no-create-home --shell /usr/sbin/nologin --home-dir /var/empty acdns \
     && if getent passwd 1000 >/dev/null; then \
-         # User image already has a user at uid 1000 (claude-code uses
-         # `claude`, node:* uses `node`, etc.). Reuse that uid for the
-         # cage workload — capsh in the supervisor uses uid 1000 numeric,
-         # not a hard-coded name. We add a `cage` alias to the same uid
-         # via /etc/passwd line append (useradd refuses to share a uid).
+         # User image already has a user at uid 1000 (ubuntu uses
+         # `ubuntu`, node:* uses `node`, claude-code uses `claude`, etc.).
+         # Reuse that user for the cage workload. The supervisor resolves
+         # the uid-1000 user's *name* at runtime (`getent passwd 1000`)
+         # and passes it to `capsh --user=`, so the existing name works
+         # without needing to alias to `cage`. useradd refuses to share
+         # a uid, which is why we don't try to create a second name here.
          existing=$(getent passwd 1000 | cut -d: -f1); \
          echo "reusing existing uid-1000 user: $existing" >&2; \
        else \

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -193,7 +193,17 @@ iptables -A OUTPUT -m owner --uid-owner 200 -j ACCEPT
 iptables -A OUTPUT -m owner --uid-owner 201 -j ACCEPT
 
 #-- 90. Drop caps + exec cage workload ------------------------------------
-log "stage 90: dropping caps, switching to cage user (uid 1000)"
+# Resolve the name of the uid-1000 user in the image. The wrapper
+# Containerfile creates `cage` only when the user image doesn't already
+# have a uid-1000 entry — bases like ubuntu (`ubuntu`), node (`node`),
+# and claude-code (`claude`) keep their own name. capsh's `--user=` flag
+# resolves by NAME (it calls getpwnam internally to get uid/gid/home),
+# so a hard-coded `--user=cage` blows up on those images with
+# "User [cage] not known" and the cage exits before any workload runs.
+CAGE_USER=$(getent passwd 1000 | cut -d: -f1)
+[ -n "${CAGE_USER}" ] \
+  || die "no user at uid 1000 in cage image — wrapper Containerfile should have created one" 89
+log "stage 90: dropping caps, switching to cage user '${CAGE_USER}' (uid 1000)"
 # capsh argv (order matters — flags are processed left to right):
 #   --no-new-privs  → set NO_NEW_PRIVS prctl. Sticks across execve; blocks
 #                     cage's children from gaining caps via setuid/setcap
@@ -204,12 +214,12 @@ log "stage 90: dropping caps, switching to cage user (uid 1000)"
 #                     guarantees the cage cannot acquire any capability
 #                     even if NNP enforcement regresses or future code
 #                     adds a privileged path we haven't considered.
-#   --user=cage     → setuid+setgid+initgroups to cage (uid 1000). The
+#   --user=$CAGE_USER → setuid+setgid+initgroups to the uid-1000 user. The
 #                     uid 0→1000 transition clears CapEff/CapPrm/CapInh.
 #                     CapBnd is already empty from --drop=all above.
 exec capsh \
   --no-new-privs \
   --drop=all \
-  --user=cage \
+  --user="${CAGE_USER}" \
   --shell=/bin/sh \
   -- -c "exec ${CMD_LINE}"

--- a/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
+++ b/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
@@ -31,10 +31,18 @@ container:
   # Install the agentcage MITM proxy CA into the system trust store at
   # startup so apt (and any other tool that doesn't read SSL_CERT_FILE)
   # can talk to the package mirrors over the intercepted TLS connection.
+  #
+  # The cp + update-ca-certificates pair is best-effort: it succeeds on the
+  # container backend (where the cage runs as root and /certs is bind-mounted)
+  # and is a harmless no-op on apple-container (the supervisor has already
+  # installed the CA at stage 60 and runs the cage workload as uid 1000,
+  # which can't write to /usr/local/share/ca-certificates). Without the
+  # `|| true` the apt-update-CA dance would crash the cage immediately on
+  # apple-container before `sleep infinity` ever runs.
   command:
     - "sh"
     - "-c"
-    - "cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/agentcage-proxy.crt && update-ca-certificates >/dev/null 2>&1 && exec sleep infinity"
+    - "{ cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/agentcage-proxy.crt && update-ca-certificates >/dev/null 2>&1; } || true; exec sleep infinity"
 
   # Project directory — mount your repo here if you want to poke at it.
   volumes:

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -206,6 +206,62 @@ def test_stage_build_context_includes_allowlist_addon(tmp_path):
     assert "403" in addon  # must respond with 403, not silently pass
 
 
+def test_supervisor_resolves_cage_user_dynamically(tmp_path):
+    """REGRESSION: capsh's `--user=` resolves by NAME, so a hard-coded
+    `--user=cage` blows up on images that already have a different uid-1000
+    user (ubuntu → `ubuntu`, node → `node`, claude-code → `claude`). The
+    supervisor must look up the uid-1000 name at runtime before exec'ing
+    capsh, otherwise stage 90 dies with `User [cage] not known` and the
+    whole container exits before any cage workload starts."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    sup = (tmp_path / "supervisor.sh").read_text()
+    # The name MUST be resolved from /etc/passwd at runtime.
+    assert "getent passwd 1000" in sup
+    # The capsh invocation that drops caps + switches to the cage user
+    # MUST reference the resolved variable, not the literal `cage`. We
+    # find the line by looking for the `--user=` argument that follows
+    # `--drop=all` (the capsh pattern unique to stage 90).
+    lines = sup.splitlines()
+    cage_user_idx = next(
+        (i for i, ln in enumerate(lines)
+         if ln.strip().startswith("--drop=all") and not ln.lstrip().startswith("#")),
+        None,
+    )
+    assert cage_user_idx is not None, (
+        "supervisor.sh has no executable `--drop=all` (stage 90 capsh)"
+    )
+    # The `--user=` argument follows on the next non-blank line.
+    follow = lines[cage_user_idx + 1].strip()
+    assert follow.startswith("--user="), (
+        f"expected --user= to follow --drop=all, got: {follow!r}"
+    )
+    assert "${CAGE_USER}" in follow, (
+        f"capsh --user= for the cage workload must reference $CAGE_USER, "
+        f"got: {follow!r}"
+    )
+
+
+def test_ubuntu_scaffold_ca_install_tolerates_eacces():
+    """REGRESSION: the ubuntu scaffold's `command` runs `cp` into a root-only
+    directory. On the container backend the cage runs as root so it works;
+    on apple-container the supervisor forces the cage workload to uid 1000,
+    which can't write to /usr/local/share/ca-certificates. Without the
+    `|| true` swallow the cp's EACCES would propagate, the cage CMD would
+    exit non-zero, and the container would stop before `sleep infinity` —
+    making `agentcage run ubuntu` look like an instant exit."""
+    from pathlib import Path
+    scaffold = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "scaffolds" / "ubuntu" / "cage.yaml.j2"
+    )
+    content = scaffold.read_text()
+    # The whole cp+update-ca-certificates pair must be guarded by `|| true`
+    # so a permission error doesn't kill the cage on apple-container.
+    assert "|| true" in content
+    # `exec sleep infinity` must still be reachable after the guard.
+    assert "exec sleep infinity" in content
+
+
 def test_user_cmd_missing_image_raises():
     with patch.object(ac_cli, "image_inspect", return_value=None):
         with pytest.raises(ValueError, match="cannot inspect"):


### PR DESCRIPTION
## Summary

`agentcage run ubuntu` on 0.20.2 / apple-container still exits immediately. The dbc8072 fix made cage.yaml's `command:` take precedence, but the cage never reaches the workload — the supervisor crashes earlier at stage 90:

```
[supervisor] stage 80: applying iptables egress rules
[supervisor] stage 90: dropping caps, switching to cage user (uid 1000)
User [cage] not known
```

The supervisor execs `capsh --user=cage ...`, but `capsh` resolves `--user=` by **name** (it calls `getpwnam` to get uid/gid/home). The wrapper Containerfile only creates a `cage` user when the user image has no uid-1000 entry — and ubuntu, node, claude-code (the popular base images) all ship their own uid-1000 user (`ubuntu`, `node`, `claude`). So `getpwnam("cage")` fails on every one of those bases and the whole container dies before any cage workload starts.

The existing Containerfile comment promised a `cage` /etc/passwd alias to fix this, but the alias was never actually appended.

## Fix

- **Supervisor** resolves the uid-1000 user's *name* at runtime (`getent passwd 1000 | cut -d: -f1`) and passes it to `capsh --user=`. The wrapper Containerfile already reuses the existing uid-1000 user when one exists, so we just need to know what it's called. Bases without a uid-1000 user still get the `cage` user from the Containerfile's `useradd` fallback.
- **Containerfile comment** updated to match the actual contract (no false promise of a `cage` alias).
- **Ubuntu scaffold's command** was a secondary blocker: it does `cp /certs/mitmproxy-ca-cert.pem /usr/local/share/ca-certificates/agentcage-proxy.crt && update-ca-certificates`. That works on the container backend (cage runs as root there, `/certs` is bind-mounted). On apple-container the supervisor has already installed the CA at stage 60 AND switches the cage workload to uid 1000, so the cp fails with EACCES, the cage CMD exits non-zero, container stops. Wrap the cp+update-ca-certificates pair in `{ ... } || true; exec sleep infinity` so the redundant install is a no-op on apple-container and the cage keeps running.

## Commands touched

- `src/agentcage/data/apple-container/supervisor.sh` — resolve `$CAGE_USER` dynamically, pass to capsh
- `src/agentcage/data/apple-container/Containerfile.wrapper.j2` — comment cleanup (no functional change)
- `src/agentcage/scaffolds/ubuntu/cage.yaml.j2` — `|| true; exec sleep infinity` so EACCES doesn't kill the cage

## Tests

Two regression tests in `tests/test_apple_container.py`:
- `test_supervisor_resolves_cage_user_dynamically` — asserts the supervisor uses `${CAGE_USER}` and looks it up via `getent passwd 1000`.
- `test_ubuntu_scaffold_ca_install_tolerates_eacces` — asserts the scaffold command guards the CA install with `|| true` and still execs sleep.

Full suite: 1376 pass, 31 pre-existing platform-dependent failures unchanged (test_doctor / test_vm_config / test_secret_cli / test_lima_prerequisites / test_cage_cli's lima cases). No new failures.

## Test plan

- [x] Reproduced original symptom on 0.20.2: `agentcage run ubuntu` → cage exits immediately, supervisor log shows `User [cage] not known`.
- [x] After fix: supervisor log shows `stage 90: dropping caps, switching to cage user 'ubuntu' (uid 1000)`, cage stays running, `agentcage cage exec testcage -- bash` works.
- [ ] CI on Linux (container backend) — should be unaffected since the apple-container supervisor.sh isn't executed there and the ubuntu scaffold's command works the same (the `|| true` is a no-op when cp succeeds).
- [ ] Validate on a node:* or claude-code scaffold to confirm the supervisor's `$CAGE_USER` resolves correctly on those bases too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)