### PR TITLE
fix(cli): gate secret list/set/rm on apple-container

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -2290,6 +2290,9 @@ def secret_list(name: str):
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+    cfg = state.load_deployment_config(name)
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("secret list")
     podman = _podman_for_cage(name)
     secrets = podman.secret_list(prefix=f"{name}.")
 
@@ -2337,6 +2340,9 @@ def secret_set(name: str, key: str):
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist — create it first with 'cage create'", err=True)
         sys.exit(1)
+    cfg = state.load_deployment_config(name)
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("secret set")
     podman = _podman_for_cage(name)
     full_name = f"{name}.{key}"
 
@@ -2411,6 +2417,9 @@ def secret_rm(name: str, key: str):
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+    cfg = state.load_deployment_config(name)
+    if _is_apple_container(cfg):
+        _exit_apple_container_unsupported("secret rm")
     podman = _podman_for_cage(name)
     full_name = f"{name}.{key}"
 

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -291,3 +291,60 @@ class TestCageStartRestartAppleContainer:
         mock_ensure_patches.assert_not_called()
         mock_restart.assert_called_once()
         assert result.exit_code == 0
+
+
+# ── secret list/set/rm: must not fall through to host podman ──
+
+
+class TestSecretCommandsAppleContainer:
+    """Regression: `agentcage secret list/set/rm <cage>` on apple-container
+    must exit cleanly with the unsupported message instead of crashing into
+    host podman (which doesn't exist on most macOS installs).
+
+    The proper apple-container secret store is tracked in #120 (heavy lift
+    for `cage backup/restore` brings the secret-store abstraction). Until
+    then `cage create` env-passes secrets directly via the supervisor's
+    config; users edit them by editing cage.yaml + `cage update`.
+    """
+
+    @patch("agentcage.cli._podman_for_cage")
+    @patch("agentcage.cli.state")
+    def test_secret_list_exits_unsupported(self, mock_state, mock_podman):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+
+        result = _runner().invoke(main, ["secret", "list", "demo"])
+
+        assert result.exit_code != 0
+        assert "apple-container" in result.output
+        assert "not yet implemented" in result.output
+        # Host podman must NEVER be instantiated.
+        mock_podman.assert_not_called()
+
+    @patch("agentcage.cli._podman_for_cage")
+    @patch("agentcage.cli.state")
+    def test_secret_set_exits_unsupported(self, mock_state, mock_podman):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+
+        result = _runner().invoke(
+            main, ["secret", "set", "demo", "MY_KEY"], input="value\n",
+        )
+
+        assert result.exit_code != 0
+        assert "apple-container" in result.output
+        assert "not yet implemented" in result.output
+        mock_podman.assert_not_called()
+
+    @patch("agentcage.cli._podman_for_cage")
+    @patch("agentcage.cli.state")
+    def test_secret_rm_exits_unsupported(self, mock_state, mock_podman):
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+
+        result = _runner().invoke(main, ["secret", "rm", "demo", "MY_KEY"])
+
+        assert result.exit_code != 0
+        assert "apple-container" in result.output
+        assert "not yet implemented" in result.output
+        mock_podman.assert_not_called()


### PR DESCRIPTION
## Summary

\`agentcage secret list/set/rm <cage>\` on apple-container fell through to host podman the same way #139's exec/shell/logs did. On macOS without podman this crashes with \`FileNotFoundError: 'podman'\`. Same fix: load config first, check \`_is_apple_container(cfg)\`, exit cleanly via \`_exit_apple_container_unsupported(...)\`.

The proper apple-container secret store is tracked in #120 (the heavy lift for \`cage backup/restore\` brings the secret-store abstraction). Until then \`cage create\` env-passes secrets via the supervisor's config; users edit them by editing cage.yaml + \`cage update\`.

## Test plan

- [x] 3 new regression tests under \`TestSecretCommandsAppleContainer\` in \`tests/test_apple_container_cli.py\` — all 15 tests in the file pass
- [x] Verified on macOS 26.3.2 + ASi: \`secret list/set/rm ubuntu02\` all exit with \`error: 'cage secret <cmd>' is not yet implemented for the apple-container backend (see issue #120)\` instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)