### PR TITLE
feat(apple-container): wire protocol_relays end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`protocol_relays:` wired on apple-container.** Pre-this-PR the parser accepted `protocol_relays:` entries (IMAP, SMTP) but the apple-container backend silently spawned no listeners — outbound mail from the cage just hung. The wrapper now bakes the cage's relay list into `/etc/agentcage/protocol_relays.json`, bundles the shared `data/proxy/{relays,inspectors}` packages into the image, and the addon's `running()` hook dispatches each entry through the same registry the container backend uses. Credentials take the hardened path from #158: written to the per-cage secrets bind mount, re-staged for uid 200 by supervisor stage 35, and read by the addon at relay-start time — never passed as `-e` flags, so `container inspect` and the cage workload's `/proc/self/environ` stay clean. Supervisor stage 80 reads `protocol_relays.json` and opens a per-port loopback ACCEPT so cage→relay connections survive the default-DROP egress lockdown. Inspector-chain wiring on relay `DATA` payloads is the next parity item under #120; per-protocol policy (recipient/sender allowlist, rate caps, size cap) is fully active today.
+
 ## [0.21.1] - 2026-05-25
 
 Three follow-ups on the 0.21.0 apple-container secret-injection model. The big one is #158 — secrets are no longer cleartext in the cage's env. Together these close out the documented gaps from `docs/apple-container.md` post-0.21.0.

--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -174,6 +174,49 @@ and dnsmasq run inside the same microVM)
 
 **Proper fix path (deferred).** Would need a routing layer in the supervisor that listens on a control socket and proxies exec requests to the right component's namespace. Architectural, not a small patch.
 
+### `protocol_relays:` — wired (was a gap pre-0.21.x)
+
+**Status.** Fixed. `protocol_relays:` entries (IMAP, SMTP) now spawn real TCP listeners inside the apple-container microVM. The in-cage mitmproxy addon's `running()` hook reads the cage's relay list from `/etc/agentcage/protocol_relays.json` (baked in at wrapper-build time), dispatches each entry's `type` through the same `data/proxy/relays` registry the container backend uses, and starts a listener on the configured `listen:` address. Pre-0.21.1 the config parsed cleanly but silently spawned nothing — outbound SMTP / IMAP from the cage would just hang. Audit events from the relay (`smtp_data`, `imap_command`, `smtp_command`, ...) land in the same `audit.jsonl` as HTTP allow/block decisions, so `cage audit` surfaces them under one timeline.
+
+**Credential handling.** Relay credentials (`auth.user_source: env:SMTP_USER`, etc.) take the same hardened path `secret_injection:` does on 0.21.1+: the backend writes each value into the per-cage secrets bind mount (`<state>/<cage>/secrets/<env>`, mode 0600), supervisor stage 35 re-stages into `/home/acproxy/secrets/<env>` (chown 200:200 mode 0400) for mitmproxy, then `umount`s the host bind so the cage workload cannot read it. The addon reads each relay-secret file in its `running()` hook and sets `os.environ[<env>]` for the relay's own `_resolve_credential` to pick up. Crucially, relay credentials are **NOT** passed as `-e` flags to `container run` — they live only in the mitmproxy process's env, so `container inspect <cage>` and the cage workload's `/proc/self/environ` never carry them.
+
+**Loopback access.** Cage workloads reach the relay over loopback on whatever port the cage author chose in `listen:`. Supervisor stage 80 reads `protocol_relays.json` and adds a per-port `iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport <port> -j ACCEPT` rule — without it the default-DROP filter chain would silently kill cage→relay connections.
+
+**Inspector chain (caveat).** The apple-container relay path currently runs with `inspectors=None` — relay-level policy (`recipient_allowlist`, `sender_allowlist`, `max_message_bytes`, rate limits) still applies, but the body inspector chain (`secrets`, `entropy`, `content-type`) does not run on SMTP `DATA` payloads. Full inspector-chain parity is the next item under #120; the container backend already wires it (`src/agentcage/data/proxy/addon.py:_start_protocol_relays`).
+
+**Example.**
+
+```yaml
+# cage.yaml — outbound SMTP through a hardened relay
+name: mail-cage
+isolation: apple-container
+container:
+  image: ubuntu:24.04
+domains:
+  allow:
+    - smtp.example.net   # only the upstream MTA is reachable
+protocol_relays:
+  - name: primary-smtp
+    type: smtp
+    listen: 127.0.0.1:2525
+    upstream:
+      host: smtp.example.net
+      port: 587
+      tls: true
+    auth:
+      type: smtp-plain
+      user_source: env:SMTP_USER
+      password_source: env:SMTP_PASS
+    policy:
+      sender_allowlist: ["bot@local"]
+      recipient_allowlist:
+        domains: ["example.com"]
+      max_message_bytes: 1048576
+      send_rate_limit: "20/hour"
+```
+
+`SMTP_USER` / `SMTP_PASS` must be set in the host environment at `cage start` time — the backend writes them into the secrets bind mount and the cage workload never sees them.
+
 ### `secret_injection.transform` — wired (was a gap pre-0.21.x)
 
 **Status.** Fixed. `transform: google-jwt-bearer` (and any future entry in `KNOWN_TRANSFORMS`) now runs end-to-end on apple-container: the in-cage mitmproxy addon loads the same `data/proxy/transforms` registry the container backend uses, mints a derived value at request time (e.g. a short-lived OAuth bearer from a service-account JWT), and substitutes that — not the raw env-passed credential — into the outbound request. The "silently has no effect on apple-container" warning no longer fires for known transforms.

--- a/src/agentcage/apple_container/wrapper.py
+++ b/src/agentcage/apple_container/wrapper.py
@@ -28,6 +28,22 @@ _DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "apple-container"
 _TRANSFORMS_SRC = (
     Path(__file__).resolve().parent.parent / "data" / "proxy" / "transforms"
 )
+# Protocol relays (IMAP, SMTP) — non-HTTP secret-injection listeners that
+# run on the same mitmproxy event loop as the HTTP allowlist. Bundled
+# into the apple-container image so the addon can do
+# ``from relays import get`` once a cage.yaml declares ``protocol_relays:``.
+_RELAYS_SRC = (
+    Path(__file__).resolve().parent.parent / "data" / "proxy" / "relays"
+)
+# Inspector base classes that ``relays.smtp`` imports at module load
+# (``from inspectors.base import InspectionContext, ...``). Bundled
+# even though the apple-container addon currently passes
+# ``inspectors=None`` to relay constructors — without the package on
+# sys.path the relay module itself fails to import. Tracked as part
+# of the broader inspector-chain parity work in #120.
+_INSPECTORS_SRC = (
+    Path(__file__).resolve().parent.parent / "data" / "proxy" / "inspectors"
+)
 
 
 def _user_cmd(user_image: str) -> list[str]:
