### PR TITLE
fix(apple-container): cage exec defaults to uid 1000 (drop root by default)

### DIFF
--- a/docs/apple-container.md
+++ b/docs/apple-container.md
@@ -92,7 +92,7 @@ All cage subcommands work the same way they do on container / vm:
 | Command | Behavior on apple-container |
 |---|---|
 | `cage create / start / stop / restart / destroy` | Routes through `container` CLI; per-cage state in `~/.config/agentcage/apple-container/<cage>/` |
-| `cage exec / shell` | `container exec [-it] <cage> <cmd>` — see [`cage exec` runs as root](#cage-exec-runs-as-root-not-uid-1000) below |
+| `cage exec / shell` | `container exec [-it] -u 1000 <cage> <cmd>` — runs as the cage workload's uid 1000 user by default (matches the workload's capability set: no CAP_NET_ADMIN / CAP_DAC_OVERRIDE). Pass `--as-root` for the operator-debug path. See [`cage exec` default-drop](#cage-exec-defaults-to-uid-1000-not-root) below |
 | `cage logs` | `container logs [-f] <cage>` — combined supervisor / proxy / dns / workload stream |
 | `cage audit` | Tails `<state>/<cage>/logs/audit.jsonl` (bind-mounted from the microVM); same filter machinery as container / vm. `--since` is post-parse only (see [Quirks](#quirks-worth-knowing)) |
 | `cage har` | Reads `<state>/<cage>/logs/capture.jsonl` and renders HAR 1.2 JSON |
@@ -237,18 +237,25 @@ host environment before `cage start`:
 
 Behaviors that are correct-by-design but surprising the first time you hit them.
 
-### `cage exec` runs as root, not uid 1000
+### `cage exec` defaults to uid 1000, not root
 
 ```
 $ agentcage cage exec ubuntu02 -- id
-uid=0(root) gid=0(root) groups=0(root)
+uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu)
 ```
 
-The supervisor's `capsh --user=...` privilege drop applies to the **workload process tree** (PID 1 = your `cage.yaml` `command`). `container exec` enters via Apple's runtime, which respects the image's default `USER` (root on debian/ubuntu/node bases).
+The CLI passes `-u 1000` to `container exec` by default, so the exec session runs with the same uid as the cage workload (PID 1 after the supervisor's stage-90 privilege drop). The workload's empty cap set applies: no `CAP_NET_ADMIN` (can't `iptables -F` and bypass the egress filter), no `CAP_DAC_OVERRIDE` (can't read `/home/acproxy/secrets/*` past mode 0400).
 
-The egress filter accommodates this: the NAT REDIRECT rule excludes uid 200 (mitmproxy) and uid 201 (dnsmasq) instead of explicitly matching uid 1000, so root-from-`cage exec` ALSO flows through the proxy + allowlist. Allowlist behavior is identical regardless of which uid initiated the request.
+For operator-debug scenarios that genuinely need root (running `apt-get install` to add a package, inspecting iptables rules, reading dnsmasq's own log files owned by uid 201), use `--as-root`:
 
-Caveat: root via `cage exec` retains the container's CAP_NET_ADMIN. So `cage exec ... -- iptables -F` would work and bypass the egress filter. The threat model treats the operator's interactive sessions as trusted; only the workload is sandboxed.
+```
+$ agentcage cage exec ubuntu02 --as-root -- apt-get install -y htop
+$ agentcage cage shell ubuntu02 --as-root
+```
+
+Threat model: the cage workload (the AI agent code) is untrusted and runs as uid 1000 with empty caps + hidepid + NoNewPrivs. Interactive operator sessions are trusted, but the default-drop keeps the agent code from masquerading as root through a `cage exec` invocation — for example, a malicious cage workload that somehow tricks the operator into running `agentcage cage exec <cage> -- malicious-binary` no longer gets root + CAP_NET_ADMIN automatically; the operator must explicitly type `--as-root` for that.
+
+**Egress filter scope.** The NAT REDIRECT rule excludes uid 200 (mitmproxy) and uid 201 (dnsmasq) instead of explicitly matching uid 1000, so requests from BOTH the workload (uid 1000) AND root-via-`cage exec --as-root` flow through the proxy + allowlist. Allowlist behavior is identical regardless of which uid initiated the request — only the cap set (which lets you re-write rules) differs.
 
 ### virtiofs locks file ownership to the host user
 
@@ -363,5 +370,5 @@ The only places the cleartext value lives are: the host shell environment of who
 
 ### Caveats
 
-- **`cage exec` runs as root.** As documented in [Quirks worth knowing](#quirks-worth-knowing), `agentcage cage exec <cage>` enters the cage as the image's default USER (root on most bases). Root in the cage CAN read `/home/acproxy/secrets/*` regardless of mode (CAP_DAC_OVERRIDE). This is the operator-debug session and is by design trusted; the threat model treats only the workload as untrusted.
+- **`cage exec` defaults to uid 1000** (the cage workload's user) on 0.21.2+. The exec session inherits the workload's empty cap set so it cannot read `/home/acproxy/secrets/*` past mode 0400, nor flush the egress filter. For operator-debug needs that require root, pass `--as-root` explicitly. Pre-0.21.2, `cage exec` defaulted to root — that was the documented quirk and is now closed.
 - **Backward compat.** If you run a fresh agentcage 0.21.1+ against a cage last started under 0.21.0 (unit JSON predates `secret_env_placeholders`), `start()` falls back to the old `-e NAME=value` cleartext-env delivery so the cage keeps starting without a `cage update`. Run `cage update <name>` to migrate to the hardened model.

--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -83,12 +83,21 @@ class Backend(Protocol):
         cmd: list[str],
         *,
         interactive: bool = False,
+        as_root: bool = False,
     ) -> list[str]:
         """Argv to exec a command inside the cage's ``service`` component.
 
         ``service`` is one of ``service_names(name)`` (typically ``cage`` /
         ``proxy`` / ``dns``). ``cmd`` is the user's command vector; the
         backend prepends its own runner (e.g. ``podman exec [-it] <c> <cmd>``).
+
+        ``as_root=False`` (default) tells the backend to drop the exec
+        session to the cage workload's unprivileged uid (1000) so an
+        interactive ``cage exec`` cannot bypass the egress filter or read
+        proxy-internal state. Implementations that already drop privileges
+        elsewhere (container / vm — their per-service Quadlets already run
+        unprivileged) may ignore the kwarg. ``as_root=True`` is the opt-in
+        operator-debug path (CLI: ``--as-root``).
         """
         ...
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -570,12 +570,28 @@ class AppleContainerBackend:
         cmd: list[str],
         *,
         interactive: bool = False,
+        as_root: bool = False,
     ) -> list[str]:
-        """`container exec [-it] <name> <cmd>`.
+        """`container exec [-it] [-u <uid-1000-user>] <name> <cmd>`.
 
         proxy / dns run in-process inside the cage microVM (supervised),
         not as separate Apple containers, so they aren't addressable by
         targeted exec. Reject those service names with a clear message.
+
+        Privilege model — `as_root=False` (default) explicitly downgrades
+        the exec session to uid 1000 (the cage workload's user) so an
+        interactive `agentcage cage exec <cage> -- <cmd>` runs <cmd>
+        with the same caps the workload has: empty Eff/Prm/Inh/Bnd set,
+        NoNewPrivs already set on the container, and no CAP_NET_ADMIN /
+        CAP_DAC_OVERRIDE that would let the exec'd process flush
+        iptables or read /home/acproxy/secrets/. Apple's wrapper image
+        ends with `USER root` (so the supervisor can boot as PID 1 and
+        do stage-10..80 setup as root), which means without this `-u`
+        override, `container exec` would default to root. Pre-this-fix,
+        running ``claude`` via ``cage exec claude01 -- claude`` had
+        ``claude`` running as root with CAP_NET_ADMIN → could bypass
+        the entire egress filter. Operators who genuinely need the
+        root-shell debug path pass ``as_root=True`` (CLI: ``--as-root``).
         """
         from agentcage.backend import BackendUnsupported
         if service != "cage":
@@ -591,6 +607,14 @@ class AppleContainerBackend:
                 "https://github.com/apple/container/releases"
             )
         flags = ["-it"] if interactive else []
+        # Default: run as uid 1000 (numeric — the supervisor's
+        # CAGE_USER resolution at stage 90 has already created the
+        # right name/uid mapping inside the image). When `as_root=True`,
+        # let the image's USER directive apply, which on the wrapper
+        # is `root` so the operator gets a privileged shell — only for
+        # explicit debugging.
+        if not as_root:
+            flags += ["-u", "1000"]
         return [binary, "exec", *flags, name, *cmd]
 
     def logs_argv(

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -199,8 +199,15 @@ class ContainerBackend:
         cmd: list[str],
         *,
         interactive: bool = False,
+        as_root: bool = False,  # noqa: ARG002 — container Quadlets already unprivileged
     ) -> list[str]:
-        """``podman exec [-it] <name>-<service> <cmd>``."""
+        """``podman exec [-it] <name>-<service> <cmd>``.
+
+        ``as_root`` is ignored — the per-service container is already
+        running as its configured unprivileged user via Quadlet, and
+        ``podman exec`` defaults to the container's USER. Operators who
+        need root use ``podman exec -u 0 ...`` directly.
+        """
         flags = ["-it"] if interactive else []
         return ["podman", "exec", *flags, f"{name}-{service}", *cmd]
 

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -520,6 +520,7 @@ class VmBackend:
         cmd: list[str],
         *,
         interactive: bool = False,
+        as_root: bool = False,  # noqa: ARG002 — vm Quadlets already unprivileged
     ) -> list[str]:
         inst = self._instance(name)
         flags = ["-it"] if interactive else []

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1586,8 +1586,12 @@ def _logs_apple_container(name, services, lines, no_follow, min_level=None):  # 
 @click.option("-s", "--service", default="cage",
               type=click.Choice(["cage", "proxy", "dns"]),
               help="Container service to exec into.", show_default=True)
+@click.option("--as-root", is_flag=True,
+              help="Run the command as root inside the cage (debug only — "
+                   "bypasses the cage's egress filter via CAP_NET_ADMIN). "
+                   "Default is the cage workload's uid 1000 user.")
 @click.argument("command", nargs=-1, type=click.UNPROCESSED, required=True)
-def cage_exec(name: str, service: str, command: tuple[str, ...]):
+def cage_exec(name: str, service: str, command: tuple[str, ...], as_root: bool):
     """Run a command inside a cage container.
 
     \b
@@ -1611,12 +1615,21 @@ def cage_exec(name: str, service: str, command: tuple[str, ...]):
 
     # Dispatch via Backend.exec_argv (lifted onto the protocol in PR-8).
     # Each backend returns the argv that runs the command inside the
-    # cage's <service>; the CLI owns the process control.
+    # cage's <service>; the CLI owns the process control. The `as_root`
+    # kwarg is honored by backends that need to gate root vs unprivileged
+    # exec sessions (apple-container in particular — pre-this-fix every
+    # cage exec was root because Apple's runtime respects the wrapper
+    # image's USER directive, which is root so the supervisor can boot;
+    # without an explicit -u override, claude / agent code ran as root
+    # with CAP_NET_ADMIN). container / vm ignore the kwarg — their proxy
+    # / dns / cage units already drop privileges per Quadlet.
     from agentcage.backend import BackendUnsupported
     backend = get_backend(cfg)
     try:
         argv = backend.exec_argv(
-            name, service, cmd, interactive=sys.stdin.isatty(),
+            name, service, cmd,
+            interactive=sys.stdin.isatty(),
+            as_root=as_root,
         )
     except BackendUnsupported as e:
         click.echo(f"error: {e}", err=True)
@@ -1639,7 +1652,11 @@ def cage_exec(name: str, service: str, command: tuple[str, ...]):
 @click.option("-s", "--service", default="cage",
               type=click.Choice(["cage", "proxy", "dns"]),
               help="Container service to shell into.", show_default=True)
-def cage_shell(name: str, service: str):
+@click.option("--as-root", is_flag=True,
+              help="Open the shell as root (debug only — bypasses the "
+                   "cage's egress filter via CAP_NET_ADMIN). Default is "
+                   "the cage workload's uid 1000 user.")
+def cage_shell(name: str, service: str, as_root: bool):
     """Open an interactive shell in a cage container."""
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist", err=True)
@@ -1676,7 +1693,14 @@ def cage_shell(name: str, service: str):
                 err=True,
             )
             sys.exit(1)
-        # Auto-detect bash, fall back to sh.
+        # Same privilege model as cage_exec: default to uid 1000 (the
+        # cage workload's user) so an operator shell can't bypass the
+        # egress filter or read /home/acproxy/secrets/. --as-root opts
+        # back into the root-shell debug path. The shell-detection probe
+        # below runs as root so it can `test -x` files the cage user
+        # might not have read on; the resulting shell exec uses the
+        # downgraded uid via `-u 1000`.
+        user_flags = [] if as_root else ["-u", "1000"]
         for shell in ("/bin/bash", "/bin/sh"):
             result = subprocess.run(
                 [binary, "exec", name, "test", "-x", shell],
@@ -1684,9 +1708,11 @@ def cage_shell(name: str, service: str):
             )
             if result.returncode == 0:
                 exec_flags = ["-it"] if sys.stdin.isatty() else []
-                os.execvp(binary, [binary, "exec", *exec_flags, name, shell])
+                os.execvp(binary, [binary, "exec", *user_flags, *exec_flags,
+                                   name, shell])
         exec_flags = ["-it"] if sys.stdin.isatty() else []
-        os.execvp(binary, [binary, "exec", *exec_flags, name, "/bin/sh"])
+        os.execvp(binary, [binary, "exec", *user_flags, *exec_flags,
+                           name, "/bin/sh"])
 
     container = f"{name}-{service}"
     # Auto-detect bash or fall back to sh

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -42,19 +42,53 @@ class TestCageExecAppleContainer:
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_calls_container_exec(self, mock_state, mock_execvp, mock_binary):
-        """exec on apple-container goes through `container exec`, not podman."""
+    def test_exec_defaults_to_uid_1000(
+        self, mock_state, mock_execvp, mock_binary,
+    ):
+        """SECURITY: exec on apple-container defaults to `-u 1000` (the
+        cage workload's user) so an interactive `cage exec <cage> --
+        claude` runs claude with the workload's empty cap set — NOT
+        with the wrapper image's root + CAP_NET_ADMIN, which would
+        let claude `iptables -F` and bypass the egress filter, or
+        `cat /home/acproxy/secrets/*` via CAP_DAC_OVERRIDE.
+
+        Pre-this-fix the exec ran as root by default (Apple's
+        container exec respects the image USER which is `root` on
+        the wrapper). This regression test pins the secure default."""
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
 
         _runner().invoke(main, ["cage", "exec", "demo", "--", "ls", "-la"])
 
-        # Routed through the apple `container` CLI on the resolved path.
+        # Routed through the apple `container` CLI WITH `-u 1000`.
         mock_execvp.assert_called_once_with(
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "demo", "ls", "-la"],
+            ["/usr/local/bin/container", "exec", "-u", "1000",
+             "demo", "ls", "-la"],
         )
+
+    @patch("agentcage.apple_container.cli.container_binary")
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_exec_as_root_opts_back_to_root(
+        self, mock_state, mock_execvp, mock_binary,
+    ):
+        """`--as-root` preserves the operator-debug path: drops the
+        `-u 1000` override so the exec session inherits the wrapper's
+        USER (root). For one-off ops needs (`apt-get install`, etc.)."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("apple-container")
+        mock_binary.return_value = "/usr/local/bin/container"
+
+        _runner().invoke(
+            main, ["cage", "exec", "demo", "--as-root", "--", "iptables", "-L"],
+        )
+
+        argv = mock_execvp.call_args.args[1]
+        assert "-u" not in argv
+        assert "1000" not in argv
+        assert "iptables" in argv
 
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
@@ -120,14 +154,14 @@ class TestCageShellAppleContainer:
         assert first_probe.args[0] == [
             "/usr/local/bin/container", "exec", "demo", "test", "-x", "/bin/bash",
         ]
-        # And the *first* execvp call is the bash that probed OK.
-        # (Without a real exec, control falls through to a host-podman
-        # fallback in container mode — but on apple-container we never
-        # reach that fallthrough; first call must already be /bin/bash.)
+        # And the *first* execvp call is the bash that probed OK,
+        # WITH `-u 1000` (default privilege drop — see cage_exec tests
+        # for the security rationale).
         first_exec = mock_execvp.call_args_list[0]
         assert first_exec.args == (
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "demo", "/bin/bash"],
+            ["/usr/local/bin/container", "exec", "-u", "1000",
+             "demo", "/bin/bash"],
         )
 
     @patch("agentcage.apple_container.cli.container_binary")
@@ -155,7 +189,8 @@ class TestCageShellAppleContainer:
         first_exec = mock_execvp.call_args_list[0]
         assert first_exec.args == (
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "demo", "/bin/sh"],
+            ["/usr/local/bin/container", "exec", "-u", "1000",
+             "demo", "/bin/sh"],
         )
 
 


### PR DESCRIPTION
## Security fix

\`agentcage cage exec <cage> -- <cmd>\` on apple-container ran <cmd> as **root**. The wrapper image's USER is \`root\` (so the supervisor can boot with CAP_SYS_ADMIN), and \`container exec\` respects the image USER. So the documented \`agentcage cage exec claude01 -- claude\` invocation had claude running as root with:

- **CAP_NET_ADMIN** → can \`iptables -F\` and bypass the egress filter
- **CAP_DAC_OVERRIDE** → can read \`/home/acproxy/secrets/*\` past mode 0400

That defeats the threat model: the workload process tree IS uid 1000 with empty caps, but the operator-debug exec was a root shortcut around the whole thing. **Any malicious agent that gets the operator to run a binary via \`cage exec\` got automatic root + full caps.**

## Fix

\`Backend.exec_argv\` for apple-container passes \`-u 1000\` by default. Operators who need root pass \`--as-root\` (same flag added to \`cage shell\`).

Backward compat: the protocol method gains a keyword-only \`as_root\` (default False). container / vm backends accept + ignore it — their Quadlets already run unprivileged.

## Test plan

- [x] 2 new tests in \`TestCageExecAppleContainer\` (default uid 1000, --as-root opt-in)
- [x] cage_shell tests updated similarly
- [x] All 93 apple-container unit + CLI tests pass
- [x] Live Mac verification on a fresh claude-code cage:
  - default \`cage exec cc01 -- id\` → \`uid=1000(node)\` (was root)
  - default \`cage exec cc01 -- iptables -F\` → permission denied
  - \`cage exec cc01 --as-root -- id\` → \`uid=0(root)\` (opt-in works)
  - \`cage exec cc01 --as-root -- iptables -F\` → succeeds (operator path works)

## Docs

The "cage exec runs as root" quirk section in \`docs/apple-container.md\` is flipped to "defaults to uid 1000" with the security rationale + --as-root path. Per-command behavior table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)