### PR TITLE
fix(apple-container): wire container.cpus / container.memory

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -26,7 +26,9 @@ Not yet shipped (follow-ups tracked in #120):
 from __future__ import annotations
 
 import json
+import math
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -37,6 +39,39 @@ from agentcage.apple_container import prerequisites as ac_prereq
 from agentcage.apple_container import scaffold as ac_scaffold
 from agentcage.apple_container import wrapper as ac_wrapper
 from agentcage.config import Config
+
+
+def _normalize_cpus(value: str) -> str:
+    """Apple's `container run --cpus` rejects fractional values; ceil to int.
+
+    Podman accepts "0.5" / "1.5"; Apple wants "1" / "2". Round up so the
+    cage gets at least the cap the user wrote. Returns the original
+    string if it's already an integer or doesn't parse as a float.
+    """
+    try:
+        f = float(value)
+    except ValueError:
+        return value
+    return str(math.ceil(f)) if f != int(f) else str(int(f))
+
+
+_MEMORY_SUFFIX_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([kKmMgGtTpP][iI]?[bB]?)?$")
+
+
+def _normalize_memory(value: str) -> str:
+    """Apple's `container run --memory` requires UPPERCASE K/M/G/T/P.
+
+    Lowercase suffixes ("512m", "2g") that podman/docker accept are
+    rejected. Uppercase the suffix in place; pass through unchanged if
+    the value doesn't match the expected `<n><suffix>` shape so any
+    operator-supplied novelty (e.g. raw byte counts) still reaches Apple
+    for its own error reporting rather than being silently mangled.
+    """
+    m = _MEMORY_SUFFIX_RE.match(value.strip())
+    if not m:
+        return value
+    number, suffix = m.group(1), (m.group(2) or "")
+    return f"{number}{suffix.upper()}"
 
 
 class AppleContainerBackend:
@@ -139,12 +174,26 @@ class AppleContainerBackend:
         in v1; egress is locked to localhost via iptables in the
         supervisor).
         """
+        # Resource resolution precedence: cage.yaml's `container.cpus` /
+        # `container.memory` (the per-cage cap the user actually wrote)
+        # wins over `vm.vcpus` / `vm.mem_mb` (which exist primarily for
+        # the Lima backend's outer VM but used to be the only thing this
+        # backend respected — silently dropping `container.cpus/memory`
+        # was a real footgun on Mac, where users edit cage.yaml not a
+        # separate vm section). Empty / unset on both → no --cpus or
+        # --memory flag, letting Apple's defaults apply.
+        cpus = config.container.cpus or (
+            str(config.vm.vcpus) if getattr(config.vm, "vcpus", 0) else ""
+        )
+        memory = config.container.memory or (
+            f"{config.vm.mem_mb}m" if getattr(config.vm, "mem_mb", 0) else ""
+        )
         unit_json = json.dumps(
             {
                 "name": deploy_name,
                 "user_image": config.container.image,
-                "cpus": getattr(config.vm, "vcpus", 0) or 0,
-                "mem_mb": getattr(config.vm, "mem_mb", 0) or 0,
+                "cpus": cpus,
+                "memory": memory,
                 "lifecycle": config.lifecycle,
             },
             indent=2,
@@ -196,11 +245,25 @@ class AppleContainerBackend:
             "--cap-add", "CAP_SYS_ADMIN",
             "--cap-add", "CAP_NET_ADMIN",
         ]
-        if meta.get("cpus"):
-            argv += ["--cpus", str(meta["cpus"])]
-        if meta.get("mem_mb"):
-            # Apple `container` accepts e.g. "2g" or raw bytes.
-            argv += ["--memory", f"{meta['mem_mb']}m"]
+        # Apple's `container run --cpus / --memory` has stricter input
+        # acceptance than podman: --cpus requires an integer (fractional
+        # like "0.5" or "1.5" → "Help: --cpus <cpus> ..." rejection), and
+        # --memory requires an UPPERCASE suffix (`512m` → rejected,
+        # `512M` accepted). agentcage config historically uses podman's
+        # looser forms, so normalize on the way out: ceil fractional cpus
+        # to the next integer (give users at least the cap they asked
+        # for) and uppercase the memory suffix.
+        # Backward compat for unit JSON: 0.20.5 and earlier used integer
+        # `cpus` + integer `mem_mb` (mb-only); accept both so cages
+        # created before this change keep starting after upgrade.
+        cpus_raw = meta.get("cpus")
+        if cpus_raw not in (None, "", 0):
+            argv += ["--cpus", _normalize_cpus(str(cpus_raw))]
+        memory_raw = meta.get("memory")
+        if memory_raw:
+            argv += ["--memory", _normalize_memory(str(memory_raw))]
+        elif meta.get("mem_mb"):  # pre-0.20.6 unit JSON
+            argv += ["--memory", f"{meta['mem_mb']}M"]
         argv.append(image)
 
         result = ac_cli.run(argv, check=False, capture_output=False)

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -478,6 +478,135 @@ def test_build_artifacts_no_cmd_anywhere_raises_helpful_error():
             AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
 
 
+# ---------------------------------------------------------------------------
+# generate_units / start: container.cpus + container.memory precedence
+# ---------------------------------------------------------------------------
+
+
+def test_generate_units_prefers_container_cpus_memory_over_vm():
+    """REGRESSION: cage.yaml's `container.cpus` / `container.memory` (the
+    per-cage cap users actually write) must win over `vm.vcpus` /
+    `vm.mem_mb` on apple-container. Pre-fix, the backend read only the
+    vm.* fields and silently dropped container.* — meaning a Mac user
+    who wrote `container: { memory: 2g, cpus: 1.5 }` got Apple's default
+    resource allocation, not the cap they asked for."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "x"
+    cfg.container.cpus = "1.5"
+    cfg.container.memory = "2g"
+    cfg.vm.vcpus = 8       # set but should be overridden
+    cfg.vm.mem_mb = 16384  # set but should be overridden
+
+    units = AppleContainerBackend().generate_units(
+        cfg, "/cfg", "/patches", "deploy",
+    )
+    meta = json.loads(units["deploy.json"])
+    assert meta["cpus"] == "1.5"
+    assert meta["memory"] == "2g"
+
+
+def test_generate_units_falls_back_to_vm_when_container_unset():
+    """vm.vcpus / vm.mem_mb are the fallback when cage.yaml doesn't set
+    container.*. Backward compatibility: existing cages that only had
+    the vm section keep working."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "x"
+    cfg.container.cpus = ""
+    cfg.container.memory = ""
+    cfg.vm.vcpus = 4
+    cfg.vm.mem_mb = 4096
+
+    units = AppleContainerBackend().generate_units(
+        cfg, "/cfg", "/patches", "deploy",
+    )
+    meta = json.loads(units["deploy.json"])
+    assert meta["cpus"] == "4"
+    assert meta["memory"] == "4096m"
+
+
+def test_start_argv_includes_normalized_cpus_memory(tmp_path):
+    """`start()` reads the unit metadata and constructs the `container run`
+    argv with normalized --cpus (integer; Apple rejects fractions) and
+    --memory (uppercase suffix; Apple rejects lowercase). Original cage.yaml
+    value "1.5" → "2", "2g" → "2G"."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "1.5",   # fractional → ceil to 2
+        "memory": "2g",  # lowercase → uppercase to 2G
+        "lifecycle": "interactive",
+    }))
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    assert run_argv[run_argv.index("--cpus") + 1] == "2"
+    assert run_argv[run_argv.index("--memory") + 1] == "2G"
+
+
+def test_normalize_cpus_ceils_fractions():
+    from agentcage.backends.apple_container import _normalize_cpus
+    assert _normalize_cpus("0.5") == "1"
+    assert _normalize_cpus("1.0") == "1"
+    assert _normalize_cpus("1.1") == "2"
+    assert _normalize_cpus("4") == "4"
+    assert _normalize_cpus("not-a-number") == "not-a-number"  # pass through
+
+
+def test_normalize_memory_uppercases_suffix():
+    from agentcage.backends.apple_container import _normalize_memory
+    assert _normalize_memory("512m") == "512M"
+    assert _normalize_memory("2g") == "2G"
+    assert _normalize_memory("1024M") == "1024M"  # already uppercase
+    assert _normalize_memory("2Gi") == "2GI"      # uppercase the i too
+    assert _normalize_memory("512") == "512"      # no suffix, pass through
+    assert _normalize_memory("garbage") == "garbage"  # doesn't match → pass through
+
+
+def test_start_argv_backward_compat_pre_0_20_6_mem_mb(tmp_path):
+    """Pre-0.20.6 unit JSON used integer `mem_mb` + `cpus` (no `memory`
+    string). Cages created before this PR must keep starting on a fresh
+    agentcage — so `start()` falls back to the old `mem_mb` field when
+    `memory` is absent. The fallback uses the uppercase M suffix Apple
+    requires."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": 4,        # old integer form
+        "mem_mb": 4096,   # old field
+        "lifecycle": "interactive",
+    }))
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    assert run_argv[run_argv.index("--memory") + 1] == "4096M"
+
+
 def test_run_streaming_pauses_active_spinner():
     """``ac_cli.run(capture_output=False)`` must wrap subprocess.run in
     ``output.pause_active_spinner()`` so Apple's CLI progress doesn't fight


