### PR TITLE
fix(cli): apple-container domain add/rm auto-rebuilds the wrapper

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -2604,18 +2604,24 @@ def _update_dns_quadlet(cfg) -> None:
             for svc in reversed(services):
                 inst.exec(["systemctl", "--user", "start", f"{name}-{svc}.service"])
     elif _is_apple_container(cfg):
-        # On apple-container the proxy/dns allowlist is baked into the
-        # wrapper image at build time, so the new allowlist only takes
-        # effect after a `cage update`. Restart the cage so the user at
-        # least sees a fresh container; warn that a rebuild is required
-        # for the change to apply.
-        if backend.is_running(name, "cage"):
-            backend.restart(name)
-        click.echo(
-            "note: apple-container bakes the allowlist into the wrapper "
-            "image; run `agentcage cage update " + name + "` to apply.",
-            err=True,
-        )
+        # On apple-container the dnsmasq + mitmproxy allowlists are baked
+        # into the wrapper image at build_artifacts() time — there's no
+        # bind-mounted allowlist file the running supervisor can re-read
+        # yet (that infra lands with the observability bridge in #120).
+        # A plain restart would re-execute the OLD allowlist; the change
+        # the user just saved to cage.yaml would silently not apply.
+        #
+        # Trigger the same build path `cage update` uses: rebuild the
+        # wrapper image (Apple's layer cache makes this ~1–2s on warm
+        # systems), then restart so the cage runs against the new image.
+        # Users no longer have to remember "now run cage update" — domain
+        # add/rm behaves like container/vm: change saved → effect applied.
+        was_running = backend.is_running(name, "cage")
+        if was_running:
+            backend.stop(name)
+        backend.build_artifacts(cfg, name, quiet=True)
+        if was_running:
+            backend.start(name, quiet=True)
     else:
         if backend.is_running(name, "dns"):
             # Stop most-dependent first, start dependencies first.

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -348,3 +348,70 @@ class TestSecretCommandsAppleContainer:
         assert "apple-container" in result.output
         assert "not yet implemented" in result.output
         mock_podman.assert_not_called()
+
+
+# ── domain add/rm: auto-rebuild wrapper on apple-container ──
+
+
+class TestDomainCommandsAppleContainer:
+    """REGRESSION: `agentcage domain add/rm` on apple-container must rebuild
+    the wrapper image (which has the dnsmasq + mitmproxy allowlists baked in
+    at build time) before restarting the cage. Pre-fix, the command saved
+    cage.yaml + restarted the cage — but the restart re-executed the OLD
+    image, so the change silently didn't apply. Users had to remember to
+    run `cage update` manually.
+    """
+
+    @patch("agentcage.cli._is_apple_container", return_value=True)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_update_dns_quadlet_rebuilds_wrapper(
+        self, mock_state, mock_get_backend, _mock_is_apple,
+    ):
+        """`_update_dns_quadlet(cfg)` on apple-container must call
+        `backend.build_artifacts()` (the rebuild path) before restart."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_config("apple-container")
+        cfg.name = "demo"
+
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        # Stop → build → start ordering matters: the rebuild must happen
+        # while the cage is stopped (otherwise Apple's `container build`
+        # would try to tag an image name in use by a running container).
+        mock_calls = [c[0] for c in backend.mock_calls]
+        stop_idx = next(i for i, c in enumerate(mock_calls) if c == "stop")
+        build_idx = next(i for i, c in enumerate(mock_calls) if c == "build_artifacts")
+        start_idx = next(i for i, c in enumerate(mock_calls) if c == "start")
+        assert stop_idx < build_idx < start_idx
+
+        backend.build_artifacts.assert_called_once()
+        ba_args = backend.build_artifacts.call_args
+        assert ba_args.args[1] == "demo"
+
+    @patch("agentcage.cli._is_apple_container", return_value=True)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_update_dns_quadlet_skips_start_when_cage_not_running(
+        self, mock_state, mock_get_backend, _mock_is_apple,
+    ):
+        """If the cage isn't running, rebuild the image but don't start it
+        (matches the container backend's behavior — `domain add` on a
+        stopped cage updates the state but doesn't auto-start)."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_config("apple-container")
+        cfg.name = "demo"
+
+        backend = MagicMock()
+        backend.is_running.return_value = False
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        backend.build_artifacts.assert_called_once()
+        backend.stop.assert_not_called()
+        backend.start.assert_not_called()


### PR DESCRIPTION
## Summary

\`agentcage domain add/rm <cage> <domain>\` on apple-container saved the change to cage.yaml, restarted the cage, and printed "note: run \`cage update\` to apply". But the restart re-executed the OLD wrapper image (allowlists are baked in at build_artifacts()), so the change silently didn't take effect.

\`_update_dns_quadlet\` on apple-container now triggers the rebuild path directly: stop → backend.build_artifacts() → start. Apple's layer cache makes this ~1–2s on warm systems. Matches container/vm UX: change saved → effect applied.

## Test plan

- [x] 2 new regression tests in \`TestDomainCommandsAppleContainer\` (stop→build→start ordering; skip when cage was down)
- [x] Verified on macOS 26.3.2 + ASi: \`domain add ubuntu02 example.com\` rebuilds + restarts; immediately afterward \`cage exec ubuntu02 -- curl https://example.com\` returns 200 (would have returned 403 from the stale allowlist before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)