### PR TITLE
fix(apple-container): cage exec wraps in capsh — NoNewPrivs + drop=all

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -689,28 +689,46 @@ class AppleContainerBackend:
         interactive: bool = False,
         as_root: bool = False,
     ) -> list[str]:
-        """`container exec [-it] [-u <uid-1000-user>] <name> <cmd>`.
+        """`container exec [-it] -u 0 <cage> -- capsh ... -- -c "exec <cmd>"`.
 
         proxy / dns run in-process inside the cage microVM (supervised),
-        not as separate Apple containers, so they aren't addressable by
-        targeted exec. Reject those service names with a clear message.
+        not as separate Apple containers. Reject those service names.
 
-        Privilege model — `as_root=False` (default) explicitly downgrades
-        the exec session to uid 1000 (the cage workload's user) so an
-        interactive `agentcage cage exec <cage> -- <cmd>` runs <cmd>
-        with the same caps the workload has: empty Eff/Prm/Inh/Bnd set,
-        NoNewPrivs already set on the container, and no CAP_NET_ADMIN /
-        CAP_DAC_OVERRIDE that would let the exec'd process flush
-        iptables or read /home/acproxy/secrets/. Apple's wrapper image
-        ends with `USER root` (so the supervisor can boot as PID 1 and
-        do stage-10..80 setup as root), which means without this `-u`
-        override, `container exec` would default to root. Pre-this-fix,
-        running ``claude`` via ``cage exec claude01 -- claude`` had
-        ``claude`` running as root with CAP_NET_ADMIN → could bypass
-        the entire egress filter. Operators who genuinely need the
-        root-shell debug path pass ``as_root=True`` (CLI: ``--as-root``).
+        Privilege model — `as_root=False` (default) execs the user's
+        command via capsh with the same primitive the supervisor uses
+        at stage 90:
+
+            capsh --no-new-privs --drop=all --user=1000 --shell=/bin/sh
+                  -- -c "exec <user-cmd>"
+
+        That gives the exec session:
+
+          1. uid 1000 — same as the cage workload
+          2. CapEff/Prm/Inh/Bnd all empty — drop=all clears CapBnd
+             BEFORE the user switch (uid 0→1000 clears the rest)
+          3. NoNewPrivs=1 — the kernel refuses to grant caps via
+             setuid binaries, even though the cage image still ships
+             /usr/bin/su, /usr/bin/mount, etc. as 4755-mode
+          4. inherits the proxy/dns/secrets isolation the workload has
+
+        Without (2)+(3), an earlier-fix `-u 1000` alone left CapBnd
+        non-empty (a82435fb = cap_net_admin + cap_sys_admin + the
+        default container set) AND NoNewPrivs=0, so a setuid-root
+        binary inside the cage could re-acquire caps and `iptables -F`
+        the egress filter. capsh closes the door.
+
+        Apple's `container` CLI doesn't support `--security-opt
+        no-new-privileges`, so the only way to set NoNewPrivs on the
+        exec session is via capsh/prctl from inside. capsh ships as
+        part of libcap2-bin in the wrapper image (installed at
+        Containerfile build for the supervisor's own stage-90 use).
+
+        `as_root=True` bypasses capsh entirely: the operator gets a
+        root shell with the container's full cap set. Only for explicit
+        debugging.
         """
         from agentcage.backend import BackendUnsupported
+        import shlex as _shlex
         if service != "cage":
             raise BackendUnsupported(
                 f"'cage exec --service {service}' is not yet supported on "
@@ -724,15 +742,35 @@ class AppleContainerBackend:
                 "https://github.com/apple/container/releases"
             )
         flags = ["-it"] if interactive else []
-        # Default: run as uid 1000 (numeric — the supervisor's
-        # CAGE_USER resolution at stage 90 has already created the
-        # right name/uid mapping inside the image). When `as_root=True`,
-        # let the image's USER directive apply, which on the wrapper
-        # is `root` so the operator gets a privileged shell — only for
-        # explicit debugging.
-        if not as_root:
-            flags += ["-u", "1000"]
-        return [binary, "exec", *flags, name, *cmd]
+        if as_root:
+            # Operator debug — pass through to the image's USER (root
+            # on the wrapper). Skips capsh entirely so apt-get install
+            # etc. work for the operator.
+            return [binary, "exec", *flags, name, *cmd]
+        # Secure default — invoke capsh as root so prctl(PR_SET_NO_NEW_PRIVS)
+        # is allowed, then capsh drops caps + setuid's to the uid-1000
+        # user + execs the user's command via sh -c so shell
+        # metacharacters work.
+        #
+        # capsh's `--user=` resolves by NAME via getpwnam (it does NOT
+        # accept a numeric uid — `--user=1000` errors with "User [1000]
+        # not known"). The uid-1000 user's name varies by base image:
+        # `ubuntu` on ubuntu:24.04, `node` on node:*, `claude` on
+        # claude-code, `cage` on bases without a uid-1000 user (the
+        # Containerfile.wrapper.j2 useradd fallback). Resolve at
+        # exec time via a shell `getent` so we don't have to teach the
+        # CLI about every base image's user name. Same trick the
+        # supervisor uses at stage 90 (PR #140).
+        inner = (
+            "CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && "
+            "exec capsh --no-new-privs --drop=all "
+            "--user=\"$CAGE_USER\" --shell=/bin/sh "
+            "-- -c " + _shlex.quote("exec " + _shlex.join(cmd))
+        )
+        return [
+            binary, "exec", "-u", "0", *flags, name,
+            "/bin/sh", "-c", inner,
+        ]
 
     def logs_argv(
         self,

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1693,26 +1693,42 @@ def cage_shell(name: str, service: str, as_root: bool):
                 err=True,
             )
             sys.exit(1)
-        # Same privilege model as cage_exec: default to uid 1000 (the
-        # cage workload's user) so an operator shell can't bypass the
-        # egress filter or read /home/acproxy/secrets/. --as-root opts
-        # back into the root-shell debug path. The shell-detection probe
-        # below runs as root so it can `test -x` files the cage user
-        # might not have read on; the resulting shell exec uses the
-        # downgraded uid via `-u 1000`.
-        user_flags = [] if as_root else ["-u", "1000"]
+        # Probes run as root so `test -x` can read setuid files that
+        # uid 1000 might not.
         for shell in ("/bin/bash", "/bin/sh"):
             result = subprocess.run(
                 [binary, "exec", name, "test", "-x", shell],
                 capture_output=True,
             )
             if result.returncode == 0:
-                exec_flags = ["-it"] if sys.stdin.isatty() else []
-                os.execvp(binary, [binary, "exec", *user_flags, *exec_flags,
-                                   name, shell])
+                chosen_shell = shell
+                break
+        else:
+            chosen_shell = "/bin/sh"
         exec_flags = ["-it"] if sys.stdin.isatty() else []
-        os.execvp(binary, [binary, "exec", *user_flags, *exec_flags,
-                           name, "/bin/sh"])
+        if as_root:
+            # Operator debug path — image's USER (root on wrapper),
+            # full cap set, NoNewPrivs=0. For apt-get install etc.
+            os.execvp(binary, [binary, "exec", *exec_flags, name, chosen_shell])
+        # Secure default — wrap in capsh exactly like the supervisor's
+        # stage-90 privilege drop: NoNewPrivs=1 + drop=all (CapBnd=0)
+        # + setuid to the uid-1000 user (resolved by name via getent;
+        # capsh --user= takes a name, not a numeric uid). Closes the
+        # setuid-binary-re-acquire-caps escalation that a plain `-u
+        # 1000` would leave open (cage ships /usr/bin/su,
+        # /usr/bin/mount, etc. setuid-root; without NoNewPrivs=1 a
+        # kernel-side re-grant of CapBnd via setuid is the documented
+        # escape path).
+        inner = (
+            "CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && "
+            "exec capsh --no-new-privs --drop=all "
+            "--user=\"$CAGE_USER\" --shell=/bin/sh "
+            f"-- -c 'exec {chosen_shell}'"
+        )
+        os.execvp(binary, [
+            binary, "exec", "-u", "0", *exec_flags, name,
+            "/bin/sh", "-c", inner,
+        ])
 
     container = f"{name}-{service}"
     # Auto-detect bash or fall back to sh

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -42,41 +42,58 @@ class TestCageExecAppleContainer:
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_defaults_to_uid_1000(
+    def test_exec_wraps_in_capsh_for_nonewprivs_and_drop_all(
         self, mock_state, mock_execvp, mock_binary,
     ):
-        """SECURITY: exec on apple-container defaults to `-u 1000` (the
-        cage workload's user) so an interactive `cage exec <cage> --
-        claude` runs claude with the workload's empty cap set — NOT
-        with the wrapper image's root + CAP_NET_ADMIN, which would
-        let claude `iptables -F` and bypass the egress filter, or
-        `cat /home/acproxy/secrets/*` via CAP_DAC_OVERRIDE.
+        """SECURITY: exec on apple-container wraps the user's command in
+        ``capsh --no-new-privs --drop=all --user=1000 ...``, the same
+        primitive supervisor.sh uses at stage 90. Three properties
+        this gives the exec session that a plain `-u 1000` wouldn't:
 
-        Pre-this-fix the exec ran as root by default (Apple's
-        container exec respects the image USER which is `root` on
-        the wrapper). This regression test pins the secure default."""
+          1. NoNewPrivs=1 — kernel refuses to grant caps via setuid
+             binaries (cage ships /usr/bin/su, /usr/bin/mount,
+             /usr/lib/openssh/ssh-keysign, etc. as 4755-mode root)
+          2. CapBnd=0 — drop=all clears the bounding set BEFORE the
+             user switch; without it, CapBnd would still contain
+             CAP_NET_ADMIN + CAP_SYS_ADMIN from the container's cap
+             set, leaving a re-grant path open
+          3. uid 1000 with all caps empty — exec session has the same
+             identity + fs ACL access as the workload
+
+        Pre-fix history:
+          - Originally `cage exec <cage> -- claude` ran as root with
+            full caps (image USER=root, container exec inherits)
+          - First fix (#162) added `-u 1000` so eff/prm caps drop, but
+            left CapBnd non-empty AND NoNewPrivs=0 — a setuid-root
+            binary could re-acquire CAP_NET_ADMIN and `iptables -F`
+            the egress filter
+          - This fix (capsh wrap) closes that last door"""
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
 
         _runner().invoke(main, ["cage", "exec", "demo", "--", "ls", "-la"])
 
-        # Routed through the apple `container` CLI WITH `-u 1000`.
         mock_execvp.assert_called_once_with(
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "-u", "1000",
-             "demo", "ls", "-la"],
+            ["/usr/local/bin/container", "exec", "-u", "0",
+             "demo",
+             "/bin/sh", "-c",
+             'CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && '
+             'exec capsh --no-new-privs --drop=all '
+             '--user="$CAGE_USER" --shell=/bin/sh '
+             '-- -c \'exec ls -la\''],
         )
 
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_as_root_opts_back_to_root(
+    def test_exec_as_root_skips_capsh_wrap(
         self, mock_state, mock_execvp, mock_binary,
     ):
-        """`--as-root` preserves the operator-debug path: drops the
-        `-u 1000` override so the exec session inherits the wrapper's
-        USER (root). For one-off ops needs (`apt-get install`, etc.)."""
+        """`--as-root` bypasses capsh entirely — operator gets a root
+        shell with the container's full cap set + NoNewPrivs=0.
+        Necessary for `apt-get install` and similar one-off ops."""
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
@@ -86,7 +103,11 @@ class TestCageExecAppleContainer:
         )
 
         argv = mock_execvp.call_args.args[1]
-        assert "-u" not in argv
+        # No capsh = full root with the container's caps.
+        assert "capsh" not in argv
+        assert "--no-new-privs" not in argv
+        assert "--drop=all" not in argv
+        # And no `-u 1000` either; image USER (root on wrapper) applies.
         assert "1000" not in argv
         assert "iptables" in argv
 
@@ -155,13 +176,21 @@ class TestCageShellAppleContainer:
             "/usr/local/bin/container", "exec", "demo", "test", "-x", "/bin/bash",
         ]
         # And the *first* execvp call is the bash that probed OK,
-        # WITH `-u 1000` (default privilege drop — see cage_exec tests
-        # for the security rationale).
+        # WRAPPED in `/bin/sh -c '... capsh --no-new-privs --drop=all
+        # --user="$CAGE_USER" ...'` (same primitive supervisor.sh uses
+        # at stage 90; see cage_exec tests for the security rationale).
+        # The shell wrapper resolves uid 1000 to its name because
+        # capsh's --user= takes a name, not a numeric uid.
         first_exec = mock_execvp.call_args_list[0]
         assert first_exec.args == (
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "-u", "1000",
-             "demo", "/bin/bash"],
+            ["/usr/local/bin/container", "exec", "-u", "0",
+             "demo",
+             "/bin/sh", "-c",
+             'CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && '
+             'exec capsh --no-new-privs --drop=all '
+             '--user="$CAGE_USER" --shell=/bin/sh '
+             "-- -c 'exec /bin/bash'"],
         )
 
     @patch("agentcage.apple_container.cli.container_binary")
@@ -189,8 +218,13 @@ class TestCageShellAppleContainer:
         first_exec = mock_execvp.call_args_list[0]
         assert first_exec.args == (
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "-u", "1000",
-             "demo", "/bin/sh"],
+            ["/usr/local/bin/container", "exec", "-u", "0",
+             "demo",
+             "/bin/sh", "-c",
+             'CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && '
+             'exec capsh --no-new-privs --drop=all '
+             '--user="$CAGE_USER" --shell=/bin/sh '
+             "-- -c 'exec /bin/sh'"],
         )
 
 


### PR DESCRIPTION
## Security follow-up to #162

#162 added \`-u 1000\` to \`cage exec\` so caps drop. But CapBnd was still non-empty (CAP_NET_ADMIN + CAP_SYS_ADMIN + the default container set) AND NoNewPrivs=0 — a setuid-root binary inside the cage could re-grant CapBnd caps via exec, bypassing the egress filter.

Cage ships 9 setuid-root binaries: su, mount, umount, passwd, chfn, chsh, gpasswd, newgrp, ssh-keysign.

## Fix

Wrap user's command in the same capsh invocation supervisor.sh uses at stage 90:
\`capsh --no-new-privs --drop=all --user=\$CAGE_USER --shell=/bin/sh -- -c "exec <user-cmd>"\`

Where \$CAGE_USER resolves at exec time via \`getent passwd 1000 | cut -d: -f1\` (capsh's --user takes a name, not a numeric uid — same gotcha #140 hit).

## Verified on live Mac

PATH 2 (cage exec) now matches PATH 1 (supervisor workload) bit-for-bit:

| Field | PATH 1 (workload) | PATH 2 pre-fix | PATH 2 this PR |
|---|---|---|---|
| Uid | 1000 | 1000 | 1000 |
| CapInh/Prm/Eff/Amb | 0 | 0 | 0 |
| CapBnd | 0 | a82435fb | 0 |
| NoNewPrivs | 1 | 0 | 1 |
| iptables -F | blocked | blocked | blocked |
| setuid re-grant | impossible | **POSSIBLE** | impossible |

\`--as-root\` still bypasses capsh for operator-debug needs (apt-get install).

## Test plan

- [x] 3 tests updated for the new argv shape
- [x] Live Mac: default exec → caps all empty + NoNewPrivs=1; --as-root → full root

🤖 Generated with [Claude Code](https://claude.com/claude-code)