### PR DESCRIPTION
## Summary

apple-container read only \`vm.vcpus\` / \`vm.mem_mb\` and silently dropped cage.yaml's \`container.cpus\` / \`container.memory\`. A Mac user who wrote \`container: { memory: 2g, cpus: 1.5 }\` got Apple's default allocation — no error, no warning. This PR resolves them with the right precedence (\`container.*\` wins over \`vm.*\`) and normalizes for Apple's stricter CLI:

- \`--cpus\` rejects fractions → ceil to next integer (\`0.5\` → \`1\`)
- \`--memory\` rejects lowercase suffixes → uppercase (\`512m\` → \`512M\`)

## Backward compat

Pre-0.20.6 unit JSON used integer \`mem_mb\` (MB-only) and integer \`cpus\`. \`start()\` accepts both the new string form and the old fields so cages created before this PR keep starting after upgrade.

## Test plan

- [x] 5 new tests in \`tests/test_apple_container.py\` covering precedence, fallback, normalization (cpus + memory), backward compat (pre-0.20.6 unit JSON)
- [x] Verified on macOS 26.3.2 + ASi: cage.yaml \`cpus: "0.5", memory: "512m"\` creates a cage with \`cpus: 1, memoryInBytes: 536870912 (512 MiB)\` per \`container inspect\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)