### PR TITLE
feat(apple-container): launchd autostart + supervisor.sh CI

### DIFF
--- a/.github/workflows/supervisor.yml
+++ b/.github/workflows/supervisor.yml
@@ -1,0 +1,52 @@
+name: Apple-container supervisor
+
+# Catches supervisor.sh regressions on every PR. The supervisor.sh in
+# src/agentcage/data/apple-container/ is the security-critical PID-1 of
+# every apple-container cage (sets up hidepid=2, per-component uids,
+# iptables egress filter, drops caps + setuid's the cage workload at
+# stage 90). Bugs here silently weaken isolation across every
+# apple-container cage, so we run two layers of validation in CI:
+#
+#   1. shellcheck — catches POSIX-sh portability bugs, common quoting
+#      errors, unset-variable references. The supervisor uses `set -eu`
+#      so an unset-variable bug bricks the cage at boot time; better to
+#      catch in CI than after deploy.
+#   2. stage-marker presence — asserts every documented `log "stage N:"`
+#      marker exists. Reordering or removing a stage without updating
+#      docs/apple-container.md is a noisy way to ship a regression;
+#      this catches it as a basic dead-code check.
+#
+# Full runtime testing (build wrapper image, run with CAP_SYS_ADMIN,
+# assert hidepid + caps + uid state) requires a multi-stage docker
+# setup that's tracked separately in issue #120. The shellcheck +
+# marker-presence layer is the minimum-viable safety net.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    paths:
+      - 'src/agentcage/data/apple-container/**'
+      - '.github/workflows/supervisor.yml'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update -qq && sudo apt-get install -y shellcheck
+      - name: Lint supervisor.sh
+        run: shellcheck src/agentcage/data/apple-container/supervisor.sh
+      - name: Assert documented stage markers are all present
+        run: |
+          set -euo pipefail
+          sup=src/agentcage/data/apple-container/supervisor.sh
+          for stage in 10 20 30 40 50 60 70 80 90; do
+            if ! grep -q "stage ${stage}:" "$sup"; then
+              echo "::error file=$sup::missing 'stage ${stage}:' log marker" >&2
+              exit 1
+            fi
+          done
+          echo "All 9 stages present (10/20/30/40/50/60/70/80/90)"

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -95,6 +95,86 @@ class AppleContainerBackend:
         """
         return self._state_dir(name) / "logs"
 
+    def _launchd_plist_path(self, name: str) -> Path:
+        """Host path of the per-cage launchd plist.
+
+        We install into the user's LaunchAgents dir (no sudo needed; runs
+        as the user at every login). The plist label and filename follow
+        reverse-DNS form `io.agentcage.<cage>` so they don't collide with
+        non-agentcage daemons in launchctl listings.
+        """
+        return Path(
+            os.path.expanduser(f"~/Library/LaunchAgents/io.agentcage.{name}.plist")
+        )
+
+    def _install_launchd_plist(self, name: str) -> None:
+        """Write + load the per-cage launchd plist.
+
+        The plist re-execs `container start <cage>` at user login. Logs
+        go under the per-cage state dir so `cage logs` already finds
+        them. Idempotent: an existing plist is overwritten and reloaded.
+        """
+        binary = ac_cli.container_binary()
+        if binary is None:
+            click.echo(
+                "warning: cannot install launchd autostart — Apple "
+                "`container` CLI not found",
+                err=True,
+            )
+            return
+        plist = self._launchd_plist_path(name)
+        plist.parent.mkdir(parents=True, exist_ok=True)
+        state_dir = self._state_dir(name)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        plist_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.agentcage.{name}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{binary}</string>
+        <string>start</string>
+        <string>{name}</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>{state_dir}/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>{state_dir}/launchd.err.log</string>
+</dict>
+</plist>
+"""
+        plist.write_text(plist_xml)
+        # bootstrap + load. `launchctl load` exits 0 even if already
+        # loaded; if it changes, run unload first so reload picks up
+        # the new ProgramArguments.
+        import subprocess as _sp
+        _sp.run(["launchctl", "unload", str(plist)],
+                check=False, capture_output=True)
+        result = _sp.run(["launchctl", "load", "-w", str(plist)],
+                         check=False, capture_output=True, text=True)
+        if result.returncode != 0:
+            click.echo(
+                f"warning: launchctl load failed for {plist}: "
+                f"{result.stderr.strip()}",
+                err=True,
+            )
+
+    def _uninstall_launchd_plist(self, name: str) -> None:
+        """Unload + remove the per-cage launchd plist. No-op if absent."""
+        plist = self._launchd_plist_path(name)
+        if not plist.exists():
+            return
+        import subprocess as _sp
+        _sp.run(["launchctl", "unload", str(plist)],
+                check=False, capture_output=True)
+        plist.unlink(missing_ok=True)
+
     # --- Backend protocol -----------------------------------------------------
 
     def check_prerequisites(self, config: Config) -> list[str]:  # noqa: ARG002
@@ -230,6 +310,7 @@ class AppleContainerBackend:
                 "memory": memory,
                 "lifecycle": config.lifecycle,
                 "secret_envs": secret_envs,
+                "autostart": bool(getattr(config, "apple_container_autostart", False)),
             },
             indent=2,
             sort_keys=True,
@@ -346,6 +427,13 @@ class AppleContainerBackend:
         result = ac_cli.run(argv, check=False, capture_output=False)
         if result.returncode != 0:
             raise RuntimeError(f"`container run` failed (exit {result.returncode})")
+        # Install (or refresh) the launchd plist if the cage opted in to
+        # autostart. Read from the unit metadata so plists stick across
+        # reloads — the user-visible cage.yaml may have been edited since
+        # but `cage create / update` is what propagates flags into the
+        # unit JSON, so we honor whatever was set at the last create/update.
+        if meta.get("autostart"):
+            self._install_launchd_plist(name)
         if not quiet:
             click.echo(f"Started {name} (apple-container)")
 
