### PR TITLE
feat(apple-container): cage audit + cage har read host-bind-mounted JSONL

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1646,10 +1646,39 @@ def _normalize_since(since: str) -> str:
     return since
 
 
+def _apple_container_audit_path(name: str) -> Path:
+    """Host-side path to a cage's audit.jsonl, written by the apple-container
+    supervisor's mitmproxy addon into /var/log/agentcage/audit.jsonl
+    (which is bind-mounted from the per-cage state dir's logs/ subdir)."""
+    from agentcage.backends.apple_container import AppleContainerBackend
+    return AppleContainerBackend().logs_dir(name) / "audit.jsonl"
+
+
+def _apple_container_capture_path(name: str) -> Path:
+    """Host-side path to a cage's capture.jsonl (mitmproxy addon output)."""
+    from agentcage.backends.apple_container import AppleContainerBackend
+    return AppleContainerBackend().logs_dir(name) / "capture.jsonl"
+
+
 def _build_audit_journal_cmd(
     name: str, cfg, *, since: str | None = None, follow: bool = False,
 ) -> list[str]:
-    """Build the journalctl command for reading audit entries."""
+    """Build the command for reading audit entries.
+
+    Each backend stores audit data differently:
+      - container: systemd-user journal (``journalctl --user -u <cage>-proxy``)
+      - vm: same wrapped in ``limactl shell`` + ``sg systemd-journal``
+      - apple-container: plain JSONL file bind-mounted from the microVM
+        to ~/.config/agentcage/apple-container/<cage>/logs/audit.jsonl;
+        ``tail -n N`` (or ``tail -F`` for follow) it. ``--since`` has no
+        time index on this backend; the AuditFilter time pass happens
+        in Python after parsing.
+    """
+    if _is_apple_container(cfg):
+        path = _apple_container_audit_path(name)
+        if follow:
+            return ["tail", "-n", "0", "-F", str(path)]
+        return ["tail", "-n", "10000", str(path)]
     if cfg.isolation == "vm":
         # In VM mode the proxy/dns are systemd --user services, but conmon
         # routes their logs to the system journal — so the right filter is
