### PR TITLE
refactor: lift exec/logs/audit onto the Backend protocol

### DIFF
--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -61,3 +61,74 @@ class Backend(Protocol):
     def service_names(self, name: str) -> list[str]:
         """Return the service suffixes for a cage (e.g. ['cage', 'proxy', 'dns'])."""
         ...
+
+    # ── Process inspection & streaming (lifted from cli.py if/elif/else) ────
+    #
+    # exec_argv / logs_argv / audit_argv return argv lists the CLI hands to
+    # subprocess.run / os.execvp / subprocess.Popen. Returning argv (rather
+    # than running the subprocess inside the backend) keeps the contract
+    # simple: the CLI owns I/O and process control; the backend owns the
+    # backend-specific "how do I reach the cage's stdout / journal / proxy
+    # log?" decision.
+    #
+    # Implementations should raise ``BackendUnsupported`` (defined alongside
+    # this protocol) when a request shape can't be served — for example
+    # ``--service proxy`` on apple-container, where the proxy isn't a
+    # separately-addressable container.
+
+    def exec_argv(
+        self,
+        name: str,
+        service: str,
+        cmd: list[str],
+        *,
+        interactive: bool = False,
+    ) -> list[str]:
+        """Argv to exec a command inside the cage's ``service`` component.
+
+        ``service`` is one of ``service_names(name)`` (typically ``cage`` /
+        ``proxy`` / ``dns``). ``cmd`` is the user's command vector; the
+        backend prepends its own runner (e.g. ``podman exec [-it] <c> <cmd>``).
+        """
+        ...
+
+    def logs_argv(
+        self,
+        name: str,
+        services: list[str],
+        *,
+        follow: bool = False,
+        lines: int = 0,
+        min_level: str | None = None,
+    ) -> list[str]:
+        """Argv to stream the cage's combined log output.
+
+        Backends decide what "combined" means: the container backend reads
+        per-service journal units; apple-container reads ``container logs``
+        for the single microVM; vm wraps journalctl in ``limactl shell``.
+        ``min_level`` is a hint; not every backend can filter at source.
+        """
+        ...
+
+    def audit_argv(
+        self,
+        name: str,
+        *,
+        since: str | None = None,
+        follow: bool = False,
+    ) -> list[str]:
+        """Argv that emits one audit JSON line per line on stdout.
+
+        The CLI parses each line via :func:`agentcage.audit.extract_audit_json`
+        and feeds matching entries through ``AuditFilter``.
+        """
+        ...
+
+
+class BackendUnsupported(Exception):
+    """Raised by Backend methods when the requested shape isn't supported.
+
+    The CLI catches this and prints the message to stderr before exit(1),
+    so each backend can produce a helpful, context-specific error (e.g.
+    ``--service proxy on apple-container``).
+    """

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -353,3 +353,86 @@ class AppleContainerBackend:
         # — once `exec`/`logs`/`audit` are lifted onto the Backend
         # protocol — for targeted component access.
         return ["cage", "proxy", "dns"]
+
+    # --- Backend protocol: process inspection / streaming --------------------
+
+    def exec_argv(
+        self,
+        name: str,
+        service: str,
+        cmd: list[str],
+        *,
+        interactive: bool = False,
+    ) -> list[str]:
+        """`container exec [-it] <name> <cmd>`.
+
+        proxy / dns run in-process inside the cage microVM (supervised),
+        not as separate Apple containers, so they aren't addressable by
+        targeted exec. Reject those service names with a clear message.
+        """
+        from agentcage.backend import BackendUnsupported
+        if service != "cage":
+            raise BackendUnsupported(
+                f"'cage exec --service {service}' is not yet supported on "
+                f"the apple-container backend; only --service cage is "
+                f"addressable (proxy and dnsmasq run inside the same microVM)"
+            )
+        binary = ac_cli.container_binary()
+        if binary is None:
+            raise BackendUnsupported(
+                "Apple `container` CLI not found; install from "
+                "https://github.com/apple/container/releases"
+            )
+        flags = ["-it"] if interactive else []
+        return [binary, "exec", *flags, name, *cmd]
+
+    def logs_argv(
+        self,
+        name: str,
+        services: list[str],  # noqa: ARG002 — single-microVM model
+        *,
+        follow: bool = False,
+        lines: int = 0,
+        min_level: str | None = None,  # noqa: ARG002 — Apple doesn't filter
+    ) -> list[str]:
+        """`container logs [-f] <name>` — combined supervisor stdout/stderr.
+
+        The supervisor multiplexes the cage workload + proxy + dnsmasq into
+        one stream; we can't filter per-service the way container/vm do
+        with their per-unit journal cursors. ``services`` is accepted for
+        protocol parity but ignored. ``lines`` is similarly ignored — Apple
+        ``container logs`` doesn't accept ``-n``; the CLI can post-trim if
+        it cares.
+        """
+        from agentcage.backend import BackendUnsupported
+        binary = ac_cli.container_binary()
+        if binary is None:
+            raise BackendUnsupported(
+                "Apple `container` CLI not found; install from "
+                "https://github.com/apple/container/releases"
+            )
+        argv = [binary, "logs"]
+        if follow:
+            argv.append("-f")
+        argv.append(name)
+        return argv
+
+    def audit_argv(
+        self,
+        name: str,
+        *,
+        since: str | None = None,  # noqa: ARG002 — no time index host-side
+        follow: bool = False,
+    ) -> list[str]:
+        """`tail` the host-side audit.jsonl bind-mounted from the microVM.
+
+        The mitmproxy addon writes one JSON line per request decision into
+        /var/log/agentcage/audit.jsonl, which `start()` bind-mounts to
+        `<state>/<cage>/logs/audit.jsonl` on the host. `since` is not yet
+        respected (the host JSONL has no journalctl-style time index);
+        the CLI's AuditFilter still applies time filtering post-parse.
+        """
+        path = self.logs_dir(name) / "audit.jsonl"
+        if follow:
+            return ["tail", "-n", "0", "-F", str(path)]
+        return ["tail", "-n", "10000", str(path)]

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -186,3 +186,63 @@ class ContainerBackend:
 
     def service_names(self, name: str) -> list[str]:
         return ["cage", "proxy", "dns"]
