### PR TITLE
feat(apple-container): bind-mount /var/log/agentcage from microVM to host

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -82,6 +82,19 @@ class AppleContainerBackend:
     def _state_dir(self, name: str) -> Path:
         return Path(os.path.expanduser("~/.config/agentcage/apple-container")) / name
 
+    def logs_dir(self, name: str) -> Path:
+        """Per-cage logs dir on the host, bind-mounted into the microVM.
+
+        The supervisor writes proxy.log + capture.jsonl + dnsmasq.log to
+        /var/log/agentcage/ inside the microVM; we mount this host path
+        there so `agentcage cage audit` and `cage har` can read those
+        files from the host without having to exec into the microVM.
+
+        Created on demand (start), preserved on stop/restart, removed by
+        destroy_resources alongside the rest of the per-cage state.
+        """
+        return self._state_dir(name) / "logs"
+
     # --- Backend protocol -----------------------------------------------------
 
     def check_prerequisites(self, config: Config) -> list[str]:  # noqa: ARG002
@@ -236,6 +249,26 @@ class AppleContainerBackend:
             ac_cli.run(["stop", name], check=False)
             ac_cli.run(["delete", "-f", name], check=False)
 
+        # Per-cage logs dir on the host: bind-mounted into the microVM
+        # at /var/log/agentcage so `cage audit` / `cage har` can read
+        # proxy.log + capture.jsonl from the host without exec'ing in.
+        # Create as 0o755 owned by the current user; the supervisor's
+        # `chown acproxy:acproxy /var/log/agentcage` inside the cage
+        # adjusts ownership to the per-component uids — Apple's bind
+        # mount transparently maps host uid ↔ guest uid.
+        logs_dir = self.logs_dir(name)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        # virtiofs locks ownership inside the cage to the host file's
+        # owner (currently the user running agentcage). uid 200
+        # (mitmproxy) and uid 201 (dnsmasq) in the guest can only write
+        # to this dir if the host-side permissions allow them — so set
+        # the dir 1777 (world-writable + sticky bit). Sticky means each
+        # file is owned (host-side) by `m1`, with all in-cage writes
+        # showing as root in the guest because of virtiofs uid mapping;
+        # that's fine — the supervisor's own chown attempts are now
+        # best-effort and tolerate EPERM.
+        os.chmod(logs_dir, 0o1777)
+
         # CAP_SYS_ADMIN: supervisor needs it to remount /proc with hidepid=2
         # and to mount the proxy's private tmpfs. CAP_NET_ADMIN: supervisor
         # needs it to apply the iptables egress lockdown. Both are dropped
@@ -244,6 +277,7 @@ class AppleContainerBackend:
             "run", "-d", "--name", name,
             "--cap-add", "CAP_SYS_ADMIN",
             "--cap-add", "CAP_NET_ADMIN",
+            "--volume", f"{logs_dir}:/var/log/agentcage",
         ]
         # Apple's `container run --cpus / --memory` has stricter input
         # acceptance than podman: --cpus requires an integer (fractional

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -66,8 +66,16 @@ log "stage 20: cage CMD = ${CMD_LINE}"
 
 #-- 30. Start dnsmasq ------------------------------------------------------
 log "stage 30: starting dnsmasq (uid 201)"
+# /var/log/agentcage is bind-mounted from the host via virtiofs when the
+# backend is configured to expose logs (apple-container's `start()` always
+# passes --volume <host>:/var/log/agentcage). virtiofs preserves host
+# ownership inside the guest and rejects chown/chmod on the mountpoint
+# itself; we don't need (and can't have) per-component ownership of the
+# top-level dir. Permissions are set host-side to 1777 so any uid in the
+# microVM can create files. Plain `mkdir -p` is a no-op when the mount
+# is present (and falls back to a regular dir for pre-bindmount cages).
 mkdir -p /var/log/agentcage
-chown acdns:acdns /var/log/agentcage
+chown acdns:acdns /var/log/agentcage 2>/dev/null || true
 dnsmasq \
   --conf-file=/etc/agentcage/dnsmasq.conf \
   --user=acdns \
