### PR TITLE
fix(apple-container): redirect non-component uids through proxy + strip AAAA

### DIFF
--- a/src/agentcage/data/apple-container/dnsmasq.conf
+++ b/src/agentcage/data/apple-container/dnsmasq.conf
@@ -21,5 +21,12 @@ no-hosts
 port=53
 server=1.1.1.1
 server=8.8.8.8
+# Strip AAAA records from upstream responses. IPv6 is disabled at the
+# netfilter + sysctl level (supervisor.sh stage 80), but if dnsmasq still
+# returns AAAA records the cage's resolvers happily try IPv6 first; the
+# attempts fail instantly ("Cannot assign requested address") and fall
+# back to IPv4 — correct but slow, and noisy in client logs. Dropping
+# AAAA at the resolver keeps everything single-stack.
+filter-AAAA
 log-queries=extra
 log-facility=/var/log/agentcage/dnsmasq.log

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -167,11 +167,21 @@ iptables -P OUTPUT DROP
 # Allow established/related so responses come back in.
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
-# Cage's egress to tcp/80 and tcp/443 → REDIRECT to local mitmproxy on
-# 8080 (transparent mode handles both HTTP and HTTPS on one port).
-iptables -t nat -A OUTPUT -p tcp --dport 80 -m owner --uid-owner 1000 \
+# Egress to tcp/80 and tcp/443 → REDIRECT to local mitmproxy on 8080
+# (transparent mode handles both HTTP and HTTPS on one port). The match
+# excludes the proxy (uid 200) and dnsmasq (uid 201) so their upstream
+# connections aren't redirected back to themselves; every OTHER uid in
+# the container — the cage workload at uid 1000 AND root (uid 0), which
+# is what `container exec` enters as because the image's default USER on
+# most bases is root — gets redirected. Without root in the redirect,
+# `agentcage cage exec ubuntu02 -- apt-get update` skips the proxy and
+# falls straight to the default-DROP filter chain (timeouts on every
+# upstream connection).
+iptables -t nat -A OUTPUT -p tcp --dport 80 \
+    -m owner ! --uid-owner 200 -m owner ! --uid-owner 201 \
     -j REDIRECT --to-ports 8080
-iptables -t nat -A OUTPUT -p tcp --dport 443 -m owner --uid-owner 1000 \
+iptables -t nat -A OUTPUT -p tcp --dport 443 \
+    -m owner ! --uid-owner 200 -m owner ! --uid-owner 201 \
     -j REDIRECT --to-ports 8080
 
 # Loopback access is allowed PER PORT, not blanket `-o lo -j ACCEPT`. The

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -206,6 +206,37 @@ def test_stage_build_context_includes_allowlist_addon(tmp_path):
     assert "403" in addon  # must respond with 403, not silently pass
 
 
+def test_nat_redirect_excludes_proxy_and_dns_not_only_uid_1000(tmp_path):
+    """REGRESSION: NAT REDIRECT for tcp/80 and tcp/443 must catch every
+    uid except the egress components (uid 200 = mitmproxy, uid 201 = dnsmasq),
+    not only the cage workload at uid 1000. `container exec` enters as the
+    image's default USER — root on every popular base — so an interactive
+    `agentcage cage exec ubuntu02 -- apt-get update` runs as uid 0. Before
+    this fix the REDIRECT only matched uid 1000, so root's port-80/443
+    egress skipped the proxy entirely and hit the default-DROP filter chain.
+    """
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    sup = (tmp_path / "supervisor.sh").read_text()
+    # The OLD (buggy) form was: `--uid-owner 1000 -j REDIRECT`. Forbid it.
+    assert "--uid-owner 1000 -j REDIRECT" not in sup
+    assert "--uid-owner 1000 \\\n    -j REDIRECT" not in sup
+    # The NEW form excludes uid 200 (mitmproxy) and uid 201 (dnsmasq) so
+    # their upstream connections aren't redirected back to themselves.
+    assert "! --uid-owner 200" in sup
+    assert "! --uid-owner 201" in sup
+
+
+def test_dnsmasq_strips_aaaa_records(tmp_path):
+    """REGRESSION: dnsmasq must `filter-AAAA` so clients don't waste time
+    trying IPv6 addresses they can never reach (IPv6 is killed at the
+    netfilter + sysctl level by supervisor.sh stage 80). Without this the
+    cage still gets AAAA records back, curl/apt try IPv6 first, fail
+    instantly with "Cannot assign requested address", then fall back to v4."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    conf = (tmp_path / "dnsmasq.conf").read_text()
+    assert "filter-AAAA" in conf
+
+
 def test_supervisor_resolves_cage_user_dynamically(tmp_path):
     """REGRESSION: capsh's `--user=` resolves by NAME, so a hard-coded
     `--user=cage` blows up on images that already have a different uid-1000


### PR DESCRIPTION
## Summary

`agentcage cage exec ubuntu02 -- apt-get update` on apple-container failed for every upstream connection ("Unable to connect to archive.ubuntu.com:http:") even though archive.ubuntu.com is in the cage's `domains.allow`. Two issues:

### 1. NAT REDIRECT was uid-1000-only

The egress filter only redirected uid 1000 (the cage workload) to mitmproxy on tcp/80 and tcp/443:

```
iptables -t nat -A OUTPUT -p tcp --dport 80 -m owner --uid-owner 1000 -j REDIRECT --to-ports 8080
```

But `container exec` enters as the image's default USER — root on every popular base (ubuntu, debian, node, claude-code). So an interactive `cage exec ... -- apt-get update` ran as uid 0, skipped the NAT REDIRECT entirely, and hit the default-DROP filter chain. Every upstream connection timed out.

Fix: the REDIRECT now excludes only the egress components (uid 200 = mitmproxy, uid 201 = dnsmasq) so their upstream connections don't loop back to themselves; every other uid in the container flows through the proxy + allowlist as intended.

### 2. dnsmasq was returning AAAA records

IPv6 is killed at the netfilter + sysctl level (supervisor.sh stage 80), but dnsmasq was still returning AAAA records. The cage's `curl` / `apt` tried IPv6 first, hit `Cannot assign requested address` instantly, then fell back to IPv4 — correct but slow and noisy in client logs. Added `filter-AAAA` to `dnsmasq.conf` so AAAA records are stripped at the resolver and everything stays single-stack.

## Files

- `src/agentcage/data/apple-container/supervisor.sh` — REDIRECT match changed from `-m owner --uid-owner 1000` to `-m owner ! --uid-owner 200 -m owner ! --uid-owner 201`
- `src/agentcage/data/apple-container/dnsmasq.conf` — `filter-AAAA` added
- `tests/test_apple_container.py` — 2 regression tests (NAT exclusion shape + dnsmasq AAAA filter)

## Test plan

- [x] `uv run pytest tests/test_apple_container.py` — 39 pass (2 new)
- [x] On macOS 26.3.2 + ASi, after rebuilding the cage:
  - `agentcage cage exec ubuntu02 -- apt-get update` → fetches 23.8 MB from archive.ubuntu.com (allowlisted) in 1s
  - `curl https://example.com` (not allowlisted) → returns 403 from mitmproxy in ~50ms
  - `getent ahosts archive.ubuntu.com` → only IPv4 addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)