### PR TITLE
feat(apple-container): run secret_injection.transform end-to-end

### DIFF
--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -174,26 +174,30 @@ and dnsmasq run inside the same microVM)
 
 **Proper fix path (deferred).** Would need a routing layer in the supervisor that listens on a control socket and proxies exec requests to the right component's namespace. Architectural, not a small patch.
 
-### `secret_injection.transform` accepted but not applied
+### `secret_injection.transform` — wired (was a gap pre-0.21.x)
 
-**Symptom.** Setting `transform: google-jwt-bearer` (or any other transform) on a `secret_injection` rule passes `validate_config` but the proxy substitutes the literal env-var value, not the transform output. `validate_config` emits a warning:
+**Status.** Fixed. `transform: google-jwt-bearer` (and any future entry in `KNOWN_TRANSFORMS`) now runs end-to-end on apple-container: the in-cage mitmproxy addon loads the same `data/proxy/transforms` registry the container backend uses, mints a derived value at request time (e.g. a short-lived OAuth bearer from a service-account JWT), and substitutes that — not the raw env-passed credential — into the outbound request. The "silently has no effect on apple-container" warning no longer fires for known transforms.
 
+**Fail-closed contract.** If the transform fails to initialize (bad SA key) or to mint at request time (Google rejects the assertion, network error, rate limit), the addon leaves the placeholder in place and logs the failure. The upstream sees `Bearer {{TOKEN}}` literally and 401s — the raw credential never leaks as a fallback.
+
+**Audit.** The per-request audit entry includes `"secret_transforms": {"<env>": "<transform_name>"}` whenever a transform ran, so the operator can distinguish raw-env substitution from derived-value substitution in `cage audit`.
+
+**Example.**
+
+```yaml
+# cage.yaml
+secret_injection:
+  - env: GCP_SA_KEY            # SA JSON, full key — never leaves the proxy
+    placeholder: "{{GCP_BEARER}}"
+    transform: google-jwt-bearer
+    transform_config:
+      scopes:
+        - https://www.googleapis.com/auth/calendar.readonly
+    inject_to:
+      - www.googleapis.com
 ```
