### PR TITLE
feat(apple-container): cage verify runs deeper probes

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -997,16 +997,7 @@ def cage_verify(name: str):
     if cfg.isolation == "container":
         _verify_container(name, _pass, _fail, _warn)
     elif _is_apple_container(cfg):
-        # The apple-container backend does service-level checks via
-        # `backend.is_running` (already run above). Deeper inside-the-cage
-        # probes (proxy CA, egress block, nested podman) aren't wired up
-        # yet on this backend — keep verify a no-crash one-liner rather
-        # than shelling out to host podman.
-        click.echo()
-        click.echo(
-            "  [INFO] deeper checks (CA / egress / nested) are not yet "
-            "implemented for apple-container; service-status checks only"
-        )
+        _verify_apple_container(name, _pass, _fail, _warn)
     else:
         _verify_vm(name, _pass, _fail)
 
@@ -1145,6 +1136,100 @@ def _verify_container(name: str, _pass, _fail, _warn):
             _fail("Podman is NOT rootless")
     except Exception:
         _fail("Podman is NOT rootless")
+
+
+def _verify_apple_container(name: str, _pass, _fail, _warn):
+    """Apple-container probes: CA cert, dnsmasq DNS, egress filter.
+
+    Service-status (is the cage `running`?) was already checked in the
+    backend-agnostic block above; this only adds the inside-the-cage
+    invariants that mean the supervisor wired itself up correctly.
+
+    Each check execs `container exec <cage> ...` via Apple's CLI and
+    inspects the exit code / output. Failures don't abort the verify
+    run — every check independently reports PASS/FAIL/WARN.
+    """
+    from agentcage.apple_container import cli as ac_cli
+
+    binary = ac_cli.container_binary()
+    if binary is None:
+        _warn(
+            "Apple `container` CLI not found; install from "
+            "https://github.com/apple/container/releases"
+        )
+        return
+
+    def _exec(argv: list[str]) -> tuple[int, str]:
+        """`container exec <name> <argv>` returning (exit, combined output).
+
+        Run via subprocess.run (not os.execvp like the cage_exec
+        command, which replaces the process) — verify is a query, not
+        a hand-off.
+        """
+        cp = subprocess.run(
+            [binary, "exec", name, *argv],
+            capture_output=True, text=True, check=False,
+        )
+        return cp.returncode, (cp.stdout + cp.stderr).strip()
+
+    # -- 1. CA cert at /certs/mitmproxy-ca-cert.pem (mirrored at stage 60)
+    click.echo()
+    click.echo("-- CA Certificate --")
+    ec, _ = _exec(["test", "-f", "/certs/mitmproxy-ca-cert.pem"])
+    if ec == 0:
+        _pass("mitmproxy CA cert exists at /certs/mitmproxy-ca-cert.pem")
+    else:
+        _fail("mitmproxy CA cert NOT found at /certs/mitmproxy-ca-cert.pem")
+
+    # -- 2. /etc/resolv.conf points to local dnsmasq (stage 70)
+    click.echo()
+    click.echo("-- DNS routing --")
+    ec, out = _exec(["cat", "/etc/resolv.conf"])
+    if ec == 0 and "nameserver 127.0.0.1" in out:
+        _pass("/etc/resolv.conf points to local dnsmasq (127.0.0.1)")
+    else:
+        _fail(
+            f"/etc/resolv.conf does NOT route to local dnsmasq "
+            f"(got: {out!r})"
+        )
+
+    # -- 3. Egress filtering: blocked domain returns 403 from mitmproxy
+    # Use a fixed domain that should never be in any cage's allowlist;
+    # mitmproxy's allowlist_addon should respond with 403.
+    click.echo()
+    click.echo("-- Egress Filtering --")
+    ec, _ = _exec(["which", "curl"])
+    if ec != 0:
+        _warn(
+            "curl not in cage image — cannot probe egress filtering "
+            "(consider installing curl in the user image to enable "
+            "this check)"
+        )
+    else:
+        # `-w '%{http_code}'` prints the HTTP status to stdout; `-o
+        # /dev/null` discards the body; `--max-time 5` caps the probe.
+        ec, status = _exec([
+            "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+            "--max-time", "5",
+            "https://evil-exfil-server.io",
+        ])
+        if status == "403":
+            _pass(
+                "Blocked domain (evil-exfil-server.io) is denied "
+                "(HTTP 403 from mitmproxy)"
+            )
+        elif status in ("000", ""):
+            # Connection refused / timeout — also a pass (the proxy or
+            # iptables dropped it); just less informative.
+            _pass(
+                f"Blocked domain (evil-exfil-server.io) is denied "
+                f"(HTTP {status or '000'})"
+            )
+        else:
+            _fail(
+                f"Blocked domain returned HTTP {status} — egress "
+                f"filtering may be broken"
+            )
 
 
 def _verify_vm(name: str, _pass, _fail):

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -204,22 +204,26 @@ class TestCageLogsAppleContainer:
 
 
 class TestCageVerifyAppleContainer:
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.subprocess.run")
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
-    def test_verify_short_circuits_with_notice(
-        self, mock_state, mock_get_backend,
+    def test_verify_runs_without_crashing(
+        self, mock_state, mock_get_backend, mock_run, mock_binary,
     ):
-        """verify on apple-container reports service status only and never
-        shells out to host podman."""
+        """Service-status checks pass and the deeper probes run via
+        `container exec` rather than host podman — confirms the basic
+        contract regardless of probe outcomes."""
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         backend = MagicMock()
         backend.service_names.return_value = ["cage", "proxy", "dns"]
         backend.is_running.return_value = True
         mock_get_backend.return_value = backend
+        mock_binary.return_value = "/usr/local/bin/container"
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
         result = _runner().invoke(main, ["cage", "verify", "demo"])
 
-        # No crash and the info banner mentions the limitation.
         assert "PASS" in result.output
         assert "apple-container" in result.output
 
@@ -275,6 +279,90 @@ class TestCageAuditHarAppleContainer:
         popen_argv = mock_popen.call_args.args[0]
         assert popen_argv[0] == "tail"
         assert str(audit_path) in popen_argv
+
+
+# ── cage verify: deeper probes on apple-container ──
+
+
+class TestCageVerifyAppleContainerProbes:
+    """`cage verify` on apple-container now runs the same shape of
+    deeper-than-service-status checks the container backend does:
+    CA cert, DNS routing, egress filtering. They exec into the cage
+    via Apple's `container exec` (not host podman) so they work on
+    macOS without podman."""
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.subprocess.run")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_verify_runs_deeper_probes_and_passes(
+        self, mock_state, mock_get_backend, mock_run, mock_binary,
+    ):
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        backend = MagicMock()
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        def fake_run(argv, **_kwargs):
+            text = " ".join(argv)
+            if "test -f /certs/mitmproxy-ca-cert.pem" in text:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if "cat /etc/resolv.conf" in text:
+                return MagicMock(returncode=0, stdout="nameserver 127.0.0.1\n", stderr="")
+            if "which curl" in text:
+                return MagicMock(returncode=0, stdout="/usr/bin/curl\n", stderr="")
+            if "curl" in text and "evil-exfil" in text:
+                return MagicMock(returncode=0, stdout="403", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fake_run
+
+        result = _runner().invoke(main, ["cage", "verify", "demo"])
+
+        assert "CA Certificate" in result.output
+        assert "DNS routing" in result.output
+        assert "Egress Filtering" in result.output
+        assert "[PASS] mitmproxy CA cert" in result.output
+        assert "[PASS] /etc/resolv.conf" in result.output
+        assert "Blocked domain" in result.output and "denied" in result.output
+        # Old INFO banner ("deeper checks not yet implemented") must be gone.
+        assert "not yet implemented" not in result.output
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.subprocess.run")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_verify_fails_loudly_when_ca_missing(
+        self, mock_state, mock_get_backend, mock_run, mock_binary,
+    ):
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        backend = MagicMock()
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        def fake_run(argv, **_kwargs):
+            text = " ".join(argv)
+            if "test -f /certs/mitmproxy-ca-cert.pem" in text:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            if "cat /etc/resolv.conf" in text:
+                return MagicMock(returncode=0, stdout="nameserver 127.0.0.1\n", stderr="")
+            if "which curl" in text:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = fake_run
+
+        result = _runner().invoke(main, ["cage", "verify", "demo"])
+
+        assert "[FAIL] mitmproxy CA cert NOT found" in result.output
+        # Egress check skipped when curl is missing — should WARN, not FAIL.
+        assert "[WARN]" in result.output
+        # Overall verify exits non-zero when any [FAIL].
+        assert result.exit_code != 0
 
 
 # ── cage backup / restore: still unsupported (Plan 3 PR-10) ──


### PR DESCRIPTION
## Summary

\`cage verify\` on apple-container used to print a one-line INFO banner saying "deeper checks not yet implemented" and stop after service-status. Now the backend gets \`_verify_apple_container()\` that execs into the microVM via Apple's \`container exec\` and runs CA / DNS routing / egress filtering probes — same shape as \`_verify_container\` does for the podman backend.

## Test plan

- [x] 3 unit tests under \`TestCageVerifyAppleContainer*\` (smoke, happy path, CA-missing sad path)
- [x] On macOS 26.3.2 + ASi: \`cage verify ubuntu02\` reports 6/6 PASS (services + CA + DNS + egress) on a healthy cage

🤖 Generated with [Claude Code](https://claude.com/claude-code)