### PR TITLE
feat(apple-container): response-side {{SECRET}} redaction

### DIFF
--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -174,17 +174,6 @@ and dnsmasq run inside the same microVM)
 
 **Proper fix path (deferred).** Would need a routing layer in the supervisor that listens on a control socket and proxies exec requests to the right component's namespace. Architectural, not a small patch.
 
-### Response redaction for `{{SECRET}}` placeholders not implemented
-
-**Symptom.** A request body that includes `{{API_KEY}}` gets the real key substituted on the way out (works correctly). But if the upstream echoes that key back in the response body (most don't, but some do — webhook receivers, debug endpoints), the cage sees the real key, not the placeholder.
-
-**Why.** PR #151 shipped request-side substitution only. The container backend's `SecretInjector` also has response-side `redact_response` logic that finds the real value in incoming bodies and rewrites it back to `{{API_KEY}}`. That path isn't ported yet.
-
-**Workarounds.**
-
-- Trust your upstreams not to echo secrets in responses. For most APIs (Anthropic, OpenAI, Stripe, etc.) this is a safe assumption.
-- For upstreams you don't trust, list them in `domains.passthrough` rather than `domains.allow` — that bypasses TLS interception entirely so the cage talks directly to the upstream and never gets the secret-substituted version.
-
 ### `secret_injection.transform` accepted but not applied
 
 **Symptom.** Setting `transform: google-jwt-bearer` (or any other transform) on a `secret_injection` rule passes `validate_config` but the proxy substitutes the literal env-var value, not the transform output. `validate_config` emits a warning:

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -114,6 +114,20 @@ class AllowlistAddon:
         self._audit_fh = self._open_log(AUDIT_LOG_PATH)
         self._capture_fh = self._open_log(CAPTURE_PATH)
 
+    @staticmethod
+    def _host_matches_inject_to(host: str, inject_to: list[str]) -> bool:
+        """Mirror the host-scope rule used by ``_maybe_inject``.
+
+        Empty ``inject_to`` means "any host" — the rule applies anywhere.
+        Otherwise the request/response host must equal or be a subdomain
+        of an entry. Same suffix semantics as ``_host_allowed`` but kept
+        rule-scoped so an unrelated allowlisted host that happens to echo
+        a substring matching a secret isn't redacted.
+        """
+        if not inject_to:
+            return True
+        return any(host == d or host.endswith("." + d) for d in inject_to)
+
     def _maybe_inject(self, flow: http.HTTPFlow) -> list[str]:
         """Substitute placeholders in request headers/body for matching hosts.
 
@@ -123,10 +137,7 @@ class AllowlistAddon:
         host = flow.request.pretty_host.lower()
         injected: list[str] = []
         for rule in self._resolved_secrets:
-            inject_to = rule["inject_to"]
-            if inject_to and not any(
-                host == d or host.endswith("." + d) for d in inject_to
-            ):
+            if not self._host_matches_inject_to(host, rule["inject_to"]):
                 continue
             placeholder = rule["placeholder"]
             value = rule["value"]
@@ -149,6 +160,63 @@ class AllowlistAddon:
             if replaced_any:
                 injected.append(rule["env"])
         return injected
+
+    def _maybe_redact(self, flow: http.HTTPFlow) -> list[str]:
+        """Replace real secret values with placeholders on inbound responses.
+
+        Mirror of ``_maybe_inject`` for the response path: for every rule
+        whose ``inject_to`` allows this host, scan response headers and
+        text body for the raw secret value and put the placeholder back
+        in its place. This means the cage never sees the secret bytes
+        even if the upstream echoes them back (e.g. ``httpbin/headers``
+        reflecting the ``X-Echo`` header we substituted on the way out).
+
+        Skip rules with an empty ``value`` (env var unset at startup) —
+        ``self._resolved_secrets`` already filters those out, but the
+        check is cheap and defensive.
+
+        Binary response bodies (images, archives) are passed through
+        unchanged: ``get_text(strict=False)`` raises on undecodable
+        bytes, same defensive pattern as ``_maybe_inject``.
+
+        Returns the list of env names that had at least one substitution
+        performed; the audit entry surfaces this as `secrets_redacted`.
+        """
+        if flow.response is None:
+            return []
+        host = flow.request.pretty_host.lower()
+        redacted: list[str] = []
+        # Sort longest value first so a secret that is a substring of
+        # another secret doesn't leave a partial leak behind.
+        sorted_rules = sorted(
+            self._resolved_secrets,
+            key=lambda r: len(r["value"]),
+            reverse=True,
+        )
+        for rule in sorted_rules:
+            value = rule["value"]
+            if not value:  # defensive — _resolved_secrets already filters
+                continue
+            if not self._host_matches_inject_to(host, rule["inject_to"]):
+                continue
+            placeholder = rule["placeholder"]
+            replaced_any = False
+            # Response headers
+            for name, val in list(flow.response.headers.items()):
+                if value in val:
+                    flow.response.headers[name] = val.replace(value, placeholder)
+                    replaced_any = True
+            # Response body — text only; binary bodies pass through.
+            try:
+                body_text = flow.response.get_text(strict=False)
+            except (UnicodeDecodeError, ValueError):
+                body_text = None
+            if body_text and value in body_text:
+                flow.response.set_text(body_text.replace(value, placeholder))
+                replaced_any = True
+            if replaced_any:
+                redacted.append(rule["env"])
+        return redacted
 
     @staticmethod
     def _open_log(path: str):
@@ -233,27 +301,63 @@ class AllowlistAddon:
         )
 
     def response(self, flow: http.HTTPFlow) -> None:
-        """Emit a capture record for successful round-trips.
+        """Redact real secret values back to placeholders, then capture.
 
-        Capture only includes responses we actually proxied (i.e. the
-        request hook did NOT short-circuit with a 403). The format is a
-        subset of the container backend's capture.jsonl, enough for
-        ``agentcage.har.capture_to_har`` to render a HAR file: ts,
-        request fields, response status/headers. Bodies are omitted in
-        v1 because the apple-container addon doesn't have the streaming
-        capture machinery; HAR will show response.content.size=0.
+        Two jobs:
+
+        1. **Redact** any rule's raw secret value that appears in the
+           response headers or text body and put the placeholder back.
+           This is the inbound complement of ``_maybe_inject``: the cage
+           never sees the secret bytes even if the upstream echoes them
+           back (e.g. ``httpbin/headers`` reflecting the ``X-Echo``
+           header we substituted on the way out). When at least one
+           substitution happens, an audit line with ``direction:
+           "inbound"`` is emitted so the operator can see which env
+           names were redacted on which host.
+
+        2. **Capture** the (now-redacted) response into capture.jsonl
+           for ``agentcage cage har``. Capture runs after redaction so
+           HAR exports never contain raw secret values. Only responses
+           we actually proxied get captured — locally-synthesized 403s
+           from the request hook are skipped via the ``"by":
+           "agentcage"`` marker check.
         """
-        if self._capture_fh is None or flow.response is None:
+        if flow.response is None:
             return
         # If we already 403ed in `request`, the response is one we
-        # constructed locally — no point re-capturing it. Match on the
-        # unique `"by": "agentcage"` marker in our JSON body so the
-        # check stays robust against accidental Content-Type changes.
+        # constructed locally — no upstream bytes to redact, no point
+        # re-capturing. Match on the unique `"by": "agentcage"` marker
+        # in our JSON body so the check stays robust against accidental
+        # Content-Type changes.
         if (
             flow.response.status_code == 403
             and flow.response.content
             and b'"by": "agentcage"' in flow.response.content
         ):
+            return
+
+        # Redact BEFORE capture so capture.jsonl never sees raw values.
+        redacted = self._maybe_redact(flow)
+        if redacted:
+            host_lc = flow.request.pretty_host
+            self._audit({
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "direction": "inbound",
+                "method": flow.request.method,
+                "host": host_lc,
+                "url": flow.request.pretty_url,
+                "path": flow.request.path,
+                "port": flow.request.port,
+                "source": "apple-container",
+                "inspectors": [],
+                "secrets_injected": [],
+                "secrets_redacted": redacted,
+                "decision": "allowed",
+                "reason": "secret-redaction",
+                "status": flow.response.status_code,
+            })
+
+        if self._capture_fh is None:
             return
         host = flow.request.pretty_host
         capture: dict = {

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import platform
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +17,29 @@ from agentcage.apple_container import scaffold as ac_scaffold
 from agentcage.apple_container import wrapper as ac_wrapper
 from agentcage.backends.apple_container import AppleContainerBackend
 from agentcage.config import Config, default_isolation, validate_config
+
+
+# ── allowlist_addon import helper ────────────────────────────
+# The addon file ships inside the wheel as a data file (it runs
+# *inside* the cage's mitmproxy process, not in the host Python).
+# To unit-test ``AllowlistAddon`` from the host, we load it by
+# absolute path; conftest.py already stubs ``mitmproxy`` so the
+# import succeeds without the real proxy bundle being installed.
+
+_ADDON_PATH = (
+    Path(__file__).parent.parent
+    / "src" / "agentcage" / "data" / "apple-container" / "allowlist_addon.py"
+)
+
+
+def _load_addon_module():
+    spec = importlib.util.spec_from_file_location(
+        "_test_allowlist_addon", _ADDON_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
 
 
 # ---------------------------------------------------------------------------
@@ -842,3 +868,174 @@ def test_run_capturing_does_not_pause_active_spinner():
         ac_cli.run(["inspect", "x"], check=False, capture_output=True)
 
     assert events == ["subprocess.run"]
+
+
+# ---------------------------------------------------------------------------
+# allowlist_addon: response-side {{SECRET}} redaction
+#
+# These exercise the addon's response() hook end-to-end with a mocked
+# mitmproxy HTTPFlow. The conftest.py stub of `mitmproxy` lets the addon
+# module import cleanly on the host; we never spin up real mitmproxy.
+# ---------------------------------------------------------------------------
+
+
+def _build_addon(monkeypatch, tmp_path, *, secret_value="redact-test-xyz",
+                 inject_to=("httpbin.org",), allowlist=("httpbin.org",)):
+    """Construct an AllowlistAddon wired to a one-rule config in tmp_path.
+
+    Returns ``(module, addon)``. Audit + capture logs are redirected
+    into tmp_path so tests can assert on the JSONL output.
+    """
+    addon_mod = _load_addon_module()
+    # Resolve secret via env so the addon's startup-time os.environ lookup
+    # picks it up (the same way `agentcage cage create -e ...` works in prod).
+    monkeypatch.setenv("AGENTCAGE_REDACT_SECRET", secret_value)
+    rules = [{
+        "env": "AGENTCAGE_REDACT_SECRET",
+        "placeholder": "{{AGENTCAGE_REDACT_SECRET}}",
+        "inject_to": list(inject_to),
+    }]
+    allow_path = tmp_path / "allowlist.txt"
+    allow_path.write_text("\n".join(allowlist) + "\n")
+    si_path = tmp_path / "secret_injection.json"
+    si_path.write_text(json.dumps(rules))
+    monkeypatch.setattr(addon_mod, "ALLOWLIST_PATH", str(allow_path))
+    monkeypatch.setattr(addon_mod, "SECRET_INJECTION_PATH", str(si_path))
+    monkeypatch.setattr(addon_mod, "AUDIT_LOG_PATH", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setattr(addon_mod, "CAPTURE_PATH", str(tmp_path / "capture.jsonl"))
+    return addon_mod, addon_mod.AllowlistAddon()
+
+
+def _make_response_flow(*, host, body, status=200, resp_headers=None,
+                        method="GET", path="/headers"):
+    """Build a minimal mock mitmproxy HTTPFlow with a response attached.
+
+    ``body`` may be ``str`` (text body) or ``bytes`` (binary). For text
+    bodies we set ``flow.response.get_text`` to return it; the addon's
+    redactor calls ``set_text`` to mutate, which writes back into
+    ``flow.response.text``.
+    """
+    flow = MagicMock()
+    flow.request.pretty_host = host
+    flow.request.pretty_url = f"https://{host}{path}"
+    flow.request.path = path
+    flow.request.port = 443
+    flow.request.method = method
+    flow.request.headers = {}
+
+    flow.response = MagicMock()
+    flow.response.status_code = status
+    flow.response.reason = "OK"
+    flow.response.headers = dict(resp_headers or {})
+    flow.response.content = body.encode() if isinstance(body, str) else body
+
+    if isinstance(body, str):
+        # Stash text in a closure so set_text() updates what get_text()
+        # returns on subsequent calls — matches mitmproxy's behaviour.
+        state = {"text": body}
+        flow.response.get_text.side_effect = lambda strict=True: state["text"]
+        def _set_text(new):
+            state["text"] = new
+            flow.response.content = new.encode()
+        flow.response.set_text.side_effect = _set_text
+    else:
+        # Binary body — mimic mitmproxy raising on undecodable bytes.
+        flow.response.get_text.side_effect = UnicodeDecodeError(
+            "utf-8", body, 0, 1, "binary body",
+        )
+    return flow
+
+
+def test_response_redaction_happy_path(tmp_path, monkeypatch):
+    """End-to-end: a response body that echoes the real secret value gets
+    rewritten back to ``{{AGENTCAGE_REDACT_SECRET}}``. The audit JSONL
+    records the env name under ``secrets_redacted``.
+
+    Mirrors the live-Mac smoke test against httpbin/headers — the upstream
+    sees the real key, the cage sees the placeholder."""
+    addon_mod, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_response_flow(
+        host="httpbin.org",
+        # Shape mimics httpbin /headers JSON output.
+        body='{"headers": {"X-Echo": "redact-test-xyz"}}',
+    )
+
+    addon.response(flow)
+
+    # Body has the placeholder, not the real value.
+    assert "redact-test-xyz" not in flow.response.content.decode()
+    assert "{{AGENTCAGE_REDACT_SECRET}}" in flow.response.content.decode()
+
+    # Audit log records the redaction.
+    audit_lines = (tmp_path / "audit.jsonl").read_text().splitlines()
+    inbound = [json.loads(l) for l in audit_lines
+               if json.loads(l).get("direction") == "inbound"]
+    assert len(inbound) == 1
+    assert inbound[0]["secrets_redacted"] == ["AGENTCAGE_REDACT_SECRET"]
+    assert inbound[0]["host"] == "httpbin.org"
+    assert inbound[0]["reason"] == "secret-redaction"
+
+
+def test_response_redaction_in_response_headers(tmp_path, monkeypatch):
+    """Headers (not just body) get redacted. Some upstreams echo bearer
+    tokens into custom response headers; the cage must never see them."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_response_flow(
+        host="httpbin.org",
+        body="ok",
+        resp_headers={"X-Reflected-Auth": "Bearer redact-test-xyz"},
+    )
+
+    addon.response(flow)
+
+    assert flow.response.headers["X-Reflected-Auth"] == (
+        "Bearer {{AGENTCAGE_REDACT_SECRET}}"
+    )
+
+
+def test_response_redaction_scoped_to_inject_to_host(tmp_path, monkeypatch):
+    """Defense-in-depth: a response from a host NOT in ``inject_to`` is
+    NOT redacted even when its body coincidentally contains the secret
+    value as a substring. Otherwise unrelated allowlisted upstreams could
+    have legitimate text mangled (e.g. a UUID that happened to match)."""
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        inject_to=("httpbin.org",),
+        allowlist=("httpbin.org", "example.com"),
+    )
+    flow = _make_response_flow(
+        host="example.com",  # allowlisted but not in inject_to
+        body="here is a coincidence: redact-test-xyz appears in this body",
+    )
+
+    addon.response(flow)
+
+    # Real value still present — scope guard worked.
+    assert "redact-test-xyz" in flow.response.content.decode()
+    assert "{{AGENTCAGE_REDACT_SECRET}}" not in flow.response.content.decode()
+
+    # No inbound audit entry emitted (nothing was redacted).
+    audit_path = tmp_path / "audit.jsonl"
+    if audit_path.exists():
+        for line in audit_path.read_text().splitlines():
+            assert json.loads(line).get("direction") != "inbound"
+
+
+def test_response_redaction_skips_binary_body(tmp_path, monkeypatch):
+    """Binary responses (images, archives) pass through unchanged — the
+    addon catches ``UnicodeDecodeError`` from ``get_text(strict=False)``
+    and never touches the body bytes. Headers are still scanned."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    binary = bytes([0xff, 0xd8, 0xff]) + b"redact-test-xyz" + bytes([0x00, 0xfe])
+    flow = _make_response_flow(
+        host="httpbin.org",
+        body=binary,
+        resp_headers={"X-Trace": "echo redact-test-xyz back"},
+    )
+
+    addon.response(flow)
+
+    # Body untouched.
+    assert flow.response.content == binary
+    # Header still got redacted.
+    assert flow.response.headers["X-Trace"] == "echo {{AGENTCAGE_REDACT_SECRET}} back"


### PR DESCRIPTION
## Summary

- Mirror of #151's outbound injection on the inbound side: when an upstream echoes a `{{SECRET}}` rule's raw value back (in a response header or text body), the mitmproxy addon now rewrites it back to the placeholder before the cage sees it.
- Same host-scope semantics as `_maybe_inject` (only rules whose `inject_to` matches the response's request host redact), binary bodies pass through untouched, and each redaction emits a `direction: "inbound"` audit entry with the env names redacted.

This is the response-side half of #151 — closes the loop on the gap called out in `docs/apple-container.md`.

## Test plan

- [x] 4 new unit tests in `tests/test_apple_container.py` cover happy-path body redaction, header redaction, the inject_to scope guard, and binary-body pass-through. Full suite: 1449 passed.
- [x] End-to-end on macOS 26 + Apple Silicon. New cage `ubuntu-redact` with one rule `AGENTCAGE_REDACT_SECRET -> {{AGENTCAGE_REDACT_SECRET}}` scoped to `httpbin.org`:

```
$ AGENTCAGE_REDACT_SECRET=redact-test-xyz agentcage cage create -c cage.yaml
$ agentcage cage exec ubuntu-redact -- curl -fsS -H 'X-Echo: {{AGENTCAGE_REDACT_SECRET}}' https://httpbin.org/headers
{
  "headers": {
    "Accept": "*/*",
    "Host": "httpbin.org",
    "User-Agent": "curl/8.5.0",
    "X-Amzn-Trace-Id": "Root=1-6a147a7a-7226214970dfe6db0c5838b4",
    "X-Echo": "{{AGENTCAGE_REDACT_SECRET}}"
  }
}
```

  httpbin reflects exactly what it received in the request headers — so the response body proves both directions worked: mitmproxy substituted `redact-test-xyz` going OUT (httpbin saw the real bytes) AND redacted back to `{{AGENTCAGE_REDACT_SECRET}}` coming IN. The cage never sees the raw value.

- [x] Audit log confirms both halves:

```
{..."direction": "outbound", ..., "secrets_injected": ["AGENTCAGE_REDACT_SECRET"], "secrets_redacted": [], "decision": "allowed", "reason": "domain-allowlist"}
{..."direction": "inbound",  ..., "secrets_injected": [], "secrets_redacted": ["AGENTCAGE_REDACT_SECRET"], "decision": "allowed", "reason": "secret-redaction", "status": 200}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)