-warning: secret_injection['MY_SA_JWT'].transform ='google-jwt-bearer':
-silently has no effect on apple-container (server-side
-{{SECRET:...}} placeholder substitution is not wired yet — the
-cage sees the raw env-passed value). See issue #120.
-```
 
-**Why.** Transforms are part of the container backend's `SecretInjector`. The apple-container addon does direct string substitution only.
-
-**Workaround.** Pre-compute the transformed value host-side and pass it as the env var:
-
-```bash
-# Instead of relying on transform: google-jwt-bearer:
-export GOOGLE_BEARER_TOKEN=$(gcloud auth print-access-token)
-agentcage cage start mycage  # the cage sees GOOGLE_BEARER_TOKEN directly
-```
+Cage agent sends `Authorization: Bearer {{GCP_BEARER}}`; the proxy substitutes a freshly minted (cached until expiry) `ya29.<...>` access token.
 
 ### `cage backup --include-secrets` rejected
 

--- a/src/agentcage/apple_container/wrapper.py
+++ b/src/agentcage/apple_container/wrapper.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import tarfile
 from pathlib import Path
 from typing import Iterable
 
@@ -20,6 +21,13 @@ from agentcage.apple_container import cli as ac_cli
 
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "apple-container"
+# Secret-injection transforms (e.g. google-jwt-bearer) live in the shared
+# proxy data dir alongside the container-backend addon. We stage them into
+# the apple-container build context so the in-cage mitmproxy addon can
+# ``import transforms`` exactly like the container backend's addon does.
+_TRANSFORMS_SRC = (
+    Path(__file__).resolve().parent.parent / "data" / "proxy" / "transforms"
+)
 
 
 def _user_cmd(user_image: str) -> list[str]:
@@ -98,16 +106,46 @@ def stage_build_context(
       - allowlist_addon.py    -- mitmproxy addon (allowlist + audit + injection)
       - cage-cmd.json         -- user image's original ENTRYPOINT+CMD
       - allowlist.txt         -- one host per line
-      - secret_injection.json -- list of {env, placeholder, inject_to} rules
-                                 read by the mitmproxy addon at startup;
-                                 actual secret values are env-passed at
-                                 container run time so the build context
-                                 stays free of secrets.
+      - secret_injection.json -- list of
+                                 ``{env, placeholder, inject_to, transform,
+                                 transform_config}`` rules read by the
+                                 mitmproxy addon at startup; actual secret
+                                 values are env-passed at container run
+                                 time so the build context stays free of
+                                 secrets.
+      - transforms.tar.gz     -- tarball of ``data/proxy/transforms`` so the
+                                 in-cage addon can import the same transform
+                                 implementations (google-jwt-bearer, ...)
+                                 the container backend uses. Rules with no
+                                 ``transform`` field never load this code.
+
+    NOTE on the tarball: Apple's ``container build`` (0.5+) silently
+    drops the contents when a Containerfile does ``COPY <dir> <dst>``
+    — the destination directory exists but is empty. ADD'ing a
+    ``.tar.gz`` works because the underlying buildkit path
+    auto-extracts archives. We use the OCI image's ADD-extract
+    semantics deliberately to dodge the directory-copy bug; if Apple
+    ever fixes plain dir COPY we can simplify here.
     """
     dest.mkdir(parents=True, exist_ok=True)
     shutil.copy2(_DATA_DIR / "supervisor.sh", dest / "supervisor.sh")
     shutil.copy2(_DATA_DIR / "dnsmasq.conf", dest / "dnsmasq.conf")
     shutil.copy2(_DATA_DIR / "allowlist_addon.py", dest / "allowlist_addon.py")
+    # Pack the transforms package into a deterministic tarball so each
+    # rebuild with unchanged source produces a bit-identical artifact
+    # (helps Apple's container layer cache; would also help reproducible
+    # builds if/when we cross-check image digests in CI). Tarball is
+    # small (a few KB) so the .gz / non-.gz choice doesn't matter.
+    transforms_archive = dest / "transforms.tar.gz"
+    with tarfile.open(transforms_archive, "w:gz") as tar:
+        for entry in sorted(_TRANSFORMS_SRC.iterdir()):
+            # Skip Python bytecode caches — they're host-local and would
+            # bloat the layer for zero functional benefit.
+            if entry.name == "__pycache__":
+                continue
+            # arcname is relative to the archive root so ADD extracts
+            # straight into /opt/agentcage/transforms/<file>.
+            tar.add(entry, arcname=entry.name)
     (dest / "cage-cmd.json").write_text(json.dumps(user_cmd))
     allow_lines = "\n".join(h.strip() for h in (allowlist or []) if h.strip())
     (dest / "allowlist.txt").write_text(allow_lines + ("\n" if allow_lines else ""))

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -243,15 +243,20 @@ class AppleContainerBackend:
         # "block all egress" (safer default than "allow all").
         allowlist = list(config.domains.allow or [])
         # Secret-injection rules — only the metadata (env name, placeholder,
-        # inject_to allow-list of domains) is baked into the image. The
-        # actual secret VALUES are env-passed at `container run` time
-        # (see `start()` below) so the build context — which ends up in
-        # the image layer — stays free of secrets.
+        # inject_to allow-list of domains, transform name + its config) is
+        # baked into the image. The actual secret VALUES are env-passed at
+        # `container run` time (see `start()` below) so the build context —
+        # which ends up in the image layer — stays free of secrets. The
+        # ``transform`` field tells the in-cage addon to derive a value
+        # (e.g. mint a Google OAuth bearer from a service-account JWT)
+        # instead of substituting the raw env value verbatim.
         secret_rules = [
             {
                 "env": r.env,
                 "placeholder": r.placeholder,
                 "inject_to": list(r.inject_to or []),
+                "transform": r.transform or "",
+                "transform_config": dict(r.transform_config or {}),
             }
             for r in (config.secret_injection or [])
         ]

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -963,14 +963,23 @@ def validate_config(config: Config) -> list[str]:
                     f"{field_path}: silently has no effect on apple-container "
                     f"({summary}). See issue #120 for the parity plan."
                 )
+        # secret_injection.transform now runs end-to-end on apple-container
+        # — the in-cage mitmproxy addon loads the same data/proxy/transforms
+        # registry the container backend uses. KNOWN_TRANSFORMS is the
+        # source of truth for "what the addon can dispatch". Anything
+        # outside that set is rejected at parse time by validate_transform,
+        # so reaching this loop with an unknown transform is impossible.
+        # We keep the loop as a hard assert so a future divergence between
+        # the schema (KNOWN_TRANSFORMS) and the in-cage registry surfaces
+        # as a config-time warning instead of a silent runtime drop.
         for rule in config.secret_injection:
-            if getattr(rule, "transform", ""):
+            transform = getattr(rule, "transform", "") or ""
+            if transform and transform not in KNOWN_TRANSFORMS:
                 warnings.append(
                     f"secret_injection[{rule.env!r}].transform "
-                    f"={rule.transform!r}: silently has no effect on "
-                    f"apple-container (server-side {{{{SECRET:...}}}} placeholder "
-                    f"substitution is not wired yet — the cage sees the raw "
-                    f"env-passed value). See issue #120."
+                    f"={transform!r}: not in KNOWN_TRANSFORMS — the "
+                    f"apple-container addon will skip the rule at "
+                    f"startup. See issue #120."
                 )
 
     # Warn when a tcp.passthrough port isn't explicitly listed in

--- a/src/agentcage/data/apple-container/Containerfile.wrapper.j2
+++ b/src/agentcage/data/apple-container/Containerfile.wrapper.j2
@@ -89,6 +89,16 @@ RUN getent passwd 200 >/dev/null && { echo "uid 200 already taken" >&2; exit 79;
 # AppleContainerBackend.build_artifacts().
 COPY supervisor.sh /opt/agentcage/supervisor
 COPY allowlist_addon.py /opt/agentcage/allowlist_addon.py
+# Transforms live next to the addon so mitmproxy's script loader puts the
+# script's dir on sys.path and `from transforms import get` resolves. Same
+# shape as src/agentcage/data/proxy/ on the container backend.
+#
+# We ADD a tar.gz (auto-extracted) rather than COPY the directory because
+# Apple's `container build` 0.5+ silently drops the contents of a COPY'd
+# directory — the target dir exists but is empty. Confirmed on macOS 26
+# with `container --version` 0.5.x; tracked alongside #120 follow-ups.
+RUN mkdir -p /opt/agentcage/transforms
+ADD transforms.tar.gz /opt/agentcage/transforms/
 COPY cage-cmd.json /etc/agentcage/cage-cmd.json
 COPY allowlist.txt /etc/agentcage/allowlist.txt
 COPY dnsmasq.conf /etc/agentcage/dnsmasq.conf

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -72,9 +72,14 @@ def _host_allowed(host: str, allowed: set[str]) -> bool:
 def _load_secret_injection_rules() -> list[dict]:
     """Load the cage's secret_injection rule list, baked in at build time.
 
-    Each rule is ``{"env": str, "placeholder": str, "inject_to": [str]}``.
-    The actual secret VALUE is read from ``os.environ[env]`` at request
-    time (forwarded by ``AppleContainerBackend.start()`` via ``-e``).
+    Each rule is ``{"env": str, "placeholder": str, "inject_to": [str],
+    "transform": str, "transform_config": dict}``. The actual secret VALUE
+    is read from ``os.environ[env]`` at request time (forwarded by
+    ``AppleContainerBackend.start()`` via ``-e``). ``transform`` is
+    optional — when set the addon looks the name up in the bundled
+    ``transforms`` package and calls ``cls(value, transform_config).
+    get_value()`` to mint a derived substitution value (e.g. a fresh
+    Google OAuth bearer) instead of using the raw env value verbatim.
     """
     try:
         with open(SECRET_INJECTION_PATH) as f:
@@ -82,6 +87,23 @@ def _load_secret_injection_rules() -> list[dict]:
             return data if isinstance(data, list) else []
     except (OSError, ValueError):
         return []
+
+
+def _build_transform_fn(name: str, secret: str, config: dict):
+    """Look up *name* in the bundled transforms registry and bind it.
+
+    Returns a zero-arg callable that yields the substitution value at
+    request time (the transform may cache internally). Raises if the
+    name is unknown or the transform fails to initialize — the caller
+    drops the rule and logs.
+    """
+    # Lazy import so a rule list with no transforms doesn't pay the
+    # cryptography import cost at addon load.
+    from transforms import get as _get
+
+    cls = _get(name)
+    instance = cls(secret, config)
+    return instance.get_value
 
 
 class AllowlistAddon:
@@ -95,21 +117,50 @@ class AllowlistAddon:
         # later os.environ changes won't propagate. Skip rules whose
         # env var isn't set (the backend logs a warning at start, and
         # the placeholder simply doesn't get substituted).
+        #
+        # Rules with a non-empty ``transform`` go through the bundled
+        # transforms registry (data/proxy/transforms, staged into
+        # /opt/agentcage/transforms by stage_build_context). The
+        # ``transform_fn`` callable replaces ``value`` at substitution
+        # time so the raw env-passed credential never lands on the wire
+        # — same contract as the container backend's SecretInjector.
         self._resolved_secrets: list[dict] = []
         for rule in self.injection_rules:
-            value = os.environ.get(rule.get("env", ""))
+            env_name = rule.get("env", "")
+            value = os.environ.get(env_name)
             if not value:
                 continue
+            transform_name = rule.get("transform", "") or ""
+            transform_fn = None
+            if transform_name:
+                transform_config = rule.get("transform_config") or {}
+                try:
+                    transform_fn = _build_transform_fn(
+                        transform_name, value, transform_config
+                    )
+                except Exception as exc:
+                    ctx.log.warn(
+                        f"[agentcage] secret_injection transform "
+                        f"{transform_name!r} for {env_name!r} failed to "
+                        f"initialize: {exc} — skipping rule"
+                    )
+                    continue
             self._resolved_secrets.append({
-                "env": rule["env"],
+                "env": env_name,
                 "placeholder": rule["placeholder"],
                 "value": value,
                 "inject_to": [d.lower() for d in (rule.get("inject_to") or [])],
+                "transform": transform_name,
+                "transform_fn": transform_fn,
             })
         if self._resolved_secrets:
             ctx.log.info(
                 f"[agentcage] secret injection: "
-                f"{[r['env'] for r in self._resolved_secrets]}"
+                + ", ".join(
+                    f"{r['env']}"
+                    + (f"({r['transform']})" if r["transform"] else "")
+                    for r in self._resolved_secrets
+                )
             )
         self._audit_fh = self._open_log(AUDIT_LOG_PATH)
         self._capture_fh = self._open_log(CAPTURE_PATH)
@@ -128,19 +179,47 @@ class AllowlistAddon:
             return True
         return any(host == d or host.endswith("." + d) for d in inject_to)
 
-    def _maybe_inject(self, flow: http.HTTPFlow) -> list[str]:
+    def _maybe_inject(
+        self, flow: http.HTTPFlow
+    ) -> tuple[list[str], dict[str, str]]:
         """Substitute placeholders in request headers/body for matching hosts.
 
-        Returns the list of env names that had at least one substitution
-        performed; the audit entry surfaces this as `secrets_injected`.
+        Returns ``(injected_envs, transforms_by_env)``:
+          * ``injected_envs`` — env names that had at least one
+            substitution performed (audit ``secrets_injected``)
+          * ``transforms_by_env`` — mapping ``env → transform_name`` for
+            the subset of those rules that ran through a transform (e.g.
+            ``{"GCP_SA_KEY": "google-jwt-bearer"}``); audit
+            ``secret_transforms``
+
+        When a rule has a transform configured, the transform's
+        ``get_value()`` is called per request — the transform itself is
+        responsible for caching (google-jwt-bearer caches the minted
+        access token until expiry). If the transform raises, the rule is
+        skipped and the placeholder is left in place so the upstream
+        request fails closed instead of leaking the raw credential.
         """
         host = flow.request.pretty_host.lower()
         injected: list[str] = []
+        transforms: dict[str, str] = {}
         for rule in self._resolved_secrets:
             if not self._host_matches_inject_to(host, rule["inject_to"]):
                 continue
             placeholder = rule["placeholder"]
-            value = rule["value"]
+            transform_fn = rule.get("transform_fn")
+            if transform_fn is not None:
+                try:
+                    value = transform_fn()
+                except Exception as exc:
+                    ctx.log.warn(
+                        f"[agentcage] secret_injection transform "
+                        f"{rule['transform']!r} for {rule['env']!r} "
+                        f"failed at request time: {exc} — leaving "
+                        f"placeholder in place"
+                    )
+                    continue
+            else:
+                value = rule["value"]
             replaced_any = False
             # Headers
             for name, val in list(flow.request.headers.items()):
@@ -159,7 +238,9 @@ class AllowlistAddon:
                 replaced_any = True
             if replaced_any:
                 injected.append(rule["env"])
-        return injected
+                if rule["transform"]:
+                    transforms[rule["env"]] = rule["transform"]
+        return injected, transforms
 
     def _maybe_redact(self, flow: http.HTTPFlow) -> list[str]:
         """Replace real secret values with placeholders on inbound responses.
@@ -270,10 +351,17 @@ class AllowlistAddon:
             # Apply secret injection BEFORE the upstream request goes out.
             # Substitutions happen in place; we record the env names in
             # the audit entry so the operator can see what was swapped.
-            injected = self._maybe_inject(flow)
+            # `secret_transforms` is a sibling field (mapping env →
+            # transform name) — present only when at least one rule ran
+            # through a transform like google-jwt-bearer, so the operator
+            # can distinguish raw-env substitution from derived-value
+            # substitution at audit time.
+            injected, transforms = self._maybe_inject(flow)
             entry["decision"] = "allowed"
             entry["reason"] = "domain-allowlist"
             entry["secrets_injected"] = injected
+            if transforms:
+                entry["secret_transforms"] = transforms
             self._audit(entry)
             return
 

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -264,6 +264,374 @@ def test_stage_build_context_empty_secret_injection(tmp_path):
     assert json.loads((tmp_path / "secret_injection.json").read_text()) == []
 
 
+def test_stage_build_context_writes_transform_field(tmp_path):
+    """Rules with a ``transform`` field flow through the build context.
+
+    The in-cage addon dispatches on this string at startup to mint a
+    derived substitution value (e.g. a Google OAuth bearer) instead of
+    using the raw env-passed credential. ``transform_config`` rides
+    along so transforms like google-jwt-bearer can configure their
+    scopes/audience without leaking the SA key into the image layer.
+    """
+    rules = [
+        {
+            "env": "GCP_SA_KEY",
+            "placeholder": "{{GCP_BEARER}}",
+            "inject_to": ["googleapis.com"],
+            "transform": "google-jwt-bearer",
+            "transform_config": {
+                "scopes": ["https://www.googleapis.com/auth/calendar.readonly"],
+            },
+        },
+    ]
+    ac_wrapper.stage_build_context(
+        tmp_path, ["sh"], allowlist=["googleapis.com"],
+        secret_injection_rules=rules,
+    )
+    si = json.loads((tmp_path / "secret_injection.json").read_text())
+    assert si == rules
+    # The transforms package must be staged as a tarball so the in-cage
+    # addon can ``import transforms`` after ADD-extraction. (Plain COPY
+    # of a directory silently empties the target on Apple's container
+    # build 0.5+; the tarball ADD path dodges that quirk.)
+    archive = tmp_path / "transforms.tar.gz"
+    assert archive.exists()
+    import tarfile as _tf
+    with _tf.open(archive) as tar:
+        names = sorted(tar.getnames())
+    assert "__init__.py" in names
+    assert "google_jwt_bearer.py" in names
+
+
+def test_stage_build_context_stages_transforms_even_without_rules(tmp_path):
+    """The transforms tarball is unconditionally staged — cheap, and
+    avoids a class of "transform added in cage.yaml after image build →
+    silent skip" bugs. The addon will still no-op on an empty rule list."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    assert (tmp_path / "transforms.tar.gz").exists()
+
+
+def test_stage_build_context_excludes_pycache_from_transforms(tmp_path, monkeypatch):
+    """__pycache__ is host-local Python bytecode — packing it into the
+    image layer wastes space and ruins layer determinism. The tarball
+    must filter it out."""
+    # Create a fake transforms src with a __pycache__ subdir so we can
+    # observe the filter without touching the real package on disk.
+    fake_src = tmp_path / "fake_src"
+    fake_src.mkdir()
+    (fake_src / "__init__.py").write_text("# real")
+    (fake_src / "google_jwt_bearer.py").write_text("# real")
+    (fake_src / "__pycache__").mkdir()
+    (fake_src / "__pycache__" / "garbage.pyc").write_bytes(b"\x00\x00\x00")
+
+    monkeypatch.setattr(ac_wrapper, "_TRANSFORMS_SRC", fake_src)
+
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+
+    import tarfile as _tf
+    with _tf.open(tmp_path / "transforms.tar.gz") as tar:
+        names = tar.getnames()
+    assert not any("__pycache__" in n for n in names), names
+
+
+def test_wrapper_containerfile_adds_transforms_tarball():
+    """The Containerfile must ADD the transforms tarball (auto-extracted
+    by OCI build) so ``from transforms import get`` resolves at runtime.
+    We deliberately don't `COPY transforms /opt/agentcage/transforms`
+    because Apple's container build silently drops the contents of a
+    directory COPY — the target dir exists but is empty."""
+    out = ac_wrapper.render_wrapper_containerfile(
+        "docker.io/library/alpine:3.20",
+        user_cmd=["sh", "-c", "echo hi"],
+    )
+    assert "ADD transforms.tar.gz /opt/agentcage/transforms/" in out
+    # And we must NOT regress to the broken directory-COPY form.
+    assert "COPY transforms /opt/agentcage/transforms" not in out
+
+
+def test_backend_threads_transform_into_build_artifacts(tmp_path, monkeypatch):
+    """The apple-container backend must forward ``transform`` and
+    ``transform_config`` from the parsed Config through to wrapper.
+    Catches the silent-drop regression: rule loaded fine, image built
+    fine, but the cage saw only ``env/placeholder/inject_to``."""
+    captured: dict = {}
+
+    def fake_build_wrapper(_name, _image, **kwargs):
+        captured["secret_injection_rules"] = kwargs.get("secret_injection_rules")
+        return "localhost/agentcage-apple-test:latest"
+
+    # Patch the wrapper as imported by the backend module — it does
+    # ``from agentcage.apple_container import wrapper as ac_wrapper`` so
+    # the backend's own binding is what we need to override.
+    from agentcage.backends import apple_container as backend_mod
+    monkeypatch.setattr(backend_mod.ac_wrapper, "build_wrapper", fake_build_wrapper)
+    monkeypatch.setattr(
+        ac_cli, "image_inspect",
+        lambda _img: {"config": {"cmd": ["/bin/sh"]}},
+    )
+    # `build_artifacts` shells out to `container image pull`; fake it.
+    monkeypatch.setattr(
+        ac_cli, "run",
+        lambda *_a, **_kw: type(
+            "CP", (), {"returncode": 0, "stdout": "", "stderr": ""},
+        )(),
+    )
+
+    from agentcage.config import SecretInjectionRule
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/test:latest"
+    # Set a command so _user_cmd isn't consulted.
+    cfg.container.command = ["/bin/sh"]
+    cfg.secret_injection = [
+        SecretInjectionRule(
+            env="GCP_SA_KEY",
+            placeholder="{{GCP_BEARER}}",
+            inject_to=["googleapis.com"],
+            transform="google-jwt-bearer",
+            transform_config={"scopes": ["a"]},
+        ),
+    ]
+    cfg.domains.allow = ["googleapis.com"]
+
+    AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
+
+    rules = captured["secret_injection_rules"]
+    assert len(rules) == 1
+    assert rules[0]["transform"] == "google-jwt-bearer"
+    assert rules[0]["transform_config"] == {"scopes": ["a"]}
+
+
+def test_allowlist_addon_runs_transform_at_request_time(monkeypatch, tmp_path):
+    """End-to-end addon test: a rule with ``transform`` set must inject
+    the transform's return value into the outbound request — NOT the
+    raw env-passed credential. This is the load-bearing assertion for
+    the whole feature.
+
+    Uses a fake transform registered in-process so we don't need
+    cryptography or network access.
+    """
+    # Write a rule list with a transform; point the addon at it.
+    rules = [{
+        "env": "SECRET_INPUT",
+        "placeholder": "{{TOKEN}}",
+        "inject_to": ["api.example.com"],
+        "transform": "_test_marker",
+        "transform_config": {"marker": "transformed-output-marker"},
+    }]
+    rule_file = tmp_path / "secret_injection.json"
+    rule_file.write_text(json.dumps(rules))
+    (tmp_path / "allowlist.txt").write_text("api.example.com\n")
+
+    # Set the raw env input that the cage agent would normally send;
+    # the test asserts the upstream sees the TRANSFORMED value instead.
+    monkeypatch.setenv("SECRET_INPUT", "raw-input-value")
+    monkeypatch.setenv("AGENTCAGE_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("AGENTCAGE_CAPTURE", str(tmp_path / "capture.jsonl"))
+
+    # Import the addon AFTER setting the env so module-level path constants
+    # resolve to tmp_path. The addon is read from data/apple-container/.
+    import importlib
+    import sys
+    addon_dir = (
+        # tests/  -> repo root -> src/agentcage/data/apple-container/
+        __import__("pathlib").Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "data" / "apple-container"
+    )
+    transforms_src = (
+        addon_dir.parent / "proxy" / "transforms"
+    )
+    monkeypatch.syspath_prepend(str(addon_dir))
+    monkeypatch.syspath_prepend(str(transforms_src.parent))
+
+    # Register a no-op transform that returns the configured marker so
+    # we don't need cryptography / network. This is the SAME registry the
+    # addon uses; the registration must happen before AllowlistAddon's
+    # __init__ runs (which is where transforms are bound).
+    import transforms as _t  # noqa: WPS433  (test-only)
+    importlib.reload(_t)
+
+    class _MarkerTransform:
+        def __init__(self, secret: str, config: dict) -> None:
+            self._marker = config["marker"]
+            self._secret = secret
+
+        def get_value(self) -> str:
+            return self._marker
+
+    _t.register("_test_marker", _MarkerTransform)
+
+    # Point the addon's module-level paths at our tmp files BEFORE import.
+    sys.modules.pop("allowlist_addon", None)
+    allowlist_addon = importlib.import_module("allowlist_addon")
+    allowlist_addon.SECRET_INJECTION_PATH = str(rule_file)
+    allowlist_addon.ALLOWLIST_PATH = str(tmp_path / "allowlist.txt")
+
+    addon = allowlist_addon.AllowlistAddon()
+
+    # Sanity: rule was resolved AND a transform_fn was bound.
+    assert len(addon._resolved_secrets) == 1
+    resolved = addon._resolved_secrets[0]
+    assert resolved["transform"] == "_test_marker"
+    assert resolved["transform_fn"] is not None
+    # The raw env value is still cached on the resolved rule (so the
+    # original injection path stays available for non-transform rules)
+    # — but it MUST NOT be the value sent on the wire.
+    assert resolved["value"] == "raw-input-value"
+
+    # Build a fake flow with the placeholder in the Authorization header.
+    fake_flow = MagicMock()
+    fake_flow.request.pretty_host = "api.example.com"
+    fake_flow.request.headers = {"Authorization": "Bearer {{TOKEN}}"}
+
+    # `headers` needs the in-place mutation pattern the real addon uses.
+    class _Headers(dict):
+        def items(self):
+            return list(super().items())
+
+    fake_flow.request.headers = _Headers(
+        {"Authorization": "Bearer {{TOKEN}}"}
+    )
+    fake_flow.request.get_text = lambda strict=False: ""
+    fake_flow.request.set_text = lambda _t: None
+
+    injected, transforms_map = addon._maybe_inject(fake_flow)
+
+    # The transform's marker — NOT the raw env value — landed in the header.
+    assert (
+        fake_flow.request.headers["Authorization"]
+        == "Bearer transformed-output-marker"
+    )
+    assert "raw-input-value" not in fake_flow.request.headers["Authorization"]
+    assert injected == ["SECRET_INPUT"]
+    assert transforms_map == {"SECRET_INPUT": "_test_marker"}
+
+
+def test_allowlist_addon_skips_rule_on_transform_init_failure(
+    monkeypatch, tmp_path,
+):
+    """A transform that raises during ``__init__`` must drop the rule at
+    startup (with a warning) — NOT crash the whole addon and NOT fall
+    back to substituting the raw env-passed credential. Failing closed
+    is the safety-critical contract."""
+    rules = [{
+        "env": "SECRET_INPUT",
+        "placeholder": "{{TOKEN}}",
+        "inject_to": ["api.example.com"],
+        "transform": "_test_broken_init",
+        "transform_config": {},
+    }]
+    rule_file = tmp_path / "secret_injection.json"
+    rule_file.write_text(json.dumps(rules))
+    (tmp_path / "allowlist.txt").write_text("api.example.com\n")
+    monkeypatch.setenv("SECRET_INPUT", "raw-input-value")
+    monkeypatch.setenv("AGENTCAGE_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("AGENTCAGE_CAPTURE", str(tmp_path / "capture.jsonl"))
+
+    import importlib
+    import sys
+    addon_dir = (
+        __import__("pathlib").Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "data" / "apple-container"
+    )
+    transforms_src = addon_dir.parent / "proxy" / "transforms"
+    monkeypatch.syspath_prepend(str(addon_dir))
+    monkeypatch.syspath_prepend(str(transforms_src.parent))
+
+    import transforms as _t
+    importlib.reload(_t)
+
+    class _BrokenInit:
+        def __init__(self, *_a, **_kw):
+            raise RuntimeError("intentional test failure")
+
+        def get_value(self) -> str:  # pragma: no cover
+            return "unreachable"
+
+    _t.register("_test_broken_init", _BrokenInit)
+
+    sys.modules.pop("allowlist_addon", None)
+    allowlist_addon = importlib.import_module("allowlist_addon")
+    allowlist_addon.SECRET_INJECTION_PATH = str(rule_file)
+    allowlist_addon.ALLOWLIST_PATH = str(tmp_path / "allowlist.txt")
+    addon = allowlist_addon.AllowlistAddon()
+
+    # Rule dropped, NOT substituted with raw value.
+    assert addon._resolved_secrets == []
+
+
+def test_allowlist_addon_skips_request_on_transform_runtime_failure(
+    monkeypatch, tmp_path,
+):
+    """If the transform raises at substitution time, the placeholder is
+    left in place — the upstream request fails closed with an auth error
+    rather than smuggling the raw credential through. No fallback to the
+    raw env value (which is the point of having a transform in the first
+    place)."""
+    rules = [{
+        "env": "SECRET_INPUT",
+        "placeholder": "{{TOKEN}}",
+        "inject_to": ["api.example.com"],
+        "transform": "_test_runtime_fail",
+        "transform_config": {},
+    }]
+    rule_file = tmp_path / "secret_injection.json"
+    rule_file.write_text(json.dumps(rules))
+    (tmp_path / "allowlist.txt").write_text("api.example.com\n")
+    monkeypatch.setenv("SECRET_INPUT", "raw-input-value")
+    monkeypatch.setenv("AGENTCAGE_AUDIT_LOG", str(tmp_path / "audit.jsonl"))
+    monkeypatch.setenv("AGENTCAGE_CAPTURE", str(tmp_path / "capture.jsonl"))
+
+    import importlib
+    import sys
+    addon_dir = (
+        __import__("pathlib").Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "data" / "apple-container"
+    )
+    transforms_src = addon_dir.parent / "proxy" / "transforms"
+    monkeypatch.syspath_prepend(str(addon_dir))
+    monkeypatch.syspath_prepend(str(transforms_src.parent))
+
+    import transforms as _t
+    importlib.reload(_t)
+
+    class _RuntimeFail:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        def get_value(self) -> str:
+            raise RuntimeError("mint failed")
+
+    _t.register("_test_runtime_fail", _RuntimeFail)
+
+    sys.modules.pop("allowlist_addon", None)
+    allowlist_addon = importlib.import_module("allowlist_addon")
+    allowlist_addon.SECRET_INJECTION_PATH = str(rule_file)
+    allowlist_addon.ALLOWLIST_PATH = str(tmp_path / "allowlist.txt")
+    addon = allowlist_addon.AllowlistAddon()
+
+    class _Headers(dict):
+        def items(self):
+            return list(super().items())
+
+    fake_flow = MagicMock()
+    fake_flow.request.pretty_host = "api.example.com"
+    fake_flow.request.headers = _Headers(
+        {"Authorization": "Bearer {{TOKEN}}"}
+    )
+    fake_flow.request.get_text = lambda strict=False: ""
+    fake_flow.request.set_text = lambda _t: None
+
+    injected, transforms_map = addon._maybe_inject(fake_flow)
+
+    # Header UNCHANGED — placeholder stays, raw value never leaks.
+    assert (
+        fake_flow.request.headers["Authorization"] == "Bearer {{TOKEN}}"
+    )
+    assert "raw-input-value" not in fake_flow.request.headers["Authorization"]
+    assert injected == []
+    assert transforms_map == {}
+
+
 def test_generate_units_persists_autostart_flag():
     """`apple_container_autostart: true` in cage.yaml flows into the unit
     JSON's `autostart` field. `start()` reads this to decide whether to

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1866,7 +1866,11 @@ class TestAppleContainerSilentDrops:
             "container.security_label_disable" in w for w in warnings
         ), warnings
 
-    def test_secret_injection_transform_warns(self, tmp_path):
+    def test_secret_injection_known_transform_no_longer_warns(self, tmp_path):
+        """Once the in-cage addon learned to dispatch on `transform`, the
+        old "silently has no effect on apple-container" warning had to
+        stop firing for known transforms — otherwise users get gaslit
+        about a working feature."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -1877,12 +1881,17 @@ class TestAppleContainerSilentDrops:
               - env: API_KEY
                 placeholder: "{{API_KEY}}"
                 transform: google-jwt-bearer
+                transform_config:
+                  scopes:
+                    - https://www.googleapis.com/auth/calendar.readonly
                 inject_to:
                   - api.example.com
         """))
         _, warnings = self._validate_under_apple(str(p))
-        assert any(
-            "secret_injection" in w and "transform" in w for w in warnings
+        assert not any(
+            "secret_injection" in w and "transform" in w
+            and "silently has no effect" in w
+            for w in warnings
         ), warnings
 
     def test_container_isolation_no_silent_drop_warnings(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.20.1"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- The apple-container mitmproxy addon now dispatches `secret_injection[].transform` rules (today: `google-jwt-bearer`) at startup using the shared `data/proxy/transforms` registry — minted values land on the wire, the raw env-passed credential never does.
- Completes the transform-on-apple-container half of #151; closes the `secret_injection.transform accepted but not applied` gap section in `docs/apple-container.md`.

## What changed

- **wrapper**: stages `data/proxy/transforms/` as `transforms.tar.gz` next to the addon — plain dir COPY silently empties the target on Apple's `container build` 0.5+, so we ADD a tarball (auto-extracted)
- **backend**: forwards `transform` + `transform_config` through cage config → wrapper rules dict
- **addon**: binds transforms in `__init__`; `_maybe_inject` calls `transform_fn()` per request; fail-closed (placeholder stays, upstream 401s) on either init or runtime failure — never falls back to the raw env value
- **audit**: new `secret_transforms: {env: transform_name}` sibling field on per-request entries, so `cage audit` can distinguish raw substitution from derived-value substitution
- **config**: drops the "silently has no effect on apple-container" warning for known transforms (unknown transforms are still rejected at parse time by `validate_transform`)
- **docs**: rewrites the gap subsection to "Fixed" with an example + fail-closed contract

## Test plan

- [x] `uv run pytest tests/` — 1453 passed (added build-time, runtime, init-failure, runtime-failure tests + flipped the validation test)
- [x] End-to-end on m1 macOS 26 with cage `ubuntu-transform`:
  - Addon startup log: `[agentcage] secret injection: TEST_GCP_SA_KEY(google-jwt-bearer)` (transform bound, not just stored)
  - From the cage: `curl https://www.googleapis.com/oauth2/v1/tokeninfo -H 'Authorization: Bearer {{TEST_GCP_BEARER}}'` triggers `google-jwt-bearer: mint failed (HTTP 400): {"error":"invalid_grant","error_description":"Invalid grant: account not found"}` — proves the transform actually called Google's OAuth endpoint with our test JWT (fake SA, expected reject)
  - On mint failure, placeholder stays — audit entry shows `secrets_injected: []` (fail-closed contract works)
  - Test used a self-generated RSA key in a sanitized SA JSON (no real Google project); a real-SA e2e was not run because no real SA was available, but the wiring is identical and the mint code path executed end-to-end against Google's real OAuth endpoint

## Coordination note

There's a parallel PR adding response-side redaction to `allowlist_addon.py` — merge conflicts expected in `_resolved_secrets` shape, `tests/test_apple_container.py`, and the docs gap section. This PR is clean against the current master tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)