### PR TITLE
feat(apple-container): file-based secret delivery — no cleartext env

### DIFF
--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -322,20 +322,46 @@ apt tries HTTP first; the upstream redirects to HTTPS; mitmproxy handles the TLS
 
 **`launchctl list io.agentcage.<cage>` says "Could not find service"** — on macOS 26 with autostart enabled, the plist is loaded into a domain `launchctl list <label>` doesn't always introspect. Check that the plist file exists at `~/Library/LaunchAgents/io.agentcage.<cage>.plist`; if it does, autostart is wired (the plist is reloaded at each login via the LaunchAgents directory's automatic discovery).
 
-## Secrets are env-passed, not stored
+## Secret delivery model
 
-| | container / vm | apple-container |
+| | container / vm | apple-container (0.21.1+) |
 |---|---|---|
-| Where secrets live at rest | host podman secret store | host environment (`os.environ`) |
+| Where secrets live at rest | host podman secret store | host environment (`os.environ`) at `cage start` time |
 | Set via | `agentcage secret set <cage> KEY` | `export KEY=value` in the shell that runs `cage start` |
 | Listed by | `agentcage secret list <cage>` | (none — exits unsupported) |
 | Persisted after host reboot | yes (podman secret store survives) | no (env vars are per-shell) |
-| Injected as | env vars on the cage container OR `{{SECRET:...}}` placeholder substitution by the proxy | env vars on the cage microVM + `{{ENV_NAME}}` placeholder substitution by the proxy addon (PR #151) |
+| How the real value reaches the proxy | mounted into proxy container at `/run/secrets/<name>` (podman secret bind) | host-side file at `<state>/<cage>/secrets/<env>` (mode 0600), bind-mounted into the microVM as `:ro`, re-staged by supervisor to `/home/acproxy/secrets/<env>` (chown 200:200 mode 0400) |
+| What the cage workload sees in its env | placeholder | placeholder (`-e API_KEY={{API_KEY}}`) |
+| What the cage workload sees on disk | nothing (proxy holds the secret) | nothing — host bind mount is `umount`ed by supervisor stage 35 after re-staging |
 
-On apple-container, `secret list / set / rm` exit with `not yet implemented` — they have no work to do. The flow is:
+### End-to-end flow
 
 1. `cage.yaml` declares the rule: `secret_injection: [{env: API_KEY, placeholder: "{{API_KEY}}", inject_to: [api.example.com]}]`
 2. Operator exports the value: `export API_KEY=sk-real-key`
-3. `agentcage cage start <cage>` reads `API_KEY` from `os.environ`, forwards via `container run -e API_KEY=sk-real-key`
-4. Inside the cage, the mitmproxy addon resolves the env var at startup and substitutes `{{API_KEY}}` → `sk-real-key` in outbound request headers/bodies whose host matches `inject_to`
-5. The cage workload only ever sees the placeholder, never the real value
+3. `agentcage cage start <cage>`:
+   - reads `API_KEY` from `os.environ`
+   - writes the value to `<state>/<cage>/secrets/API_KEY` (mode 0600 on host)
+   - passes `--volume <state>/<cage>/secrets:/run/agentcage/secrets:ro` and `-e API_KEY={{API_KEY}}` to `container run` (NOT the cleartext value)
+4. Supervisor stage 35 (in-cage, as root): copies `/run/agentcage/secrets/*` → `/home/acproxy/secrets/*` with chown 200:200 mode 0400, then `umount /run/agentcage/secrets` so the workload can't read the host-side bind mount
+5. Mitmproxy addon (uid 200) reads `/home/acproxy/secrets/API_KEY` at startup
+6. Cage workload (uid 1000) reads `os.environ["API_KEY"]` → gets `{{API_KEY}}` (the placeholder)
+7. Cage makes an outbound request to api.example.com with `Authorization: Bearer {{API_KEY}}`
+8. Mitmproxy intercepts, substitutes `{{API_KEY}}` → `sk-real-key` on the wire (PR #151) — `secrets_injected` audit entry records the env name
+9. On the response, mitmproxy redacts the real value back to `{{API_KEY}}` (PR #156) — `secrets_redacted` audit entry records it; the cage never sees the bytes even if the upstream echoes them
+
+### What's NOT exposed (verified)
+
+| Surface | What's visible | Why |
+|---|---|---|
+| Host `ps -ef` | placeholder, never the real value | the `container run` argv only carries `-e KEY={{KEY}}`; value goes via bind-mounted file |
+| `container inspect <cage>` | placeholder | container env config is `KEY={{KEY}}` |
+| Cage workload's `/proc/self/environ` | placeholder | cage workload's env is exactly what `-e` set: placeholder |
+| Cage workload reading `/run/agentcage/secrets/` | `No such file or directory` | supervisor umount'd after re-staging |
+| Cage workload reading `/home/acproxy/secrets/` | `Permission denied` | dir is acproxy-only-readable (mode 0700, owned uid 200), workload runs as uid 1000 |
+
+The only places the cleartext value lives are: the host shell environment of whoever ran `cage start` (the operator's responsibility), the per-cage secrets dir on the host (mode 0600 owned by the host user), and inside the mitmproxy process's memory while it's running.
+
+### Caveats
+
+- **`cage exec` runs as root.** As documented in [Quirks worth knowing](#quirks-worth-knowing), `agentcage cage exec <cage>` enters the cage as the image's default USER (root on most bases). Root in the cage CAN read `/home/acproxy/secrets/*` regardless of mode (CAP_DAC_OVERRIDE). This is the operator-debug session and is by design trusted; the threat model treats only the workload as untrusted.
+- **Backward compat.** If you run a fresh agentcage 0.21.1+ against a cage last started under 0.21.0 (unit JSON predates `secret_env_placeholders`), `start()` falls back to the old `-e NAME=value` cleartext-env delivery so the cage keeps starting without a `cage update`. Run `cage update <name>` to migrate to the hardened model.

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -95,6 +95,27 @@ class AppleContainerBackend:
         """
         return self._state_dir(name) / "logs"
 
+    def secrets_dir(self, name: str) -> Path:
+        """Per-cage secrets dir on the host, bind-mounted into the microVM
+        read-only at /run/agentcage/secrets.
+
+        Each ``secret_injection`` rule's resolved value gets written to
+        ``<secrets_dir>/<env-name>`` (mode 0600, owned by the host user)
+        at ``start()`` time. The cage's ``container run`` argv carries
+        only the PLACEHOLDER (``-e API_KEY={{API_KEY}}``) — the raw value
+        is never on the command line (visible to host `ps`) nor in
+        ``container inspect`` output. Inside the cage, virtiofs preserves
+        the host's 0600 perms so only root in the microVM can read; the
+        supervisor (PID 1, root) re-stages each file into
+        /home/acproxy/secrets/<env-name> (mode 0400, owned by acproxy
+        uid 200) so mitmproxy can read them but the cage workload (uid
+        1000) cannot.
+
+        Created on demand (start), removed by destroy_resources alongside
+        the rest of the per-cage state.
+        """
+        return self._state_dir(name) / "secrets"
+
     def _launchd_plist_path(self, name: str) -> Path:
         """Host path of the per-cage launchd plist.
 
@@ -302,11 +323,19 @@ class AppleContainerBackend:
         memory = config.container.memory or (
             f"{config.vm.mem_mb}m" if getattr(config.vm, "mem_mb", 0) else ""
         )
-        # Persist the secret-injection rule list so `start()` knows which
-        # env vars to forward into the microVM at `container run` time.
-        # Only the env names are stored — the actual secret values come
-        # from the host environment (or, in future, a Keychain lookup).
+        # Persist the secret-injection env→placeholder map so `start()` knows
+        # which env vars to resolve from the host environment AND which
+        # placeholder string to pass to the cage in their place. The
+        # placeholder (not the real value) ends up in the cage's env via
+        # `-e ENV={{ENV}}` so cage code that reads `os.environ["KEY"]`
+        # gets the placeholder; the real value lives only in the
+        # bind-mounted secrets file and the mitmproxy addon substitutes
+        # it on the wire. ``secret_envs`` kept (list of env names) for
+        # backward compat with cages last started on 0.21.0 or earlier.
         secret_envs = [r.env for r in (config.secret_injection or [])]
+        secret_env_placeholders = {
+            r.env: r.placeholder for r in (config.secret_injection or [])
+        }
         unit_json = json.dumps(
             {
                 "name": deploy_name,
@@ -315,6 +344,7 @@ class AppleContainerBackend:
                 "memory": memory,
                 "lifecycle": config.lifecycle,
                 "secret_envs": secret_envs,
+                "secret_env_placeholders": secret_env_placeholders,
                 "autostart": bool(getattr(config, "apple_container_autostart", False)),
             },
             indent=2,
@@ -407,25 +437,61 @@ class AppleContainerBackend:
         elif meta.get("mem_mb"):  # pre-0.20.6 unit JSON
             argv += ["--memory", f"{meta['mem_mb']}M"]
 
-        # Secret-injection env-passing. For each env named in the cage's
-        # `secret_injection:` rules, look it up in the current host
-        # environment and forward via `-e NAME=value` to `container run`.
-        # The mitmproxy addon inside the cage reads these at startup and
-        # uses them to substitute `{{NAME}}` placeholders in outbound
-        # requests destined for the rule's inject_to allow-list.
-        # Missing env vars are skipped with a stderr warning rather than
-        # failing — the cage may not need every secret on every host.
-        for env_name in meta.get("secret_envs") or []:
-            value = os.environ.get(env_name)
-            if value is None:
-                click.echo(
-                    f"warning: secret_injection env {env_name!r} "
-                    f"not set in host environment; placeholder will "
-                    f"NOT be substituted in cage requests",
-                    err=True,
-                )
-                continue
-            argv += ["-e", f"{env_name}={value}"]
+        # Secret-injection. For each env named in the cage's
+        # `secret_injection:` rules:
+        #   - Write the real value to <secrets_dir>/<env-name> on the
+        #     host (mode 0600). The dir gets bind-mounted at
+        #     /run/agentcage/secrets:ro in the cage; supervisor stage 35
+        #     re-stages each file as /home/acproxy/secrets/<env-name>
+        #     (chown 200:200, mode 0400) for mitmproxy.
+        #   - Pass `-e <env>={{PLACEHOLDER}}` (the placeholder, NOT the
+        #     real value) to `container run`. The cage's env carries the
+        #     placeholder so cage code that reads `os.environ["API_KEY"]`
+        #     gets `{{API_KEY}}` and the proxy substitutes the real
+        #     value on the wire. This means the cleartext value is NOT
+        #     visible via host `ps -ef`, NOT in `container inspect`,
+        #     and NOT in the cage workload's `/proc/self/environ`.
+        # Missing env vars are skipped with a stderr warning — the cage
+        # may not need every secret on every host. Backward compat: if
+        # the unit JSON predates this PR (no secret_env_placeholders),
+        # fall back to the old `-e NAME=value` cleartext behavior so
+        # existing cages keep working after upgrade.
+        placeholders = meta.get("secret_env_placeholders") or {}
+        secret_envs = meta.get("secret_envs") or list(placeholders.keys())
+        if secret_envs:
+            secrets_dir = self.secrets_dir(name)
+            secrets_dir.mkdir(parents=True, exist_ok=True)
+            os.chmod(secrets_dir, 0o700)
+            # Drop any stale secret files from a prior start so removed
+            # rules don't linger in the bind mount.
+            for stale in secrets_dir.iterdir():
+                stale.unlink()
+            for env_name in secret_envs:
+                value = os.environ.get(env_name)
+                if value is None:
+                    click.echo(
+                        f"warning: secret_injection env {env_name!r} "
+                        f"not set in host environment; placeholder will "
+                        f"NOT be substituted in cage requests",
+                        err=True,
+                    )
+                    continue
+                placeholder = placeholders.get(env_name)
+                if placeholder:
+                    secret_file = secrets_dir / env_name
+                    secret_file.write_text(value)
+                    os.chmod(secret_file, 0o600)
+                    argv += ["-e", f"{env_name}={placeholder}"]
+                else:
+                    # Pre-0.21.1 unit JSON: no placeholder map. Fall back
+                    # to cleartext-env delivery to preserve behavior for
+                    # cages last started under 0.21.0.
+                    argv += ["-e", f"{env_name}={value}"]
+            # Mount the per-cage secrets dir read-only into the microVM.
+            # Only mount if any files were written (avoid mounting an empty
+            # dir when every secret env was missing host-side).
+            if any(secrets_dir.iterdir()):
+                argv += ["--volume", f"{secrets_dir}:/run/agentcage/secrets:ro"]
 
         argv.append(image)
 

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -39,6 +39,11 @@ from mitmproxy import ctx, http
 
 ALLOWLIST_PATH = "/etc/agentcage/allowlist.txt"
 SECRET_INJECTION_PATH = "/etc/agentcage/secret_injection.json"
+# Per-cage resolved-secret files; supervisor stage 35 re-stages from
+# the host-bind-mounted /run/agentcage/secrets to this acproxy-only path
+# (chown 200:200, mode 0400). The cage workload (uid 1000) cannot read
+# this dir.
+SECRETS_DIR = "/home/acproxy/secrets"
 AUDIT_LOG_PATH = os.environ.get(
     "AGENTCAGE_AUDIT_LOG", "/var/log/agentcage/audit.jsonl"
 )
@@ -127,7 +132,19 @@ class AllowlistAddon:
         self._resolved_secrets: list[dict] = []
         for rule in self.injection_rules:
             env_name = rule.get("env", "")
-            value = os.environ.get(env_name)
+            # Read the resolved value from /home/acproxy/secrets/<env>
+            # (re-staged by supervisor stage 35 from the host bind mount).
+            # Falls back to os.environ for backward compat with cages
+            # last started under 0.21.0 or earlier (which env-passed the
+            # cleartext value); on the file path, mitmproxy's own env
+            # never holds the raw secret.
+            value = ""
+            secret_file = os.path.join(SECRETS_DIR, env_name)
+            try:
+                with open(secret_file) as f:
+                    value = f.read()
+            except OSError:
+                value = os.environ.get(env_name, "")
             if not value:
                 continue
             transform_name = rule.get("transform", "") or ""

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -92,6 +92,46 @@ done
 ss -lnu 2>/dev/null | grep -q '127.0.0.1:53' \
   || die "dnsmasq did not bind 127.0.0.1:53; see /var/log/agentcage/dnsmasq.log" 30
 
+#-- 35. Re-stage proxy secrets for uid 200 --------------------------------
+# Apple-container's hardened secret model (0.21.x+): the backend writes
+# each secret_injection rule's resolved value to a host-side file and
+# bind-mounts the dir read-only at /run/agentcage/secrets. virtiofs
+# maps the host owner to root inside the cage, so /run/agentcage/secrets
+# is root-owned-mode-0600 here. mitmproxy runs as uid 200 and can't read
+# it directly — supervisor (PID 1, root) re-stages each file into
+# /home/acproxy/secrets/<env> with chown 200:200 mode 0400. The cage
+# workload (uid 1000) never sees either path: /run/agentcage/secrets is
+# root-only-readable (so uid 1000 can't even open it) and
+# /home/acproxy/secrets is acproxy-only-readable.
+#
+# Idempotent: if no secrets dir is bind-mounted (cage has no
+# secret_injection rules, or backend predates this), the loop is empty.
+if [ -d /run/agentcage/secrets ]; then
+  log "stage 35: re-staging proxy secrets for uid 200"
+  mkdir -p /home/acproxy/secrets
+  chown acproxy:acproxy /home/acproxy/secrets
+  chmod 0700 /home/acproxy/secrets
+  # Copy each file individually so we can chown/chmod each one. `cp -p`
+  # would preserve host-side perms which we don't want.
+  for f in /run/agentcage/secrets/*; do
+    [ -f "$f" ] || continue
+    dest="/home/acproxy/secrets/$(basename "$f")"
+    cp "$f" "$dest"
+    chown acproxy:acproxy "$dest"
+    chmod 0400 "$dest"
+  done
+  # Unmount the host bind mount so the cage workload (uid 1000) can't
+  # read it. virtiofs maps host file ownership through identity so the
+  # host-side mode 0600 file shows up readable to whatever uid the
+  # cage workload is running as. The only privilege-correct way to
+  # hide it from the workload is to remove the mount from the shared
+  # mount namespace before the workload starts. Requires CAP_SYS_ADMIN
+  # which the supervisor still has until stage 90.
+  umount /run/agentcage/secrets 2>/dev/null \
+    || die "could not unmount /run/agentcage/secrets after staging — would leak secrets to cage workload" 35
+  rmdir /run/agentcage/secrets 2>/dev/null || true
+fi
+
 #-- 40. Start mitmproxy ----------------------------------------------------
 log "stage 40: starting mitmproxy (uid 200)"
 # Chown the mitmproxy home + log dir BEFORE starting mitmproxy so the

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -694,6 +694,213 @@ def test_install_launchd_plist_writes_well_formed_xml(tmp_path, monkeypatch):
     assert parsed["ProgramArguments"][-1] == "demo"
 
 
+def test_start_argv_uses_file_delivery_when_placeholders_known(
+    tmp_path, monkeypatch,
+):
+    """0.21.1+ hardened path: when the unit JSON carries
+    ``secret_env_placeholders``, start() writes the resolved value to
+    ``<secrets_dir>/<env-name>`` (mode 0600) and passes
+    ``-e <env>={{<env>}}`` (the placeholder, NOT the cleartext value) to
+    `container run`. This is the entire point — host `ps`, `container
+    inspect`, and `cage exec ... -- env` all see only the placeholder.
+    """
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "interactive",
+        "secret_envs": ["API_KEY", "MISSING_KEY"],
+        "secret_env_placeholders": {
+            "API_KEY": "{{API_KEY}}",
+            "MISSING_KEY": "{{MISSING_KEY}}",
+        },
+    }))
+    monkeypatch.setenv("API_KEY", "sk-real-1234")
+    monkeypatch.delenv("MISSING_KEY", raising=False)
+
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    logs_dir = tmp_path / "logs"
+    secrets_dir = tmp_path / "secrets"
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(backend, "secrets_dir", return_value=secrets_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    # The cage env carries the placeholder, NEVER the raw value.
+    assert "API_KEY={{API_KEY}}" in run_argv
+    assert "sk-real-1234" not in " ".join(run_argv)
+    # The bind mount is present.
+    assert any(
+        a == f"{secrets_dir}:/run/agentcage/secrets:ro" for a in run_argv
+    )
+    # The secret file exists on the host, mode 0600, containing the real value.
+    secret_file = secrets_dir / "API_KEY"
+    assert secret_file.is_file()
+    assert secret_file.read_text() == "sk-real-1234"
+    assert oct(secret_file.stat().st_mode & 0o777) == "0o600"
+    # The missing env has NO file (skipped) and isn't in argv.
+    assert not (secrets_dir / "MISSING_KEY").exists()
+    assert "MISSING_KEY=" not in " ".join(run_argv)
+    # The secrets dir itself is mode 0700 (only host user can read).
+    assert oct(secrets_dir.stat().st_mode & 0o777) == "0o700"
+
+
+def test_start_argv_drops_stale_secrets_from_prior_starts(
+    tmp_path, monkeypatch,
+):
+    """start() removes pre-existing files in <secrets_dir> so a rule
+    that's been removed from cage.yaml doesn't linger in the bind mount
+    after `cage update`. Keeps the secrets dir an accurate reflection
+    of the current rule list."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "interactive",
+        "secret_envs": ["NEW_KEY"],
+        "secret_env_placeholders": {"NEW_KEY": "{{NEW_KEY}}"},
+    }))
+    monkeypatch.setenv("NEW_KEY", "new-value")
+
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    # Stale leftover from a previous create where OLD_KEY was a rule.
+    (secrets_dir / "OLD_KEY").write_text("old-stale-value")
+
+    def fake_run(argv, **_kwargs):  # noqa: ARG001
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
+         patch.object(backend, "secrets_dir", return_value=secrets_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    # OLD_KEY removed; NEW_KEY present.
+    assert not (secrets_dir / "OLD_KEY").exists()
+    assert (secrets_dir / "NEW_KEY").read_text() == "new-value"
+
+
+def test_start_argv_backcompat_pre_021_1_cleartext(tmp_path, monkeypatch):
+    """Backward compat: unit JSON without ``secret_env_placeholders``
+    (cage last started under 0.21.0) falls back to the old
+    ``-e NAME=value`` cleartext path so existing cages keep starting
+    after upgrade without a `cage update`."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo",
+        "user_image": "x",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "interactive",
+        "secret_envs": ["API_KEY"],
+        # no secret_env_placeholders — pre-0.21.1 shape
+    }))
+    monkeypatch.setenv("API_KEY", "sk-real-1234")
+
+    captured_argv = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
+         patch.object(backend, "secrets_dir", return_value=tmp_path / "secrets"), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a[0] == "run")
+    # Backward-compat: cleartext value via -e, no bind mount.
+    assert "API_KEY=sk-real-1234" in run_argv
+    assert not any("secrets:ro" in a for a in run_argv)
+
+
+def test_generate_units_persists_secret_env_placeholders():
+    """generate_units writes the env→placeholder map for start() to use."""
+    from agentcage.config import SecretInjectionRule
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "x"
+    cfg.secret_injection = [
+        SecretInjectionRule(env="API_KEY", placeholder="{{API_KEY}}"),
+        SecretInjectionRule(env="DB_URL", placeholder="{{DATABASE_URL}}"),
+    ]
+    units = AppleContainerBackend().generate_units(cfg, "/cfg", "/p", "deploy")
+    meta = json.loads(units["deploy.json"])
+    assert meta["secret_env_placeholders"] == {
+        "API_KEY": "{{API_KEY}}",
+        "DB_URL": "{{DATABASE_URL}}",
+    }
+    # secret_envs still present for backward compat.
+    assert meta["secret_envs"] == ["API_KEY", "DB_URL"]
+
+
+def test_supervisor_restages_secrets_for_uid_200(tmp_path):
+    """REGRESSION: supervisor.sh stage 35 must copy /run/agentcage/secrets/*
+    into /home/acproxy/secrets/* with chown 200:200 mode 0400, so mitmproxy
+    can read them but the cage workload (uid 1000) cannot.
+
+    Without stage 35, mitmproxy (uid 200) can't open the bind-mounted
+    files (virtiofs maps them to root-owned mode 0600), and the cage
+    workload (uid 1000) ALSO can't open them — secret_injection silently
+    no-ops."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    sup = (tmp_path / "supervisor.sh").read_text()
+    assert "stage 35" in sup
+    assert "/run/agentcage/secrets" in sup
+    assert "/home/acproxy/secrets" in sup
+    assert "chown acproxy:acproxy" in sup
+    assert "chmod 0400" in sup
+
+
+def test_supervisor_umounts_secrets_after_restaging(tmp_path):
+    """REGRESSION: supervisor must `umount /run/agentcage/secrets` after
+    re-staging to /home/acproxy/secrets. Without the unmount, virtiofs
+    keeps the host-side files visible at the bind-mount path, and the
+    cage workload (uid 1000 — but virtiofs maps host owner through
+    identity so the file shows as workload-owned) can `cat` them.
+
+    Mac e2e verification (with the umount):
+      $ cage exec ubuntu-sec -- su ubuntu -s /bin/sh -c \\
+            'cat /run/agentcage/secrets/AGENTCAGE_SECFILE_SECRET'
+      cat: /run/agentcage/secrets/AGENTCAGE_SECFILE_SECRET: No such
+      file or directory   ← pass
+
+    Without the umount, the same command returns the secret value
+    cleartext — a silent end-run around the file-based delivery model.
+    `die` on umount failure so a broken stage 35 fails closed rather
+    than booting a cage that leaks."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    sup = (tmp_path / "supervisor.sh").read_text()
+    assert "umount /run/agentcage/secrets" in sup
+    # Failure must abort the cage; otherwise the leak is silent.
+    assert 'die "could not unmount /run/agentcage/secrets' in sup
+
+
 def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
     """start() reads secret_envs from the unit metadata and forwards each
     via `-e NAME=value`. Missing env vars are skipped (with a warning)."""


### PR DESCRIPTION
## Summary

0.21.0's \`secret_injection\` env-passed the real secret value via \`container run -e NAME=value\`. The value was visible in three places: host \`ps -ef\` (CLI argv), \`container inspect <cage>\` (env config), and the cage workload's \`/proc/self/environ\` — defeating the whole point of the \`{{SECRET}}\` placeholder.

This PR switches to file-based delivery:

- Backend writes each resolved secret to \`<state>/<cage>/secrets/<env>\` (mode 0600 host-side)
- Bind-mounts at \`/run/agentcage/secrets:ro\`, passes \`-e <env>={{PLACEHOLDER}}\` (NOT cleartext)
- Supervisor stage 35 copies into \`/home/acproxy/secrets/*\` (chown 200:200 mode 0400), then \`umount\` the host bind so the workload can't read it (virtiofs maps file owner through identity; without umount the workload could still cat the bind-mounted files)
- Addon reads from \`/home/acproxy/secrets/<env>\` instead of \`os.environ\`

Backward compat: pre-0.21.1 unit JSON (no \`secret_env_placeholders\` field) falls through to the old cleartext path so existing cages keep starting without \`cage update\`.

## Verified on macOS 26.3.2 + ASi

All five exposure surfaces:

| Surface | Result |
|---|---|
| Host \`ps -ef \| grep <secret>\` | no match |
| \`container inspect\` env | placeholder |
| Workload \`/proc/1/environ\` | placeholder |
| Workload \`cat /run/agentcage/secrets/*\` | No such file (umount'd) |
| Workload \`cat /home/acproxy/secrets/*\` | Permission denied |

Functional via audit log: \`injected: [X]\` outbound + \`redacted: [X]\` inbound — full end-to-end substitution + redaction works.

## Test plan

- [x] 6 new unit tests in \`tests/test_apple_container.py\` (file delivery argv, stale-rule cleanup, backcompat cleartext, env→placeholder map, supervisor stage 35, umount fail-closed)
- [x] Live Mac verification of all five exposure surfaces + audit-log functional check

🤖 Generated with [Claude Code](https://claude.com/claude-code)