### PR TITLE
feat(apple-container): server-side {{SECRET}} placeholder injection

### DIFF
--- a/src/agentcage/apple_container/wrapper.py
+++ b/src/agentcage/apple_container/wrapper.py
@@ -85,20 +85,24 @@ def render_wrapper_containerfile(user_image: str, *, user_cmd: list[str] | None 
 
 
 def stage_build_context(
-    dest: Path, user_cmd: list[str], allowlist: list[str] | None = None
+    dest: Path,
+    user_cmd: list[str],
+    allowlist: list[str] | None = None,
+    secret_injection_rules: list[dict] | None = None,
 ) -> None:
     """Stage supervisor + cage CMD + egress filter config into *dest*.
 
     Files written:
-      - supervisor.sh    -- PID 1 of the cage microVM (security-critical)
-      - dnsmasq.conf     -- static catch-all that rewrites every DNS query
-                            to 127.0.0.1
-      - cage-cmd.json    -- user image's original ENTRYPOINT+CMD, exec'd by
-                            the supervisor after the egress filter is up
-      - allowlist.txt    -- one host per line; supervisor builds a single
-                            regex for mitmproxy's --allow-hosts. Empty
-                            allowlist means "block everything" (safer
-                            default than "allow everything").
+      - supervisor.sh         -- PID 1 of the cage microVM (security-critical)
+      - dnsmasq.conf          -- static catch-all DNS rewriter
+      - allowlist_addon.py    -- mitmproxy addon (allowlist + audit + injection)
+      - cage-cmd.json         -- user image's original ENTRYPOINT+CMD
+      - allowlist.txt         -- one host per line
+      - secret_injection.json -- list of {env, placeholder, inject_to} rules
+                                 read by the mitmproxy addon at startup;
+                                 actual secret values are env-passed at
+                                 container run time so the build context
+                                 stays free of secrets.
     """
     dest.mkdir(parents=True, exist_ok=True)
     shutil.copy2(_DATA_DIR / "supervisor.sh", dest / "supervisor.sh")
@@ -107,6 +111,9 @@ def stage_build_context(
     (dest / "cage-cmd.json").write_text(json.dumps(user_cmd))
     allow_lines = "\n".join(h.strip() for h in (allowlist or []) if h.strip())
     (dest / "allowlist.txt").write_text(allow_lines + ("\n" if allow_lines else ""))
+    (dest / "secret_injection.json").write_text(
+        json.dumps(secret_injection_rules or [])
+    )
 
 
 def wrapped_image_name(cage_name: str) -> str:
@@ -120,6 +127,7 @@ def build_wrapper(
     *,
     user_cmd: list[str] | None = None,
     allowlist: list[str] | None = None,
+    secret_injection_rules: list[dict] | None = None,
 ) -> str:
     """Generate Containerfile, stage build context, run `container build`.
 
@@ -136,7 +144,10 @@ def build_wrapper(
     with tempfile.TemporaryDirectory(prefix="agentcage-apple-build-") as tmp:
         tmpdir = Path(tmp)
         (tmpdir / "Containerfile").write_text(containerfile)
-        stage_build_context(tmpdir, user_cmd, allowlist=allowlist)
+        stage_build_context(
+            tmpdir, user_cmd, allowlist=allowlist,
+            secret_injection_rules=secret_injection_rules,
+        )
         ac_cli.run(
             ["build", "-t", image, "-f", str(tmpdir / "Containerfile"), str(tmpdir)],
             capture_output=False,  # stream output to user

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -162,8 +162,24 @@ class AppleContainerBackend:
         # so no defensive getattr is needed. An empty allowlist means
         # "block all egress" (safer default than "allow all").
         allowlist = list(config.domains.allow or [])
+        # Secret-injection rules — only the metadata (env name, placeholder,
+        # inject_to allow-list of domains) is baked into the image. The
+        # actual secret VALUES are env-passed at `container run` time
+        # (see `start()` below) so the build context — which ends up in
+        # the image layer — stays free of secrets.
+        secret_rules = [
+            {
+                "env": r.env,
+                "placeholder": r.placeholder,
+                "inject_to": list(r.inject_to or []),
+            }
+            for r in (config.secret_injection or [])
+        ]
         ac_wrapper.build_wrapper(
-            deploy_name, user_image, user_cmd=user_cmd, allowlist=allowlist,
+            deploy_name, user_image,
+            user_cmd=user_cmd,
+            allowlist=allowlist,
+            secret_injection_rules=secret_rules,
         )
         if not quiet:
             click.echo(f"Built {ac_wrapper.wrapped_image_name(deploy_name)}")
@@ -201,6 +217,11 @@ class AppleContainerBackend:
         memory = config.container.memory or (
             f"{config.vm.mem_mb}m" if getattr(config.vm, "mem_mb", 0) else ""
         )
+        # Persist the secret-injection rule list so `start()` knows which
+        # env vars to forward into the microVM at `container run` time.
+        # Only the env names are stored — the actual secret values come
+        # from the host environment (or, in future, a Keychain lookup).
+        secret_envs = [r.env for r in (config.secret_injection or [])]
         unit_json = json.dumps(
             {
                 "name": deploy_name,
@@ -208,6 +229,7 @@ class AppleContainerBackend:
                 "cpus": cpus,
                 "memory": memory,
                 "lifecycle": config.lifecycle,
+                "secret_envs": secret_envs,
             },
             indent=2,
             sort_keys=True,
@@ -298,6 +320,27 @@ class AppleContainerBackend:
             argv += ["--memory", _normalize_memory(str(memory_raw))]
         elif meta.get("mem_mb"):  # pre-0.20.6 unit JSON
             argv += ["--memory", f"{meta['mem_mb']}M"]
+
+        # Secret-injection env-passing. For each env named in the cage's
+        # `secret_injection:` rules, look it up in the current host
+        # environment and forward via `-e NAME=value` to `container run`.
+        # The mitmproxy addon inside the cage reads these at startup and
+        # uses them to substitute `{{NAME}}` placeholders in outbound
+        # requests destined for the rule's inject_to allow-list.
+        # Missing env vars are skipped with a stderr warning rather than
+        # failing — the cage may not need every secret on every host.
+        for env_name in meta.get("secret_envs") or []:
+            value = os.environ.get(env_name)
+            if value is None:
+                click.echo(
+                    f"warning: secret_injection env {env_name!r} "
+                    f"not set in host environment; placeholder will "
+                    f"NOT be substituted in cage requests",
+                    err=True,
+                )
+                continue
+            argv += ["-e", f"{env_name}={value}"]
+
         argv.append(image)
 
         result = ac_cli.run(argv, check=False, capture_output=False)

--- a/src/agentcage/data/apple-container/Containerfile.wrapper.j2
+++ b/src/agentcage/data/apple-container/Containerfile.wrapper.j2
@@ -80,6 +80,7 @@ COPY allowlist_addon.py /opt/agentcage/allowlist_addon.py
 COPY cage-cmd.json /etc/agentcage/cage-cmd.json
 COPY allowlist.txt /etc/agentcage/allowlist.txt
 COPY dnsmasq.conf /etc/agentcage/dnsmasq.conf
+COPY secret_injection.json /etc/agentcage/secret_injection.json
 RUN chmod 0755 /opt/agentcage/supervisor
 
 # Supervisor runs as PID 1.

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -38,6 +38,7 @@ from mitmproxy import ctx, http
 
 
 ALLOWLIST_PATH = "/etc/agentcage/allowlist.txt"
+SECRET_INJECTION_PATH = "/etc/agentcage/secret_injection.json"
 AUDIT_LOG_PATH = os.environ.get(
     "AGENTCAGE_AUDIT_LOG", "/var/log/agentcage/audit.jsonl"
 )
@@ -68,14 +69,86 @@ def _host_allowed(host: str, allowed: set[str]) -> bool:
     return False
 
 
+def _load_secret_injection_rules() -> list[dict]:
+    """Load the cage's secret_injection rule list, baked in at build time.
+
+    Each rule is ``{"env": str, "placeholder": str, "inject_to": [str]}``.
+    The actual secret VALUE is read from ``os.environ[env]`` at request
+    time (forwarded by ``AppleContainerBackend.start()`` via ``-e``).
+    """
+    try:
+        with open(SECRET_INJECTION_PATH) as f:
+            data = json.load(f)
+            return data if isinstance(data, list) else []
+    except (OSError, ValueError):
+        return []
+
+
 class AllowlistAddon:
     def __init__(self) -> None:
         self.allowed = _load_allowlist()
         ctx.log.info(
             f"[agentcage] allowlist loaded: {sorted(self.allowed) or '(empty — block all)'}"
         )
+        self.injection_rules = _load_secret_injection_rules()
+        # Resolve secret values from the environment ONCE at startup —
+        # later os.environ changes won't propagate. Skip rules whose
+        # env var isn't set (the backend logs a warning at start, and
+        # the placeholder simply doesn't get substituted).
+        self._resolved_secrets: list[dict] = []
+        for rule in self.injection_rules:
+            value = os.environ.get(rule.get("env", ""))
+            if not value:
+                continue
+            self._resolved_secrets.append({
+                "env": rule["env"],
+                "placeholder": rule["placeholder"],
+                "value": value,
+                "inject_to": [d.lower() for d in (rule.get("inject_to") or [])],
+            })
+        if self._resolved_secrets:
+            ctx.log.info(
+                f"[agentcage] secret injection: "
+                f"{[r['env'] for r in self._resolved_secrets]}"
+            )
         self._audit_fh = self._open_log(AUDIT_LOG_PATH)
         self._capture_fh = self._open_log(CAPTURE_PATH)
+
+    def _maybe_inject(self, flow: http.HTTPFlow) -> list[str]:
+        """Substitute placeholders in request headers/body for matching hosts.
+
+        Returns the list of env names that had at least one substitution
+        performed; the audit entry surfaces this as `secrets_injected`.
+        """
+        host = flow.request.pretty_host.lower()
+        injected: list[str] = []
+        for rule in self._resolved_secrets:
+            inject_to = rule["inject_to"]
+            if inject_to and not any(
+                host == d or host.endswith("." + d) for d in inject_to
+            ):
+                continue
+            placeholder = rule["placeholder"]
+            value = rule["value"]
+            replaced_any = False
+            # Headers
+            for name, val in list(flow.request.headers.items()):
+                if placeholder in val:
+                    flow.request.headers[name] = val.replace(placeholder, value)
+                    replaced_any = True
+            # Body — only attempt if it's text-ish; binary bodies passed
+            # through unchanged. Skip if the placeholder isn't there to
+            # avoid round-tripping the body through .text.
+            try:
+                body_text = flow.request.get_text(strict=False)
+            except (UnicodeDecodeError, ValueError):
+                body_text = None
+            if body_text and placeholder in body_text:
+                flow.request.set_text(body_text.replace(placeholder, value))
+                replaced_any = True
+            if replaced_any:
+                injected.append(rule["env"])
+        return injected
 
     @staticmethod
     def _open_log(path: str):
@@ -126,8 +199,13 @@ class AllowlistAddon:
         }
 
         if _host_allowed(host, self.allowed):
+            # Apply secret injection BEFORE the upstream request goes out.
+            # Substitutions happen in place; we record the env names in
+            # the audit entry so the operator can see what was swapped.
+            injected = self._maybe_inject(flow)
             entry["decision"] = "allowed"
             entry["reason"] = "domain-allowlist"
+            entry["secrets_injected"] = injected
             self._audit(entry)
             return
 

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -206,6 +206,70 @@ def test_stage_build_context_includes_allowlist_addon(tmp_path):
     assert "403" in addon  # must respond with 403, not silently pass
 
 
+def test_stage_build_context_includes_secret_injection_rules(tmp_path):
+    """secret_injection rules baked into the wrapper image at build time —
+    the actual secret VALUES are env-passed at container run time so the
+    image stays free of credentials. The mitmproxy addon reads the rule
+    list from /etc/agentcage/secret_injection.json at startup and resolves
+    each `env` against os.environ."""
+    rules = [
+        {"env": "API_KEY", "placeholder": "{{API_KEY}}",
+         "inject_to": ["api.example.com"]},
+    ]
+    ac_wrapper.stage_build_context(
+        tmp_path, ["sh"], allowlist=["a.com"], secret_injection_rules=rules,
+    )
+    si = json.loads((tmp_path / "secret_injection.json").read_text())
+    assert si == rules
+
+
+def test_stage_build_context_empty_secret_injection(tmp_path):
+    """No rules → empty list (NOT a missing file), so the addon's loader
+    can read+parse unconditionally."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    assert (tmp_path / "secret_injection.json").exists()
+    assert json.loads((tmp_path / "secret_injection.json").read_text()) == []
+
+
+def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
+    """start() reads secret_envs from the unit metadata and forwards each
+    via `-e NAME=value`. Missing env vars are skipped (with a warning)."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "interactive",
+        "secret_envs": ["API_KEY", "MISSING_KEY"],
+    }))
+    monkeypatch.setenv("API_KEY", "sk-real-1234")
+    monkeypatch.delenv("MISSING_KEY", raising=False)
+
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    logs_dir = tmp_path / "logs"
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    assert "-e" in run_argv
+    assert "API_KEY=sk-real-1234" in run_argv
+    # Missing env name MUST NOT appear (no `-e MISSING_KEY=` with empty value).
+    assert "MISSING_KEY=" not in " ".join(run_argv)
+
+
 def test_nat_redirect_excludes_proxy_and_dns_not_only_uid_1000(tmp_path):
     """REGRESSION: NAT REDIRECT for tcp/80 and tcp/443 must catch every
     uid except the egress components (uid 200 = mitmproxy, uid 201 = dnsmasq),


### PR DESCRIPTION
## Summary

apple-container's mitmproxy addon now substitutes \`{{ENV_NAME}}\` placeholders in outbound request headers/bodies with real secret values, mirroring the container backend's \`secret_injection\` contract. The cage sees only placeholders; the proxy holds the real values (env-passed at \`container run\` time, never baked into the image).

This is the minimal viable port — request-side substitution only. Response redaction and transform functions (e.g. \`google-jwt-bearer\`) are tracked as follow-ups in #120.

## Mechanism

1. \`wrapper.stage_build_context\` writes \`/etc/agentcage/secret_injection.json\` with the per-cage rule list (env + placeholder + inject_to). Just metadata — no values.
2. \`AppleContainerBackend.start\` reads \`secret_envs\` from the unit JSON, looks each up in the host environment, forwards \`-e NAME=value\` to \`container run\`. Missing host vars → stderr warning, skipped.
3. \`allowlist_addon.py\` resolves rules against \`os.environ\` at startup; on each request, substitutes in-place when destination host matches \`inject_to\`.

## Test plan

- [x] 3 new unit tests in \`tests/test_apple_container.py\` (rules baked in, empty baseline, env forwarding with missing-key skip)
- [x] On macOS 26.3.2 + ASi: cage with \`secret_injection\` rule and \`AGENTCAGE_TEST_SECRET=test-secret-xyz\` env: \`curl -H 'X-Test-Auth: {{AGENTCAGE_TEST_SECRET}}' https://httpbin.org/headers\` returns \`"X-Test-Auth": "test-secret-xyz"\` (real value reached upstream, cage saw only the placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)