@@ -1805,12 +1834,22 @@ def cage_audit(name, decisions, directions, hosts, inspectors, severity,
 
     cfg = state.load_deployment_config(name)
 
-    # Audit on apple-container needs a different log path (mitmproxy
-    # writes /var/log/proxy.log inside the microVM, not the host
-    # journal). Not wired up yet — exit cleanly instead of running
-    # journalctl on a missing host.
+    # apple-container reads audit.jsonl from the per-cage logs dir
+    # (bind-mounted from the microVM by `start()`); _build_audit_journal_cmd
+    # below dispatches to a tail-based reader for this backend.
     if _is_apple_container(cfg):
-        _exit_apple_container_unsupported("audit")
+        path = _apple_container_audit_path(name)
+        if not path.is_file():
+            click.echo(
+                f"error: no audit log yet for cage '{name}'\n"
+                f"  Expected: {path}\n"
+                f"  Either the cage hasn't received any proxy traffic since "
+                f"start, or it was last started before 0.20.6 (the audit-bridge "
+                f"is wired only for cages created on 0.20.6+). Try:\n"
+                f"    agentcage cage update {name}    # rebuild + restart",
+                err=True,
+            )
+            sys.exit(1)
 
     filt = AuditFilter(
         decisions=list(decisions),
@@ -1881,15 +1920,15 @@ def cage_har(name, view, decisions, hosts, methods, directions, since,
         sys.exit(1)
 
     cfg = state.load_deployment_config(name)
-    # HAR export depends on the proxy's capture.jsonl being bind-mounted
-    # to a host path; that's not wired up for apple-container yet (the
-    # capture file lives inside the microVM).
-    if _is_apple_container(cfg):
-        _exit_apple_container_unsupported("har")
 
     from agentcage.har import CaptureFilter, capture_to_har, parse_since
 
-    capture_path = state.capture_file(name)
+    # apple-container's capture.jsonl is host-visible via the bind-mounted
+    # logs dir (0.20.6+); container/vm use the central state path.
+    if _is_apple_container(cfg):
+        capture_path = _apple_container_capture_path(name)
+    else:
+        capture_path = state.capture_file(name)
     if not capture_path.is_file():
         click.echo(f"error: no capture file found for cage '{name}'", err=True)
         click.echo(f"  Expected: {capture_path}", err=True)

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -1,4 +1,4 @@
-"""agentcage apple-container egress allowlist addon for mitmproxy.
+"""agentcage apple-container egress allowlist + audit addon for mitmproxy.
 
 The mitmproxy `--allow-hosts` flag controls *interception scope* (which
 hosts get MITMed) but does NOT block non-listed hosts. It just passes
@@ -9,17 +9,41 @@ against /etc/agentcage/allowlist.txt (one entry per line, subdomains
 auto-allowed). Non-matching requests are replied to with a 403 from
 mitmproxy itself — the upstream connection is never opened.
 
+For every decision we emit a structured JSON line to
+``/var/log/agentcage/audit.jsonl`` (or ``$AGENTCAGE_AUDIT_LOG``), in the
+format ``agentcage.audit.AuditEntry.from_dict`` expects — that's what
+``agentcage cage audit`` consumes on the host side once the file is
+bind-mounted out of the microVM. For successful 2xx responses we also
+emit a basic capture record to ``/var/log/agentcage/capture.jsonl`` so
+``agentcage cage har`` can produce HAR 1.2 JSON.
+
+This is a leaner audit format than the container backend's
+``addon.py`` (no inspector chain, no body capture, no secret-injection
+metadata yet — those are tracked as separate items in #120's parity
+plan). The fields here are the minimum subset ``AuditEntry`` /
+``CaptureFilter`` need to filter and summarize.
+
 The allowlist file is read once at startup; restart the cage to pick up
-changes. Empty allowlist means "block everything" — same default as the
-supervisor's `--allow-hosts` regex fallback.
+changes. Empty allowlist means "block everything".
 """
 
 from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
 
 
 ALLOWLIST_PATH = "/etc/agentcage/allowlist.txt"
+AUDIT_LOG_PATH = os.environ.get(
+    "AGENTCAGE_AUDIT_LOG", "/var/log/agentcage/audit.jsonl"
+)
+CAPTURE_PATH = os.environ.get(
+    "AGENTCAGE_CAPTURE", "/var/log/agentcage/capture.jsonl"
+)
 
 
 def _load_allowlist() -> set[str]:
@@ -50,12 +74,67 @@ class AllowlistAddon:
         ctx.log.info(
             f"[agentcage] allowlist loaded: {sorted(self.allowed) or '(empty — block all)'}"
         )
+        self._audit_fh = self._open_log(AUDIT_LOG_PATH)
+        self._capture_fh = self._open_log(CAPTURE_PATH)
+
+    @staticmethod
+    def _open_log(path: str):
+        """Append-open ``path``; return None and log a warning on failure.
+
+        ``/var/log/agentcage`` is bind-mounted from the host (mode 1777)
+        on apple-container, so the open should succeed even though the
+        mitmproxy process runs as uid 200. Tests can point both paths
+        at /dev/null via the env vars.
+        """
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            return open(path, "a", buffering=1)  # line-buffered
+        except OSError as exc:  # pragma: no cover — virtiofs surprise
+            ctx.log.warn(f"[agentcage] cannot open {path}: {exc}")
+            return None
+
+    def _write(self, fh, entry: dict) -> None:
+        if fh is None:
+            return
+        try:
+            fh.write(json.dumps(entry) + "\n")
+        except OSError as exc:  # pragma: no cover
+            ctx.log.warn(f"[agentcage] write failed: {exc}")
+
+    def _audit(self, entry: dict) -> None:
+        # Mirror entries to stderr so they also surface in `container logs`
+        # (same pattern container's addon.py uses for the journalctl path).
+        print(json.dumps(entry), file=sys.stderr, flush=True)
+        self._write(self._audit_fh, entry)
 
     def request(self, flow: http.HTTPFlow) -> None:
         host = flow.request.pretty_host
+        now = datetime.now(timezone.utc).isoformat()
+
+        entry: dict = {
+            "ts": now,
+            "direction": "outbound",
+            "method": flow.request.method,
+            "host": host,
+            "url": flow.request.pretty_url,
+            "path": flow.request.path,
+            "port": flow.request.port,
+            "source": "apple-container",
+            "inspectors": [],
+            "secrets_injected": [],
+            "secrets_redacted": [],
+        }
+
         if _host_allowed(host, self.allowed):
+            entry["decision"] = "allowed"
+            entry["reason"] = "domain-allowlist"
+            self._audit(entry)
             return
+
         ctx.log.info(f"[agentcage] BLOCK {flow.request.method} {host}")
+        entry["decision"] = "blocked"
+        entry["reason"] = "domain-allowlist: host not in cage allowlist"
+        self._audit(entry)
         flow.response = http.Response.make(
             403,
             (
@@ -65,6 +144,57 @@ class AllowlistAddon:
             ).encode(),
             {"Content-Type": "text/plain"},
         )
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        """Emit a capture record for successful round-trips.
+
+        Capture only includes responses we actually proxied (i.e. the
+        request hook did NOT short-circuit with a 403). The format is a
+        subset of the container backend's capture.jsonl, enough for
+        ``agentcage.har.capture_to_har`` to render a HAR file: ts,
+        request fields, response status/headers. Bodies are omitted in
+        v1 because the apple-container addon doesn't have the streaming
+        capture machinery; HAR will show response.content.size=0.
+        """
+        if self._capture_fh is None or flow.response is None:
+            return
+        # If we already 403ed in `request`, the response is one we
+        # constructed locally — no point re-capturing it.
+        if (
+            flow.response.status_code == 403
+            and flow.response.headers.get("Content-Type", "").startswith(
+                "text/plain"
+            )
+            and flow.response.content
+            and flow.response.content.startswith(b"agentcage: host '")
+        ):
+            return
+        host = flow.request.pretty_host
+        capture: dict = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "direction": "outbound",
+            "decision": "allowed",
+            "host": host,
+            "method": flow.request.method,
+            "url": flow.request.pretty_url,
+            "request": {
+                "method": flow.request.method,
+                "url": flow.request.pretty_url,
+                "headers": [
+                    {"name": k, "value": v}
+                    for k, v in flow.request.headers.items()
+                ],
+            },
+            "response": {
+                "status": flow.response.status_code,
+                "statusText": flow.response.reason or "",
+                "headers": [
+                    {"name": k, "value": v}
+                    for k, v in flow.response.headers.items()
+                ],
+            },
+        }
+        self._write(self._capture_fh, capture)
 
 
 addons = [AllowlistAddon()]

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -224,18 +224,65 @@ class TestCageVerifyAppleContainer:
         assert "apple-container" in result.output
 
 
-# ── cage audit / har / backup / restore: gated on apple-container ──
+# ── cage audit + har: bridged via host-bind-mounted JSONL ──
 
 
-class TestCageGatedCommandsAppleContainer:
+class TestCageAuditHarAppleContainer:
+    """`cage audit` / `cage har` no longer exit unsupported — they read
+    audit.jsonl / capture.jsonl from the host-bind-mounted logs dir
+    (PR-5 added the bind mount; PR-6 wired the readers). If the JSONL
+    file doesn't exist yet (cage just created and no traffic, or the
+    cage predates 0.20.6), the command exits with a clear pointer to
+    `cage update`."""
+
+    @patch("agentcage.cli._apple_container_audit_path")
     @patch("agentcage.cli.state")
-    def test_audit_exits_unsupported(self, mock_state):
+    def test_audit_missing_file_exits_with_hint(
+        self, mock_state, mock_path, tmp_path,
+    ):
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        # Non-existent path → friendly error pointing at `cage update`.
+        mock_path.return_value = tmp_path / "does-not-exist.jsonl"
+
         result = _runner().invoke(main, ["cage", "audit", "demo"])
+
         assert result.exit_code != 0
-        assert "apple-container" in result.output
-        assert "not yet implemented" in result.output
+        assert "no audit log yet" in result.output
+        assert "cage update" in result.output
+
+    @patch("agentcage.cli.subprocess.Popen")
+    @patch("agentcage.cli._apple_container_audit_path")
+    @patch("agentcage.cli.state")
+    def test_audit_uses_tail_reader_on_apple_container(
+        self, mock_state, mock_path, mock_popen, tmp_path,
+    ):
+        """Once the audit file exists, audit reads it via `tail -n 10000`
+        rather than journalctl; subprocess.Popen receives the right argv."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        audit_path = tmp_path / "audit.jsonl"
+        audit_path.touch()
+        mock_path.return_value = audit_path
+
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([])
+        mock_popen.return_value = fake_proc
+
+        _runner().invoke(main, ["cage", "audit", "demo"])
+
+        # First Popen call is the tail of the host audit file.
+        popen_argv = mock_popen.call_args.args[0]
+        assert popen_argv[0] == "tail"
+        assert str(audit_path) in popen_argv
+
+
+# ── cage backup / restore: still unsupported (Plan 3 PR-10) ──
+
+
+class TestCageBackupRestoreStillUnsupported:
+    """Backup/restore stay unsupported on apple-container until the
+    secret-store abstraction lands (Plan 3 PR-10)."""
 
     @patch("agentcage.cli.state")
     def test_backup_exits_unsupported(self, mock_state):


### PR DESCRIPTION
## Summary

\`cage audit\` and \`cage har\` exited unsupported on apple-container because their data lived inside the microVM with no host bridge. PR-5 added the bind-mount; this PR wires the bridge to the two commands.

- **mitmproxy addon** now emits JSON lines to \`/var/log/agentcage/audit.jsonl\` (every decision) and \`/var/log/agentcage/capture.jsonl\` (every successful round-trip), in the formats \`AuditEntry.from_dict\` and \`capture_to_har\` already understand
- **\`cage audit\`** dispatches to a \`tail -n N\` / \`tail -F\` reader on apple-container; same filtering machinery
- **\`cage har\`** reads the host capture path; same HAR pipeline

Body capture + the fuller inspector/severity/secret-injection metadata is tracked separately in #120.

## Test plan

- [x] Unit + apple-container CLI tests pass (64 / 64)
- [x] Verified on macOS 26.3.2 + ASi: after curling allowed + blocked URLs, \`cage audit ubuntu02\` shows the entries in the standard table; \`cage har ubuntu02\` produces HAR 1.2 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)