+
+    # --- Backend protocol: process inspection / streaming --------------------
+    #
+    # These return argv lists for the CLI to subprocess.Popen / os.execvp.
+    # See agentcage.backend.Backend for the contract.
+
+    def exec_argv(
+        self,
+        name: str,
+        service: str,
+        cmd: list[str],
+        *,
+        interactive: bool = False,
+    ) -> list[str]:
+        """``podman exec [-it] <name>-<service> <cmd>``."""
+        flags = ["-it"] if interactive else []
+        return ["podman", "exec", *flags, f"{name}-{service}", *cmd]
+
+    def logs_argv(
+        self,
+        name: str,
+        services: list[str],
+        *,
+        follow: bool = False,
+        lines: int = 0,
+        min_level: str | None = None,  # noqa: ARG002 — caller-side filter
+    ) -> list[str]:
+        """``journalctl --user -u <name>-<svc> -o cat`` for the requested
+        services. Container backend's services are systemd --user units
+        managed by Quadlet; this reads their combined output. ``min_level``
+        isn't passed through because journalctl's priority filter would
+        require numeric levels that don't map cleanly to our string set —
+        the CLI's per-line filter handles it post-parse."""
+        argv = ["journalctl", "--user", "-o", "cat"]
+        for svc in services:
+            argv += ["-u", f"{name}-{svc}"]
+        if follow:
+            argv.append("-f")
+        if lines:
+            argv += ["-n", str(lines)]
+        return argv
+
+    def audit_argv(
+        self,
+        name: str,
+        *,
+        since: str | None = None,
+        follow: bool = False,
+    ) -> list[str]:
+        """``journalctl`` for the proxy+dns units. Audit JSON lines are
+        emitted by the mitmproxy addon to stderr (= journal stream)."""
+        argv = ["journalctl", "--user",
+                "-u", f"{name}-proxy", "-u", f"{name}-dns", "-o", "cat"]
+        if since:
+            argv += ["--since", since]
+        if follow:
+            argv.append("-f")
+        else:
+            argv += ["-n", "10000"]  # over-read; many lines aren't audit
+        return argv

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -505,3 +505,67 @@ class VmBackend:
 
     def service_names(self, name: str) -> list[str]:
         return ["cage", "proxy", "dns"]