@@ -88,9 +96,11 @@ ss -lnu 2>/dev/null | grep -q '127.0.0.1:53' \
 log "stage 40: starting mitmproxy (uid 200)"
 # Chown the mitmproxy home + log dir BEFORE starting mitmproxy so the
 # ownership state is final before any file the proxy writes lands here.
+# See stage 30 for the virtiofs note on /var/log/agentcage (chown there
+# is best-effort).
 mkdir -p /home/acproxy/.mitmproxy /var/log/agentcage
 chown acproxy:acproxy /home/acproxy /home/acproxy/.mitmproxy
-chown acproxy:acproxy /var/log/agentcage
+chown acproxy:acproxy /var/log/agentcage 2>/dev/null || true
 
 # The mitmproxy addon (/opt/agentcage/allowlist_addon.py) reads
 # /etc/agentcage/allowlist.txt and 403s non-listed hosts from the proxy

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -575,6 +575,56 @@ def test_normalize_memory_uppercases_suffix():
     assert _normalize_memory("garbage") == "garbage"  # doesn't match → pass through
 
 
+def test_start_creates_logs_dir_and_bind_mounts_it(tmp_path):
+    """`start()` must create the per-cage logs dir on the host and pass
+    --volume <host_logs>:/var/log/agentcage to `container run` so the
+    supervisor's proxy.log / capture.jsonl / dnsmasq.log are visible to
+    the host. This unlocks `cage audit` and `cage har` on apple-container
+    (both gated unsupported pre-bind-mount because they had no host path
+    to read)."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "interactive",
+    }))
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    logs_dir = tmp_path / "logs"
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    # Host logs dir created.
+    assert logs_dir.is_dir()
+    # --volume <logs_dir>:/var/log/agentcage in the run argv.
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    vol_idx = run_argv.index("--volume")
+    assert run_argv[vol_idx + 1] == f"{logs_dir}:/var/log/agentcage"
+
+
+def test_logs_dir_lives_under_per_cage_state_dir():
+    """logs_dir(name) is `<state-dir>/<name>/logs/` so destroy_resources's
+    recursive rmtree of _state_dir(name) sweeps it up automatically."""
+    backend = AppleContainerBackend()
+    logs = backend.logs_dir("demo")
+    state = backend._state_dir("demo")
+    assert logs.parent == state
+    assert logs.name == "logs"
+
+
 def test_start_argv_backward_compat_pre_0_20_6_mem_mb(tmp_path):
     """Pre-0.20.6 unit JSON used integer `mem_mb` + `cpus` (no `memory`
     string). Cages created before this PR must keep starting on a fresh


### PR DESCRIPTION
## Summary

The supervisor writes proxy.log + dnsmasq.log (+ soon capture.jsonl) to \`/var/log/agentcage/\` inside the microVM. Before this PR there was no way for the host to read them — \`cage audit\` and \`cage har\` exit unsupported on apple-container specifically because of this gap.

This PR adds the bridge: every \`start()\` creates \`<state-dir>/<cage>/logs/\` on the host (mode 0o1777) and passes \`--volume <host>:/var/log/agentcage\` to \`container run\`. Apple's virtiofs preserves host ownership inside the guest, so the supervisor's chown calls on the mountpoint now fail with EPERM — tolerated via \`chown ... 2>/dev/null || true\`. The host-side 1777 mode lets uid 200 (mitmproxy) and uid 201 (dnsmasq) write their logs.

Infrastructure-only: \`cage audit\` / \`cage har\` / \`cage verify\` deeper probes still exit unsupported. PR-6 lifts that exit by reading the now-host-visible files.

## Test plan

- [x] 2 new tests in \`test_apple_container.py\` covering the --volume argv flag + path layout
- [x] Verified on macOS 26.3.2 + ASi: \`tail ~/.config/agentcage/apple-container/ubuntu02/logs/proxy.log\` shows mitmproxy BLOCK events in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)