@@ -358,6 +446,11 @@ class AppleContainerBackend:
 
     def destroy_resources(self, name: str, keep_secrets: bool = False) -> list[str]:  # noqa: ARG002
         removed: list[str] = []
+        # launchd plist (best-effort; only present when autostart was enabled).
+        plist = self._launchd_plist_path(name)
+        if plist.exists():
+            self._uninstall_launchd_plist(name)
+            removed.append(f"launchd:{plist}")
         # Container
         if ac_cli.inspect(name) is not None:
             ac_cli.run(["stop", name], check=False)

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -292,6 +292,12 @@ class Config:
     help: str = ""
     exec_aliases: dict[str, list[str]] = field(default_factory=dict)
     scaffold: str = ""  # scaffold name, stored in metadata for cage ls
+    # apple-container only: when True, agentcage installs a per-cage
+    # launchd plist into ~/Library/LaunchAgents so the cage re-starts
+    # automatically at user login. Opt-in because most users prefer to
+    # control which cages come back after a reboot. Other isolation
+    # backends ignore this. See docs/apple-container.md.
+    apple_container_autostart: bool = False
 
 
 def default_isolation() -> str:
@@ -681,6 +687,9 @@ def load_config(path: str) -> Config:
         pt.udp.allow = list(raw_udp_allow)
 
     cfg.ports = pt
+
+    # apple-container only: opt-in launchd autostart at user login.
+    cfg.apple_container_autostart = bool(raw.get("apple_container_autostart", False))
 
     # Help text
     cfg.help = str(raw.get("help", "") or "")

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -238,6 +238,68 @@ def test_stage_build_context_empty_secret_injection(tmp_path):
     assert json.loads((tmp_path / "secret_injection.json").read_text()) == []
 
 
+def test_generate_units_persists_autostart_flag():
+    """`apple_container_autostart: true` in cage.yaml flows into the unit
+    JSON's `autostart` field. `start()` reads this to decide whether to
+    install a launchd plist."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "x"
+    cfg.apple_container_autostart = True
+
+    units = AppleContainerBackend().generate_units(
+        cfg, "/cfg", "/patches", "deploy",
+    )
+    meta = json.loads(units["deploy.json"])
+    assert meta["autostart"] is True
+
+
+def test_generate_units_autostart_default_false():
+    """Autostart is opt-in. Cages that don't set the flag get
+    `autostart: false` in the unit JSON; `start()` skips the plist."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "x"
+    units = AppleContainerBackend().generate_units(
+        cfg, "/cfg", "/patches", "deploy",
+    )
+    meta = json.loads(units["deploy.json"])
+    assert meta["autostart"] is False
+
+
+def test_launchd_plist_path_is_under_user_launchagents():
+    """plist file goes under ~/Library/LaunchAgents — user-scope so no
+    sudo, runs at the user's login session."""
+    p = AppleContainerBackend()._launchd_plist_path("demo")
+    assert str(p).endswith("/Library/LaunchAgents/io.agentcage.demo.plist")
+
+
+def test_install_launchd_plist_writes_well_formed_xml(tmp_path, monkeypatch):
+    """`_install_launchd_plist` writes a valid Apple plist XML with the
+    expected ProgramArguments shape and the cage name in the Label."""
+    backend = AppleContainerBackend()
+    monkeypatch.setattr(backend, "_launchd_plist_path",
+                        lambda name: tmp_path / f"io.agentcage.{name}.plist")
+    monkeypatch.setattr(backend, "_state_dir",
+                        lambda name: tmp_path / f"state-{name}")
+    with patch.object(ac_cli, "container_binary",
+                       return_value="/usr/local/bin/container"), \
+         patch("subprocess.run",
+               return_value=type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()):
+        backend._install_launchd_plist("demo")
+
+    plist_text = (tmp_path / "io.agentcage.demo.plist").read_text()
+    assert "<key>Label</key>" in plist_text
+    assert "<string>io.agentcage.demo</string>" in plist_text
+    assert "<string>/usr/local/bin/container</string>" in plist_text
+    assert "<string>start</string>" in plist_text
+    assert "<string>demo</string>" in plist_text
+    # Well-formedness: round-trip via plistlib.
+    import plistlib
+    parsed = plistlib.loads(plist_text.encode())
+    assert parsed["Label"] == "io.agentcage.demo"
+    assert parsed["RunAtLoad"] is True
+    assert parsed["ProgramArguments"][-1] == "demo"
+
+
 def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
     """start() reads secret_envs from the unit metadata and forwards each
     via `-e NAME=value`. Missing env vars are skipped (with a warning)."""


### PR DESCRIPTION
## Summary

Closes out Plan 3 of #120 with two pieces:

1. **Per-cage launchd plist** — opt-in via cage.yaml \`apple_container_autostart: true\`. Cage re-starts at user login (matches container/vm's quadlet autostart). plist lives in \`~/Library/LaunchAgents/io.agentcage.<cage>.plist\`; \`cage destroy\` unloads + removes it.
2. **Linux CI for supervisor.sh** (\`.github/workflows/supervisor.yml\`) — shellcheck + stage-marker presence check. Catches POSIX-sh / quoting / unset-var regressions in the security-critical PID 1. Full runtime test (CAP_SYS_ADMIN + hidepid + caps assertions) needs docker-in-docker setup; tracked as follow-up in #120.

## Test plan

- [x] 4 new unit tests covering autostart flag persistence + plist XML well-formedness
- [x] Verified on macOS 26.3.2 + ASi: plist installs, contains the right Label + ProgramArguments, removed by destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)