+
+    # --- Backend protocol: process inspection / streaming --------------------
+    #
+    # The VM backend wraps everything in ``limactl shell <inst> --`` and the
+    # journal needs ``sg systemd-journal`` because Lima's persistent SSH
+    # ControlMaster establishes the session before provisioning runs
+    # ``usermod -aG systemd-journal`` and the SSH inherits stale groups.
+
+    def exec_argv(
+        self,
+        name: str,
+        service: str,
+        cmd: list[str],
+        *,
+        interactive: bool = False,
+    ) -> list[str]:
+        inst = self._instance(name)
+        flags = ["-it"] if interactive else []
+        return ["limactl", "shell", inst.name, "--",
+                "podman", "exec", *flags, f"{name}-{service}", *cmd]
+
+    def logs_argv(
+        self,
+        name: str,
+        services: list[str],
+        *,
+        follow: bool = False,
+        lines: int = 0,
+        min_level: str | None = None,  # noqa: ARG002
+    ) -> list[str]:
+        import shlex
+        inst = self._instance(name)
+        # conmon routes proxy/dns logs to the system journal even when the
+        # service unit is a `--user` one, so the right filter is
+        # `--user-unit` rather than `--user -u`.
+        journal_argv = ["journalctl", "-o", "cat"]
+        for svc in services:
+            journal_argv += ["--user-unit", f"{name}-{svc}"]
+        if follow:
+            journal_argv.append("-f")
+        if lines:
+            journal_argv += ["-n", str(lines)]
+        return ["limactl", "shell", inst.name, "--",
+                "sg", "systemd-journal", "-c", shlex.join(journal_argv)]
+
+    def audit_argv(
+        self,
+        name: str,
+        *,
+        since: str | None = None,
+        follow: bool = False,
+    ) -> list[str]:
+        import shlex
+        inst = self._instance(name)
+        journal_argv = ["journalctl", "--user-unit", f"{name}-proxy",
+                        "--user-unit", f"{name}-dns", "-o", "cat"]
+        if since:
+            journal_argv += ["--since", since]
+        if follow:
+            journal_argv.append("-f")
+        else:
+            journal_argv += ["-n", "10000"]
+        return ["limactl", "shell", inst.name, "--",
+                "sg", "systemd-journal", "-c", shlex.join(journal_argv)]

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1609,35 +1609,28 @@ def cage_exec(name: str, service: str, command: tuple[str, ...]):
     if cmd[0] in cfg.exec_aliases:
         cmd = cfg.exec_aliases[cmd[0]] + cmd[1:]
 
-    if cfg.isolation == "vm":
-        inst = LimaInstance(name)
-        exec_flags = ["-it"] if sys.stdin.isatty() else []
-        os.execvp("limactl", ["limactl", "shell", inst.name, "--",
-                  "podman", "exec", *exec_flags, f"{name}-{service}", *cmd])
+    # Dispatch via Backend.exec_argv (lifted onto the protocol in PR-8).
+    # Each backend returns the argv that runs the command inside the
+    # cage's <service>; the CLI owns the process control.
+    from agentcage.backend import BackendUnsupported
+    backend = get_backend(cfg)
+    try:
+        argv = backend.exec_argv(
+            name, service, cmd, interactive=sys.stdin.isatty(),
+        )
+    except BackendUnsupported as e:
+        click.echo(f"error: {e}", err=True)
+        sys.exit(1)
 
-    if _is_apple_container(cfg):
-        _require_cage_service_on_apple_container(service, "exec")
-        from agentcage.apple_container import cli as ac_cli
-        binary = ac_cli.container_binary()
-        if binary is None:
-            click.echo(
-                "error: Apple `container` CLI not found; install from "
-                "https://github.com/apple/container/releases",
-                err=True,
-            )
-            sys.exit(1)
-        exec_flags = ["-it"] if sys.stdin.isatty() else []
-        # The cage is one Apple container named after the cage itself
-        # (see backends.apple_container — no -cage/-proxy/-dns suffix split).
-        os.execvp(binary, [binary, "exec", *exec_flags, name, *cmd])
-
-    container = f"{name}-{service}"
-    exec_flags = []
-    if sys.stdin.isatty():
-        exec_flags = ["-it"]
-    result = subprocess.run(
-        ["podman", "exec"] + exec_flags + [container] + cmd,
-    )
+    # vm and apple-container backends want exec semantics (replace the
+    # current process); container backend's `podman exec` we run as a
+    # subprocess and propagate the exit code. Distinguishing here keeps
+    # the existing UX for both shapes — limactl shell + container exec
+    # benefit from os.execvp's tty handling, while podman exec on Linux
+    # has historically been run via subprocess.run.
+    if cfg.isolation in ("vm", "apple-container"):
+        os.execvp(argv[0], argv)
+    result = subprocess.run(argv)
     sys.exit(result.returncode)
 
 
@@ -1750,49 +1743,19 @@ def _build_audit_journal_cmd(
 ) -> list[str]:
     """Build the command for reading audit entries.
 
-    Each backend stores audit data differently:
-      - container: systemd-user journal (``journalctl --user -u <cage>-proxy``)
-      - vm: same wrapped in ``limactl shell`` + ``sg systemd-journal``
-      - apple-container: plain JSONL file bind-mounted from the microVM
-        to ~/.config/agentcage/apple-container/<cage>/logs/audit.jsonl;
-        ``tail -n N`` (or ``tail -F`` for follow) it. ``--since`` has no
-        time index on this backend; the AuditFilter time pass happens
-        in Python after parsing.
+    Backend.audit_argv (lifted onto the protocol in PR-8) returns the
+    backend-specific argv: journalctl for container, journalctl wrapped
+    in `limactl shell` + `sg systemd-journal` for vm, `tail` of the
+    host-bind-mounted audit.jsonl for apple-container. This function is
+    now a thin wrapper that normalizes the `--since` value for the two
+    backends that accept time-based filtering (apple-container's tail
+    has no time index — filtering happens via AuditFilter post-parse).
     """