@@ -92,11 +108,33 @@ def render_wrapper_containerfile(user_image: str, *, user_cmd: list[str] | None 
     return tmpl.render(user_image=user_image)
 
 
+def _pack_tarball(src: Path, archive: Path) -> None:
+    """Pack ``src``'s top-level entries into a flat ``archive`` tarball.
+
+    Excludes ``__pycache__`` (host-local Python bytecode that bloats
+    the image layer and ruins layer determinism). Entries are added in
+    sorted order so each rebuild with unchanged source produces a
+    bit-identical artifact — helps Apple's container layer cache and
+    is required for reproducible-build digests downstream.
+
+    The archive uses flat (top-level-only) ``arcname``s so an
+    ``ADD foo.tar.gz /opt/agentcage/foo/`` directive in the
+    Containerfile drops the contents straight into the target dir
+    — no nested ``foo/foo/...`` directory.
+    """
+    with tarfile.open(archive, "w:gz") as tar:
+        for entry in sorted(src.iterdir()):
+            if entry.name == "__pycache__":
+                continue
+            tar.add(entry, arcname=entry.name)
+
+
 def stage_build_context(
     dest: Path,
     user_cmd: list[str],
     allowlist: list[str] | None = None,
     secret_injection_rules: list[dict] | None = None,
+    protocol_relays: list[dict] | None = None,
 ) -> None:
     """Stage supervisor + cage CMD + egress filter config into *dest*.
 
@@ -118,8 +156,26 @@ def stage_build_context(
                                  implementations (google-jwt-bearer, ...)
                                  the container backend uses. Rules with no
                                  ``transform`` field never load this code.
+      - relays.tar.gz         -- tarball of ``data/proxy/relays`` so the
+                                 in-cage addon can ``from relays import get``
+                                 to spawn IMAP/SMTP listeners declared in
+                                 cage.yaml ``protocol_relays:``.
+      - inspectors.tar.gz     -- tarball of ``data/proxy/inspectors`` —
+                                 the relays package imports
+                                 ``inspectors.base`` at module load even
+                                 when the apple-container addon passes
+                                 ``inspectors=None``; bundling satisfies
+                                 the import without dragging the full
+                                 mitmproxy inspector wiring in.
+      - protocol_relays.json  -- the cage's ``protocol_relays:`` list
+                                 (passes through ``name/type/listen/
+                                 upstream/auth/policy``). Credential
+                                 VALUES are NOT here — the addon reads
+                                 them at relay-start time from the same
+                                 ``/home/acproxy/secrets/<env>`` files
+                                 secret_injection uses.
 
-    NOTE on the tarball: Apple's ``container build`` (0.5+) silently
+    NOTE on the tarballs: Apple's ``container build`` (0.5+) silently
     drops the contents when a Containerfile does ``COPY <dir> <dst>``
     — the destination directory exists but is empty. ADD'ing a
     ``.tar.gz`` works because the underlying buildkit path
@@ -131,26 +187,24 @@ def stage_build_context(
     shutil.copy2(_DATA_DIR / "supervisor.sh", dest / "supervisor.sh")
     shutil.copy2(_DATA_DIR / "dnsmasq.conf", dest / "dnsmasq.conf")
     shutil.copy2(_DATA_DIR / "allowlist_addon.py", dest / "allowlist_addon.py")
-    # Pack the transforms package into a deterministic tarball so each
-    # rebuild with unchanged source produces a bit-identical artifact
-    # (helps Apple's container layer cache; would also help reproducible
-    # builds if/when we cross-check image digests in CI). Tarball is
-    # small (a few KB) so the .gz / non-.gz choice doesn't matter.
-    transforms_archive = dest / "transforms.tar.gz"
-    with tarfile.open(transforms_archive, "w:gz") as tar:
-        for entry in sorted(_TRANSFORMS_SRC.iterdir()):
-            # Skip Python bytecode caches — they're host-local and would
-            # bloat the layer for zero functional benefit.
-            if entry.name == "__pycache__":
-                continue
-            # arcname is relative to the archive root so ADD extracts
-            # straight into /opt/agentcage/transforms/<file>.
-            tar.add(entry, arcname=entry.name)
+    # Pack the transforms, relays, and inspectors packages into
+    # deterministic tarballs (sorted entries, no __pycache__). Each is
+    # a few KB; the COPY-drop bug forces us through ADD for every
+    # directory we want bundled.
+    _pack_tarball(_TRANSFORMS_SRC, dest / "transforms.tar.gz")
+    _pack_tarball(_RELAYS_SRC, dest / "relays.tar.gz")
+    _pack_tarball(_INSPECTORS_SRC, dest / "inspectors.tar.gz")
     (dest / "cage-cmd.json").write_text(json.dumps(user_cmd))
     allow_lines = "\n".join(h.strip() for h in (allowlist or []) if h.strip())
     (dest / "allowlist.txt").write_text(allow_lines + ("\n" if allow_lines else ""))
     (dest / "secret_injection.json").write_text(
         json.dumps(secret_injection_rules or [])
+    )
+    # protocol_relays.json is always written (possibly as ``[]``) so the
+    # in-cage addon's loader can read+parse unconditionally — same
+    # pattern as secret_injection.json above.
+    (dest / "protocol_relays.json").write_text(
+        json.dumps(protocol_relays or [])
     )
 
 
@@ -166,6 +220,7 @@ def build_wrapper(
     user_cmd: list[str] | None = None,
     allowlist: list[str] | None = None,
     secret_injection_rules: list[dict] | None = None,
+    protocol_relays: list[dict] | None = None,
 ) -> str:
     """Generate Containerfile, stage build context, run `container build`.
 
@@ -185,6 +240,7 @@ def build_wrapper(
         stage_build_context(
             tmpdir, user_cmd, allowlist=allowlist,
             secret_injection_rules=secret_injection_rules,
+            protocol_relays=protocol_relays,
         )
         ac_cli.run(
             ["build", "-t", image, "-f", str(tmpdir / "Containerfile"), str(tmpdir)],

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -281,11 +281,57 @@ class AppleContainerBackend:
             }
             for r in (config.secret_injection or [])
         ]
+        # Protocol relays (IMAP, SMTP) — same metadata-only contract as
+        # secret_injection: the credential VALUES never go into the
+        # image layer; only the structural config does. Credential env
+        # names are resolved at `start()` and written to the per-cage
+        # secrets bind mount alongside secret_injection values, so the
+        # in-cage addon can read them at relay-start time.
+        relay_rules = [
+            {
+                "name": r.name,
+                "type": r.type,
+                "listen": r.listen,
+                "upstream": {
+                    "host": r.upstream.host,
+                    "port": r.upstream.port,
+                    "tls": r.upstream.tls,
+                },
+                "auth": {
+                    "type": r.auth.type,
+                    "user_source": r.auth.user_source,
+                    "password_source": r.auth.password_source,
+                },
+                "policy": {
+                    "readonly": r.policy.readonly,
+                    "folder_allowlist": list(r.policy.folder_allowlist or []),
+                    "sender_allowlist": list(r.policy.sender_allowlist or []),
+                    "recipient_allowlist": {
+                        "addresses": list(
+                            r.policy.recipient_allowlist.addresses or []
+                        ),
+                        "domains": list(
+                            r.policy.recipient_allowlist.domains or []
+                        ),
+                    },
+                    "max_message_bytes": r.policy.max_message_bytes,
+                    "max_recipients": r.policy.max_recipients,
+                    "conn_rate_limit": r.policy.conn_rate_limit,
+                    "send_rate_limit": r.policy.send_rate_limit,
+                    "idle_timeout_seconds": r.policy.idle_timeout_seconds,
+                    "bypass_inspectors_for_allowlisted": list(
+                        r.policy.bypass_inspectors_for_allowlisted or []
+                    ),
+                },
+            }
+            for r in (config.protocol_relays or [])
+        ]
         ac_wrapper.build_wrapper(
             deploy_name, user_image,
             user_cmd=user_cmd,
             allowlist=allowlist,
             secret_injection_rules=secret_rules,
+            protocol_relays=relay_rules,
         )
         if not quiet:
             click.echo(f"Built {ac_wrapper.wrapped_image_name(deploy_name)}")
@@ -336,6 +382,21 @@ class AppleContainerBackend:
         secret_env_placeholders = {
             r.env: r.placeholder for r in (config.secret_injection or [])
         }
+        # Protocol-relay credential env names — must reach the mitmproxy
+        # process inside the cage (where the relay's _resolve_credential
+        # reads them) but must NOT reach the cage workload's env. We
+        # write each value into the same per-cage secrets bind mount
+        # secret_injection uses; the addon reads it at relay-start time
+        # and sets os.environ[<env>] before constructing the relay.
+        # Critically, these env names do NOT get a `-e` flag on
+        # `container run` — that's how we keep them off the cage
+        # workload's environ block.
+        relay_secret_envs: list[str] = []
+        for relay in (config.protocol_relays or []):
+            for src in (relay.auth.user_source, relay.auth.password_source):
+                scheme, _, var = (src or "").partition(":")
+                if scheme and var and var not in relay_secret_envs:
+                    relay_secret_envs.append(var)
         unit_json = json.dumps(
             {
                 "name": deploy_name,
@@ -345,6 +406,7 @@ class AppleContainerBackend:
                 "lifecycle": config.lifecycle,
                 "secret_envs": secret_envs,
                 "secret_env_placeholders": secret_env_placeholders,
+                "relay_secret_envs": relay_secret_envs,
                 "autostart": bool(getattr(config, "apple_container_autostart", False)),
             },
             indent=2,
@@ -458,7 +520,17 @@ class AppleContainerBackend:
         # existing cages keep working after upgrade.
         placeholders = meta.get("secret_env_placeholders") or {}
         secret_envs = meta.get("secret_envs") or list(placeholders.keys())
-        if secret_envs:
+        # Protocol-relay credential env names. Same secrets bind mount as
+        # secret_injection — but NO `-e` flag is added to `container run`,
+        # so the cage workload's environ block never carries the relay
+        # password. The in-cage mitmproxy addon reads each file in its
+        # `running()` hook and `os.environ[var] = value` before calling
+        # the relay's constructor.
+        relay_secret_envs = meta.get("relay_secret_envs") or []
+        all_secret_envs = list(secret_envs) + [
+            v for v in relay_secret_envs if v not in secret_envs
+        ]
+        if all_secret_envs:
             secrets_dir = self.secrets_dir(name)
             secrets_dir.mkdir(parents=True, exist_ok=True)
             os.chmod(secrets_dir, 0o700)
@@ -466,15 +538,32 @@ class AppleContainerBackend:
             # rules don't linger in the bind mount.
             for stale in secrets_dir.iterdir():
                 stale.unlink()
-            for env_name in secret_envs:
+            relay_only = set(relay_secret_envs) - set(secret_envs)
+            for env_name in all_secret_envs:
                 value = os.environ.get(env_name)
                 if value is None:
-                    click.echo(
-                        f"warning: secret_injection env {env_name!r} "
-                        f"not set in host environment; placeholder will "
-                        f"NOT be substituted in cage requests",
-                        err=True,
-                    )
+                    if env_name in relay_only:
+                        click.echo(
+                            f"warning: protocol_relays env {env_name!r} "
+                            f"not set in host environment; the relay "
+                            f"will fail to start with empty credentials",
+                            err=True,
+                        )
+                    else:
+                        click.echo(
+                            f"warning: secret_injection env {env_name!r} "
+                            f"not set in host environment; placeholder will "
+                            f"NOT be substituted in cage requests",
+                            err=True,
+                        )
+                    continue
+                if env_name in relay_only:
+                    # Relay credential — file goes in the bind mount so
+                    # the addon can read it, but no `-e` so the cage
+                    # workload never sees the credential name in its env.
+                    secret_file = secrets_dir / env_name
+                    secret_file.write_text(value)
+                    os.chmod(secret_file, 0o600)
                     continue
                 placeholder = placeholders.get(env_name)
                 if placeholder:

--- a/src/agentcage/data/apple-container/Containerfile.wrapper.j2
+++ b/src/agentcage/data/apple-container/Containerfile.wrapper.j2
@@ -97,12 +97,22 @@ COPY allowlist_addon.py /opt/agentcage/allowlist_addon.py
 # Apple's `container build` 0.5+ silently drops the contents of a COPY'd
 # directory — the target dir exists but is empty. Confirmed on macOS 26
 # with `container --version` 0.5.x; tracked alongside #120 follow-ups.
-RUN mkdir -p /opt/agentcage/transforms
+RUN mkdir -p /opt/agentcage/transforms /opt/agentcage/relays /opt/agentcage/inspectors
 ADD transforms.tar.gz /opt/agentcage/transforms/
+# Protocol relays (IMAP, SMTP) and the inspector base classes they
+# import. Same tarball workaround for the directory-COPY bug — see
+# the transforms ADD above. The mitmproxy script loader puts the
+# addon's directory on sys.path, so we put the relays + inspectors
+# packages NEXT to the addon so ``from relays import get`` and
+# ``from inspectors.base import ...`` both resolve from the same
+# import root the addon lives under.
+ADD relays.tar.gz /opt/agentcage/relays/
+ADD inspectors.tar.gz /opt/agentcage/inspectors/
 COPY cage-cmd.json /etc/agentcage/cage-cmd.json
 COPY allowlist.txt /etc/agentcage/allowlist.txt
 COPY dnsmasq.conf /etc/agentcage/dnsmasq.conf
 COPY secret_injection.json /etc/agentcage/secret_injection.json
+COPY protocol_relays.json /etc/agentcage/protocol_relays.json
 RUN chmod 0755 /opt/agentcage/supervisor
 
 # Supervisor runs as PID 1.

--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -29,6 +29,7 @@ changes. Empty allowlist means "block everything".
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -39,6 +40,7 @@ from mitmproxy import ctx, http
 
 ALLOWLIST_PATH = "/etc/agentcage/allowlist.txt"
 SECRET_INJECTION_PATH = "/etc/agentcage/secret_injection.json"
+PROTOCOL_RELAYS_PATH = "/etc/agentcage/protocol_relays.json"
 # Per-cage resolved-secret files; supervisor stage 35 re-stages from
 # the host-bind-mounted /run/agentcage/secrets to this acproxy-only path
 # (chown 200:200, mode 0400). The cage workload (uid 1000) cannot read
@@ -88,6 +90,26 @@ def _load_secret_injection_rules() -> list[dict]:
     """
     try:
         with open(SECRET_INJECTION_PATH) as f:
+            data = json.load(f)
+            return data if isinstance(data, list) else []
+    except (OSError, ValueError):
+        return []
+
+
+def _load_protocol_relays() -> list[dict]:
+    """Load the cage's ``protocol_relays`` list, baked in at build time.
+
+    Each entry is a YAML-parsed protocol_relays mapping with
+    ``name/type/listen/upstream/auth/policy`` keys. The actual
+    credential VALUES are NOT in this file (they live alongside
+    secret_injection secrets at /home/acproxy/secrets/<env> after
+    supervisor stage 35 re-stages them). The addon resolves them
+    in ``_seed_relay_secrets_env`` below before constructing each
+    relay so the relay's own ``_resolve_credential(scheme:VAR)``
+    can read them straight from ``os.environ``.
+    """
+    try:
+        with open(PROTOCOL_RELAYS_PATH) as f:
             data = json.load(f)
             return data if isinstance(data, list) else []
     except (OSError, ValueError):
@@ -181,6 +203,15 @@ class AllowlistAddon:
             )
         self._audit_fh = self._open_log(AUDIT_LOG_PATH)
         self._capture_fh = self._open_log(CAPTURE_PATH)
+
+        # Protocol relays (IMAP, SMTP, ...) — loaded here, instantiated
+        # in the ``running()`` hook once the mitmproxy asyncio loop is
+        # live. We can't start TCP listeners from __init__ because the
+        # loop may not exist yet (mitmproxy creates it during its own
+        # startup). The relay objects themselves live in
+        # ``self._relays`` so the ``done()`` hook can drain them.
+        self._relay_entries: list[dict] = _load_protocol_relays()
+        self._relays: list = []
 
     @staticmethod
     def _host_matches_inject_to(host: str, inject_to: list[str]) -> bool:
@@ -490,6 +521,201 @@ class AllowlistAddon:
             },
         }
         self._write(self._capture_fh, capture)
+
+    # ── Protocol relays (IMAP, SMTP, ...) ──────────────────
+
+    def _seed_relay_secrets_env(self, entry: dict) -> None:
+        """Populate ``os.environ`` with the relay's credential env vars
+        before constructing the relay class.
+
+        The relay's ``_resolve_credential("env:VAR")`` (and the equivalent
+        ``cmd:``/``systemd-creds:``/``podman:`` schemes — same code path)
+        simply reads ``os.environ[VAR]`` at instantiation time. On
+        apple-container the cleartext value lives in
+        ``/home/acproxy/secrets/<VAR>`` (re-staged by supervisor stage 35
+        from the host bind mount). We read each file once here and copy
+        it into the addon process's env so the relay's resolver works
+        with no patching.
+
+        The cage workload (uid 1000) never sees these env vars: they
+        are set on the mitmproxy process (uid 200) and are NOT among
+        the ``-e`` flags ``AppleContainerBackend.start()`` passes to
+        ``container run`` — those are filtered to only secret_injection
+        env names. Defense-in-depth: even ``container inspect <cage>``
+        won't show relay credentials in the env block.
+        """
+        auth = entry.get("auth") or {}
+        for key in ("user_source", "password_source"):
+            src = str(auth.get(key, "") or "")
+            scheme, _, var = src.partition(":")
+            if not var or scheme not in (
+                "env", "cmd", "systemd-creds", "podman", "",
+            ):
+                continue
+            if os.environ.get(var):
+                continue  # already set by container -e (legacy path)
+            secret_file = os.path.join(SECRETS_DIR, var)
+            try:
+                with open(secret_file) as f:
+                    value = f.read()
+            except OSError:
+                continue
+            if value:
+                os.environ[var] = value
+
+    def _start_relay(self, entry: dict) -> None:
+        """Instantiate one relay and schedule its ``start()`` on the
+        mitmproxy event loop. Surfaces failures to the audit log
+        instead of crashing the proxy.
+
+        The container backend's addon does the same dance in
+        ``_start_protocol_relays`` — we mirror that pattern so cages
+        get the same operator-visible diagnostics on either backend.
+        """
+        rname = entry.get("name", "?") if isinstance(entry, dict) else "?"
+        # Late import: ``relays.smtp`` pulls in ``inspectors.base`` at
+        # module load. Doing the import lazily keeps a config-less
+        # apple-container cage from paying the cost (and keeps the
+        # addon importable on the host for unit tests when the
+        # ``relays`` package isn't on sys.path).
+        try:
+            from relays import get as _get_relay
+            from relays._validate import validate_relay_entry
+        except ImportError as exc:
+            ctx.log.warn(
+                f"[agentcage] protocol_relays: cannot import relays "
+                f"package ({exc}); skipping {rname!r}"
+            )
+            self._audit({
+                "kind": "relay_import_failed",
+                "relay": rname,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+            return
+
+        try:
+            validate_relay_entry(entry)
+        except ValueError as exc:
+            ctx.log.warn(
+                f"[agentcage] protocol_relays: {rname!r} invalid: {exc}"
+            )
+            self._audit({
+                "kind": "relay_config_invalid",
+                "relay": rname,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+            return
+
+        rtype = entry["type"]
+        try:
+            cls = _get_relay(rtype)
+        except KeyError as exc:
+            ctx.log.warn(
+                f"[agentcage] protocol_relays: unknown type {exc}"
+            )
+            self._audit({
+                "kind": "relay_unknown_type",
+                "relay": rname,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+            return
+
+        self._seed_relay_secrets_env(entry)
+
+        try:
+            relay = cls(
+                entry,
+                audit_log=self._audit,
+                log_allowed=False,
+                # Inspector chain wiring is the next parity item; for now
+                # apple-container relays run with the per-protocol policy
+                # (recipient/sender allowlist, size + rate caps) but no
+                # body inspector chain. Tracked under issue #120.
+                inspectors=None,
+            )
+        except Exception as exc:
+            ctx.log.warn(
+                f"[agentcage] protocol_relays: {rname!r} init failed: {exc}"
+            )
+            self._audit({
+                "kind": "relay_init_failed",
+                "relay": rname,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+            return
+
+        try:
+            loop = asyncio.get_event_loop()
+            task = loop.create_task(relay.start())
+        except Exception as exc:
+            ctx.log.warn(
+                f"[agentcage] protocol_relays: {rname!r} schedule failed: "
+                f"{exc}"
+            )
+            self._audit({
+                "kind": "relay_start_failed",
+                "relay": rname,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+            return
+
+        def _on_done(t: "asyncio.Task", name: str = rname) -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is None:
+                return
+            ctx.log.error(
+                f"[agentcage] protocol_relays: {name!r} start failed: {exc}"
+            )
+            self._audit({
+                "kind": "relay_start_failed",
+                "relay": name,
+                "error": str(exc),
+                "source": "apple-container",
+            })
+
+        task.add_done_callback(_on_done)
+        self._relays.append(relay)
+        ctx.log.info(
+            f"[agentcage] protocol_relays: scheduled {rname!r} ({rtype})"
+        )
+
+    def running(self) -> None:
+        """mitmproxy lifecycle hook: called once the proxy is fully up.
+
+        We start protocol_relays listeners here (not in ``__init__``)
+        because relay TCP listeners need the asyncio loop that mitmproxy
+        creates during its own startup. Same hook the container backend
+        uses for the symmetric ``_start_protocol_relays`` call.
+        """
+        if not self._relay_entries:
+            return
+        for entry in self._relay_entries:
+            if not isinstance(entry, dict):
+                continue
+            self._start_relay(entry)
+
+    async def done(self) -> None:
+        """mitmproxy lifecycle hook: graceful shutdown.
+
+        ``SmtpRelay.stop()`` / ``ImapRelay.stop()`` cancel in-flight
+        client sessions so long-lived IDLE / DATA streams get a clean
+        protocol-level close (``* BYE`` for IMAP, ``421`` for SMTP)
+        instead of a TCP reset. Without this hook the careful shutdown
+        logic in each relay is bypassed when mitmproxy tears down.
+        """
+        relays = list(self._relays)
+        if not relays:
+            return
+        await asyncio.gather(
+            *[r.stop() for r in relays], return_exceptions=True
+        )
 
 
 addons = [AllowlistAddon()]

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -243,6 +243,29 @@ iptables -t nat -A OUTPUT -p tcp --dport 443 \
 iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport 8080 -j ACCEPT
 iptables -A OUTPUT -p udp -d 127.0.0.1 --dport 53 -j ACCEPT
 iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport 53 -j ACCEPT
+
+# Protocol relays (IMAP, SMTP) listen on cage-author-chosen ports inside
+# the same mitmproxy process (uid 200). The cage workload reaches them
+# over loopback — without an explicit ACCEPT per relay port the default
+# DROP policy would silently kill cage→relay connections. The relay
+# listens on whatever ``listen:`` says in cage.yaml; we read the JSON
+# the wrapper baked into the image and open one loopback ACCEPT per
+# unique destination port. jq is already required for stage 20.
+if [ -f /etc/agentcage/protocol_relays.json ]; then
+  RELAY_PORTS=$(jq -r '
+    .[]
+    | .listen // ""
+    | split(":")
+    | .[-1]
+    | select(test("^[0-9]+$"))
+  ' /etc/agentcage/protocol_relays.json 2>/dev/null \
+    | sort -u || true)
+  for port in ${RELAY_PORTS}; do
+    log "stage 80: allowing loopback access on protocol_relay port ${port}"
+    iptables -A OUTPUT -p tcp -d 127.0.0.1 --dport "${port}" -j ACCEPT \
+      || die "iptables protocol_relay loopback rule failed (port ${port})" 82
+  done
+fi
 # mitmproxy ↔ self (the addon talks to mitmproxy's own internals) and
 # dnsmasq ↔ self need full loopback; uid-owner ACCEPT rules below cover
 # that path because both run as their respective per-component uids.

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1614,3 +1614,439 @@ def test_response_redaction_skips_binary_body(tmp_path, monkeypatch):
     assert flow.response.content == binary
     # Header still got redacted.
     assert flow.response.headers["X-Trace"] == "echo {{AGENTCAGE_REDACT_SECRET}} back"
+
+
+# ---------------------------------------------------------------------------
+# protocol_relays (PR #160): SMTP/IMAP listeners on apple-container
+# ---------------------------------------------------------------------------
+
+
+def _smtp_relay_entry(name="primary-smtp", port=2525):
+    return {
+        "name": name,
+        "type": "smtp",
+        "listen": f"127.0.0.1:{port}",
+        "upstream": {
+            "host": "smtp.example.net",
+            "port": 587,
+            "tls": True,
+        },
+        "auth": {
+            "type": "smtp-plain",
+            "user_source": "env:AGENTCAGE_SMTP_USER",
+            "password_source": "env:AGENTCAGE_SMTP_PASSWORD",
+        },
+        "policy": {
+            "sender_allowlist": ["sender@local"],
+            "recipient_allowlist": {"domains": ["example.com"]},
+        },
+    }
+
+
+def test_stage_build_context_writes_protocol_relays_json(tmp_path):
+    """The cage's ``protocol_relays:`` list is baked into the wrapper image
+    so the in-cage addon can spawn listeners at mitmproxy startup. The
+    file must be JSON the addon's loader can read+parse — same shape as
+    secret_injection.json.
+    """
+    relays = [_smtp_relay_entry()]
+    ac_wrapper.stage_build_context(
+        tmp_path, ["sh"],
+        allowlist=["smtp.example.net"],
+        protocol_relays=relays,
+    )
+    pr = json.loads((tmp_path / "protocol_relays.json").read_text())
+    assert pr == relays
+    assert pr[0]["type"] == "smtp"
+    assert pr[0]["listen"] == "127.0.0.1:2525"
+
+
+def test_stage_build_context_empty_protocol_relays(tmp_path):
+    """No relays declared → empty list (NOT a missing file), so the
+    addon's loader can read unconditionally without a path check."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    assert (tmp_path / "protocol_relays.json").exists()
+    assert json.loads((tmp_path / "protocol_relays.json").read_text()) == []
+
+
+def test_stage_build_context_stages_relays_tarball(tmp_path):
+    """The ``relays`` package must be staged as a tarball so the in-cage
+    addon can ``from relays import get`` after ADD-extraction. Same
+    rationale as the transforms tarball — Apple's container build
+    silently drops the contents of a directory COPY."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    archive = tmp_path / "relays.tar.gz"
+    assert archive.exists()
+    import tarfile as _tf
+    with _tf.open(archive) as tar:
+        names = sorted(tar.getnames())
+    assert "__init__.py" in names
+    assert "smtp.py" in names
+    assert "imap.py" in names
+    assert "_validate.py" in names
+
+
+def test_stage_build_context_stages_inspectors_tarball(tmp_path):
+    """The ``relays.smtp`` module imports ``inspectors.base`` at module
+    load time — bundling the inspectors package satisfies that import
+    even though the apple-container addon currently passes
+    ``inspectors=None`` to relay constructors. Without this the addon
+    crashes at relay-import time the moment a cage declares
+    ``protocol_relays:``."""
+    ac_wrapper.stage_build_context(tmp_path, ["sh"], allowlist=["a.com"])
+    archive = tmp_path / "inspectors.tar.gz"
+    assert archive.exists()
+    import tarfile as _tf
+    with _tf.open(archive) as tar:
+        names = sorted(tar.getnames())
+    assert "__init__.py" in names
+    assert "base.py" in names
+    assert "util.py" in names
+
+
+def test_wrapper_containerfile_adds_relays_and_inspectors():
+    """The Containerfile must ADD relays.tar.gz + inspectors.tar.gz
+    next to the addon — mitmproxy's script loader puts the addon's
+    dir on sys.path, so the packages live at /opt/agentcage/{relays,
+    inspectors}/ for ``from relays import get`` to resolve."""
+    out = ac_wrapper.render_wrapper_containerfile(
+        "docker.io/library/alpine:3.20",
+        user_cmd=["sh", "-c", "echo hi"],
+    )
+    assert "ADD relays.tar.gz /opt/agentcage/relays/" in out
+    assert "ADD inspectors.tar.gz /opt/agentcage/inspectors/" in out
+    assert "COPY protocol_relays.json /etc/agentcage/protocol_relays.json" in out
+    # And we must NOT regress to the broken directory-COPY form.
+    assert "COPY relays /opt/agentcage/relays" not in out
+    assert "COPY inspectors /opt/agentcage/inspectors" not in out
+
+
+def test_backend_threads_protocol_relays_into_build_artifacts(
+    tmp_path, monkeypatch,
+):
+    """The apple-container backend must forward ``protocol_relays`` from
+    the parsed Config through to wrapper.build_wrapper. Catches the
+    silent-drop regression: rule loaded fine, image built fine, but
+    the cage saw no relays.json baked in."""
+    captured: dict = {}
+
+    def fake_build_wrapper(_name, _image, **kwargs):
+        captured["protocol_relays"] = kwargs.get("protocol_relays")
+        return "localhost/agentcage-apple-test:latest"
+
+    from agentcage.backends import apple_container as backend_mod
+    monkeypatch.setattr(
+        backend_mod.ac_wrapper, "build_wrapper", fake_build_wrapper,
+    )
+    monkeypatch.setattr(
+        ac_cli, "image_inspect",
+        lambda _img: {"config": {"cmd": ["/bin/sh"]}},
+    )
+    monkeypatch.setattr(
+        ac_cli, "run",
+        lambda *_a, **_kw: type(
+            "CP", (), {"returncode": 0, "stdout": "", "stderr": ""},
+        )(),
+    )
+
+    from agentcage.config import (
+        ProtocolRelay, RelayAuth, RelayPolicy,
+        RelayRecipientAllowlist, RelayUpstream,
+    )
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/test:latest"
+    cfg.container.command = ["/bin/sh"]
+    cfg.protocol_relays = [
+        ProtocolRelay(
+            name="primary",
+            type="smtp",
+            listen="127.0.0.1:2525",
+            upstream=RelayUpstream(
+                host="smtp.example.net", port=587, tls=True,
+            ),
+            auth=RelayAuth(
+                type="smtp-plain",
+                user_source="env:SMTP_USER",
+                password_source="env:SMTP_PASS",
+            ),
+            policy=RelayPolicy(
+                recipient_allowlist=RelayRecipientAllowlist(
+                    domains=["example.com"],
+                ),
+            ),
+        ),
+    ]
+    cfg.domains.allow = ["smtp.example.net"]
+
+    AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
+
+    relays = captured["protocol_relays"]
+    assert len(relays) == 1
+    assert relays[0]["name"] == "primary"
+    assert relays[0]["type"] == "smtp"
+    assert relays[0]["listen"] == "127.0.0.1:2525"
+    assert relays[0]["upstream"]["host"] == "smtp.example.net"
+    assert relays[0]["auth"]["user_source"] == "env:SMTP_USER"
+    # The policy must carry over so the in-cage addon can construct
+    # the same SmtpRelay state machine the container backend does.
+    assert relays[0]["policy"]["recipient_allowlist"]["domains"] == [
+        "example.com",
+    ]
+
+
+def test_backend_protocol_relay_envs_collected_into_unit_json(monkeypatch):
+    """``generate_units`` must capture every relay credential env name
+    so ``start()`` knows to read+stage the value into the per-cage
+    secrets dir. Crucially, these env names are NOT placed in
+    ``secret_envs`` — that list drives the ``-e PLACEHOLDER`` flag
+    set, and relay credentials must stay off the cage workload's env
+    block.
+    """
+    from agentcage.config import (
+        ProtocolRelay, RelayAuth, RelayPolicy,
+        RelayRecipientAllowlist, RelayUpstream,
+    )
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/test:latest"
+    cfg.protocol_relays = [
+        ProtocolRelay(
+            name="primary",
+            type="smtp",
+            listen="127.0.0.1:2525",
+            upstream=RelayUpstream(host="smtp.example.net", port=587),
+            auth=RelayAuth(
+                type="smtp-plain",
+                user_source="env:SMTP_USER",
+                password_source="env:SMTP_PASS",
+            ),
+            policy=RelayPolicy(
+                recipient_allowlist=RelayRecipientAllowlist(),
+            ),
+        ),
+    ]
+    cfg.domains.allow = ["smtp.example.net"]
+
+    units = AppleContainerBackend().generate_units(
+        cfg, "/dev/null", "/dev/null", "t",
+    )
+    meta = json.loads(units["t.json"])
+    assert sorted(meta["relay_secret_envs"]) == ["SMTP_PASS", "SMTP_USER"]
+    # Relay creds must NOT appear in secret_envs — start() uses that
+    # list to set `-e ENV={{PLACEHOLDER}}` on the cage workload, which
+    # is exactly what we DON'T want for relay credentials.
+    assert "SMTP_USER" not in meta["secret_envs"]
+    assert "SMTP_PASS" not in meta["secret_envs"]
+
+
+def test_addon_running_hook_spawns_relay(monkeypatch, tmp_path):
+    """End-to-end addon test: a protocol_relays entry in the JSON file
+    causes the addon's ``running()`` hook to dispatch through the
+    relays registry, instantiate the relay class, and schedule
+    ``start()`` on the asyncio loop. The relay's credential env vars
+    are seeded from the secrets dir before instantiation so the
+    relay's ``_resolve_credential`` succeeds.
+
+    Uses a fake relay registered in-process so we don't need a real
+    SMTP listener or network. The wiring is the load-bearing part —
+    the SMTP state machine is already covered in
+    tests/test_protocol_relays_smtp.py.
+    """
+    import asyncio
+    import importlib
+    import os
+    import sys
+
+    addon_dir = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "data" / "apple-container"
+    )
+    proxy_dir = addon_dir.parent / "proxy"
+    monkeypatch.syspath_prepend(str(addon_dir))
+    monkeypatch.syspath_prepend(str(proxy_dir))
+
+    # Pre-stage the relay credential in the secrets dir the addon
+    # reads from. The supervisor stage 35 normally does this from the
+    # host bind mount; for unit testing we just write the file.
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    (secrets_dir / "AGENTCAGE_RELAY_USER").write_text("relay-user")
+    (secrets_dir / "AGENTCAGE_RELAY_PASS").write_text("relay-pass")
+
+    relays_cfg = [{
+        "name": "test-relay",
+        # We use type "smtp" so structural validation passes, then
+        # swap the registry below to return a fake class. Using a made-up
+        # type here would be rejected by validate_relay_entry before
+        # the registry is even consulted.
+        "type": "smtp",
+        "listen": "127.0.0.1:25000",
+        "upstream": {"host": "smtp.example.net", "port": 587, "tls": True},
+        "auth": {
+            "type": "smtp-plain",
+            "user_source": "env:AGENTCAGE_RELAY_USER",
+            "password_source": "env:AGENTCAGE_RELAY_PASS",
+        },
+        "policy": {
+            "recipient_allowlist": {"domains": ["example.com"]},
+        },
+    }]
+    relays_path = tmp_path / "protocol_relays.json"
+    relays_path.write_text(json.dumps(relays_cfg))
+    (tmp_path / "allowlist.txt").write_text("smtp.example.net\n")
+    (tmp_path / "secret_injection.json").write_text("[]")
+
+    # Register a fake relay class on the shared registry so the addon's
+    # ``_get_relay`` lookup resolves without us needing a real SMTP
+    # listener. The fake records the kwargs it was called with and
+    # exposes start/stop coroutines.
+    import relays as _r  # noqa: WPS433  (test-only)
+    importlib.reload(_r)
+
+    constructed: list[dict] = []
+
+    class _FakeRelay:
+        def __init__(self, entry, *, audit_log, log_allowed, inspectors):
+            constructed.append({
+                "entry": entry,
+                "audit_log": audit_log,
+                "log_allowed": log_allowed,
+                "inspectors": inspectors,
+            })
+            self.started = False
+            self.stopped = False
+
+        async def start(self):
+            self.started = True
+
+        async def stop(self):
+            self.stopped = True
+
+    # Swap the smtp slot in the registry for our fake. The addon's
+    # ``_get_relay("smtp")`` looks up ``_REGISTRY["smtp"]`` first, so an
+    # explicit register() of the same name short-circuits ``_lazy_load``.
+    _r.register("smtp", _FakeRelay)
+
+    # Point the addon's module-level paths at our tmp files BEFORE import.
+    sys.modules.pop("allowlist_addon", None)
+    allowlist_addon = importlib.import_module("allowlist_addon")
+    allowlist_addon.SECRETS_DIR = str(secrets_dir)
+    allowlist_addon.SECRET_INJECTION_PATH = str(
+        tmp_path / "secret_injection.json"
+    )
+    allowlist_addon.ALLOWLIST_PATH = str(tmp_path / "allowlist.txt")
+    allowlist_addon.PROTOCOL_RELAYS_PATH = str(relays_path)
+    allowlist_addon.AUDIT_LOG_PATH = str(tmp_path / "audit.jsonl")
+    allowlist_addon.CAPTURE_PATH = str(tmp_path / "capture.jsonl")
+
+    addon = allowlist_addon.AllowlistAddon()
+    # Relay entries are loaded at __init__ but listeners are deferred
+    # to ``running()`` (need the mitmproxy asyncio loop).
+    assert len(addon._relay_entries) == 1
+    assert addon._relays == []
+
+    # Drive the running() hook on a real loop and let the start task run.
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        addon.running()
+        # One tick to let the scheduled task progress.
+        loop.run_until_complete(asyncio.sleep(0))
+    finally:
+        loop.run_until_complete(addon.done())
+        loop.close()
+        asyncio.set_event_loop(None)
+
+    assert len(constructed) == 1
+    record = constructed[0]
+    # The relay constructor was called with the entry from the JSON
+    # plus our addon's audit sink — so SMTP audit records land in the
+    # same audit.jsonl as HTTP allow/block decisions.
+    assert record["entry"]["name"] == "test-relay"
+    assert callable(record["audit_log"])
+    # ``inspectors=None`` is the v1 wiring; tracked in #120.
+    assert record["inspectors"] is None
+    # Credentials must have been seeded into os.environ before
+    # construction — that's the apple-container-specific glue that
+    # lets the relay's own ``_resolve_credential("env:VAR")`` work
+    # against the bind-mounted secrets file.
+    assert os.environ.get("AGENTCAGE_RELAY_USER") == "relay-user"
+    assert os.environ.get("AGENTCAGE_RELAY_PASS") == "relay-pass"
+    # The relay was started and then stopped (done() drains).
+    assert len(addon._relays) == 1
+    relay_obj = addon._relays[0]
+    assert relay_obj.started is True
+    assert relay_obj.stopped is True
+
+
+def test_addon_running_hook_no_relays_is_noop(monkeypatch, tmp_path):
+    """A cage with no ``protocol_relays:`` must not touch the relays
+    package at all — keeps existing apple-container cages from paying
+    the cost of an unnecessary import and avoids spurious failures on
+    import errors when no relay was ever configured."""
+    addon_mod = _load_addon_module()
+    monkeypatch.setattr(
+        addon_mod, "PROTOCOL_RELAYS_PATH", str(tmp_path / "no-such-file.json"),
+    )
+    monkeypatch.setattr(
+        addon_mod, "ALLOWLIST_PATH", str(tmp_path / "allowlist.txt"),
+    )
+    monkeypatch.setattr(
+        addon_mod, "SECRET_INJECTION_PATH",
+        str(tmp_path / "secret_injection.json"),
+    )
+    (tmp_path / "allowlist.txt").write_text("a.com\n")
+    (tmp_path / "secret_injection.json").write_text("[]")
+    addon = addon_mod.AllowlistAddon()
+    assert addon._relay_entries == []
+    addon.running()  # should be a no-op
+    assert addon._relays == []
+
+
+def test_validate_config_protocol_relays_on_apple_container_no_warning():
+    """A cage.yaml with ``protocol_relays:`` on apple-container must NOT
+    trigger any silent-drop warning — relays are wired now. (We never
+    had an explicit warning for this, but the test pins the contract
+    in case someone adds one later.)
+
+    Construct the Config directly so the test runs on any host (the
+    platform-gated isolation acceptance is exercised elsewhere).
+    """
+    from agentcage.config import (
+        ProtocolRelay, RelayAuth, RelayPolicy,
+        RelayRecipientAllowlist, RelayUpstream,
+    )
+    # Patch the platform check so validate_config accepts
+    # isolation="apple-container" off-Mac.
+    with patch.object(platform, "system", return_value="Darwin"), \
+            patch.object(platform, "machine", return_value="arm64"), \
+            patch.object(
+                platform, "mac_ver",
+                return_value=("26.0", ("", "", ""), ""),
+            ):
+        cfg = Config(name="relays-cage", isolation="apple-container")
+        cfg.container.image = "ubuntu:24.04"
+        cfg.domains.allow = ["smtp.example.net"]
+        cfg.ports.tcp.passthrough = [2525]
+        cfg.protocol_relays = [
+            ProtocolRelay(
+                name="primary",
+                type="smtp",
+                listen="127.0.0.1:2525",
+                upstream=RelayUpstream(
+                    host="smtp.example.net", port=587, tls=True,
+                ),
+                auth=RelayAuth(
+                    type="smtp-plain",
+                    user_source="env:SMTP_USER",
+                    password_source="env:SMTP_PASS",
+                ),
+                policy=RelayPolicy(
+                    recipient_allowlist=RelayRecipientAllowlist(
+                        domains=["example.com"],
+                    ),
+                ),
+            ),
+        ]
+        warnings = validate_config(cfg)
+    relay_warnings = [w for w in warnings if "protocol_relays" in w]
+    assert relay_warnings == []

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Pre-this-PR, `protocol_relays:` entries (IMAP, SMTP) on apple-container parsed cleanly but spawned no listeners — outbound mail just hung. The wrapper now bundles the shared `data/proxy/{relays,inspectors}` packages + `protocol_relays.json`, the addon's `running()` hook dispatches each entry through the same registry the container backend uses, and supervisor stage 80 opens per-relay-port loopback ACCEPTs.
- Relay credentials take the hardened path from #158: written to the per-cage secrets bind mount, re-staged for uid 200 by supervisor stage 35, read by the addon at relay-start time, and **never** passed as `-e` flags — `container inspect` and the cage workload's `/proc/self/environ` stay clean.
- Verified end-to-end on a live Mac: cage `ubuntu-relay` ran a full EHLO → MAIL FROM → RCPT TO transaction over `127.0.0.1:2525` with recipient_allowlist enforcement; the 550 rejection landed in `audit.jsonl` as `smtp_command blocked`.

Closes the `protocol_relays:` gap from `docs/apple-container.md`. Inspector-chain wiring on relay DATA payloads is the next parity item under #120.

## Test plan

- [x] `uv run pytest tests/` — 1473 passed (10 new tests covering bundle staging, Containerfile ADD, backend threading, addon `running()` lifecycle wiring, no-relays no-op, and validate_config silent-drop pin).
- [x] End-to-end on live Mac (cage `ubuntu-relay`, ubuntu:24.04 base): supervisor logs the per-port iptables rule, addon logs `scheduled 'primary-smtp' (smtp)`, SMTP relay logs its listener at `127.0.0.1:2525 -> smtp.example.net:587`, bash `/dev/tcp` client drives EHLO/MAIL/RCPT/QUIT, `audit.jsonl` records the 550 for the out-of-allowlist recipient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)