-    if _is_apple_container(cfg):
-        path = _apple_container_audit_path(name)
-        if follow:
-            return ["tail", "-n", "0", "-F", str(path)]
-        return ["tail", "-n", "10000", str(path)]
-    if cfg.isolation == "vm":
-        # In VM mode the proxy/dns are systemd --user services, but conmon
-        # routes their logs to the system journal — so the right filter is
-        # --user-unit, not "--user -u". And Lima's persistent SSH
-        # ControlMaster is established before provisioning runs `usermod
-        # -aG systemd-journal`, so the SSH session inherits stale groups
-        # and the user can't read system.journal directly. `sg
-        # systemd-journal -c '...'` adds the missing group for the
-        # journalctl process, which works for both existing and new VMs.
-        journal_cmd = ["journalctl", "--user-unit", f"{name}-proxy",
-                       "--user-unit", f"{name}-dns", "-o", "cat"]
-    else:
-        journal_cmd = ["journalctl", "--user", "-u", f"{name}-proxy",
-                       "-u", f"{name}-dns", "-o", "cat"]
-
-    if since:
-        journal_cmd += ["--since", _normalize_since(since)]
-
-    if follow:
-        journal_cmd.append("-f")
-    else:
-        # Over-read: many lines aren't audit entries
-        journal_cmd += ["-n", "10000"]
-
-    if cfg.isolation == "vm":
-        inst = LimaInstance(name)
-        return ["limactl", "shell", inst.name, "--",
-                "sg", "systemd-journal", "-c", shlex.join(journal_cmd)]
-    return journal_cmd
+    backend = get_backend(cfg)
+    normalized_since = _normalize_since(since) if since else None
+    return backend.audit_argv(
+        name, since=normalized_since, follow=follow,
+    )
 
 
 def _audit_batch(name, cfg, filt, lines, since, as_json, no_color):

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -262,18 +262,29 @@ class TestCageAuditHarAppleContainer:
         self, mock_state, mock_path, mock_popen, tmp_path,
     ):
         """Once the audit file exists, audit reads it via `tail -n 10000`
-        rather than journalctl; subprocess.Popen receives the right argv."""
+        rather than journalctl; subprocess.Popen receives the right argv.
+
+        The CLI dispatches through Backend.audit_argv (lifted onto the
+        protocol in PR-8) — for apple-container that returns
+        ``tail -n 10000 <host-audit.jsonl>``. We mock the backend's
+        logs_dir to point at tmp_path so audit_argv resolves to a path
+        we control."""
+        from agentcage.backends.apple_container import AppleContainerBackend
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         audit_path = tmp_path / "audit.jsonl"
         audit_path.touch()
+        # _apple_container_audit_path is the "does the file exist?" probe
+        # at the CLI layer; the actual argv is built by backend.audit_argv,
+        # which calls logs_dir(name) — patch THAT to control the path.
         mock_path.return_value = audit_path
 
         fake_proc = MagicMock()
         fake_proc.stdout = iter([])
         mock_popen.return_value = fake_proc
 
-        _runner().invoke(main, ["cage", "audit", "demo"])
+        with patch.object(AppleContainerBackend, "logs_dir", return_value=tmp_path):
+            _runner().invoke(main, ["cage", "audit", "demo"])
 
         # First Popen call is the tail of the host audit file.
         popen_argv = mock_popen.call_args.args[0]


### PR DESCRIPTION
## Summary

\`cage exec\` / \`cage audit\` previously dispatched in cli.py via if/elif/else on \`cfg.isolation\` and built backend-specific argv inline. This PR moves the argv construction onto the Backend protocol so each backend owns its own \`exec_argv\` / \`logs_argv\` / \`audit_argv\` implementations.

- **\`Backend.exec_argv\`** — \`podman exec\` / \`container exec\` / \`limactl shell + podman exec\`
- **\`Backend.logs_argv\`** — \`journalctl --user\` / \`container logs\` / \`limactl shell + sg systemd-journal\`
- **\`Backend.audit_argv\`** — same plus \`tail -F\` of the host audit.jsonl for apple-container
- **\`BackendUnsupported\`** exception — raised by backends when a request shape isn't served (\`--service proxy\` on apple-container)

Migrated: \`cage_exec\` and the three \`_audit_*\` helpers via \`_build_audit_journal_cmd\`. \`cage_logs\` per-backend helpers stay (they do richer per-line classification that doesn't fit a single argv) — follow-up when the classifier moves to a shared formatter.

## Test plan

- [x] All 1438 unit + integration tests pass
- [x] On macOS 26.3.2 + ASi: \`cage exec\` works, \`--service proxy\` rejects cleanly, \`cage audit\` shows the JSON entries via the host-tail reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)