### PR TITLE
fix(apple-container): read secret_injection values from --set-secret, drop host-env fallback

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -529,6 +529,11 @@ class AppleContainerBackend:
 
         # Secret-injection. For each env named in the cage's
         # `secret_injection:` rules:
+        #   - Resolve the real value from <deployment_dir>/pending_secrets.json,
+        #     written by `agentcage cage create -s KEY=VAL` and
+        #     `agentcage run -s KEY=VAL`. Values are NEVER read from the
+        #     host shell's environment — anything not passed via
+        #     --set-secret is treated as missing and a warning is emitted.
         #   - Write the real value to <secrets_dir>/<env-name> on the
         #     host (mode 0600). The dir gets bind-mounted at
         #     /run/agentcage/secrets:ro in the cage; supervisor stage 35
@@ -541,11 +546,6 @@ class AppleContainerBackend:
         #     value on the wire. This means the cleartext value is NOT
         #     visible via host `ps -ef`, NOT in `container inspect`,
         #     and NOT in the cage workload's `/proc/self/environ`.
-        # Missing env vars are skipped with a stderr warning — the cage
-        # may not need every secret on every host. Backward compat: if
-        # the unit JSON predates this PR (no secret_env_placeholders),
-        # fall back to the old `-e NAME=value` cleartext behavior so
-        # existing cages keep working after upgrade.
         placeholders = meta.get("secret_env_placeholders") or {}
         secret_envs = meta.get("secret_envs") or list(placeholders.keys())
         # Protocol-relay credential env names. Same secrets bind mount as
@@ -559,6 +559,23 @@ class AppleContainerBackend:
             v for v in relay_secret_envs if v not in secret_envs
         ]
         if all_secret_envs:
+            # Load --set-secret values staged by run.py / cli.py at the
+            # per-cage 0600 plaintext file. No host podman / Keychain on
+            # apple-container yet (#120); plaintext-at-0600 is the
+            # persistence mechanism. Missing file = no secrets provided.
+            from agentcage import state as _state
+            provided: dict[str, str] = {}
+            pending_path = _state.deployment_dir(name) / "pending_secrets.json"
+            if pending_path.is_file():
+                try:
+                    provided = {k: v for k, v in json.loads(pending_path.read_text())}
+                except Exception:
+                    click.echo(
+                        f"warning: failed to parse {pending_path}; treating "
+                        f"all secret_injection rules as unprovided",
+                        err=True,
+                    )
+
             secrets_dir = self.secrets_dir(name)
             secrets_dir.mkdir(parents=True, exist_ok=True)
             os.chmod(secrets_dir, 0o700)
@@ -568,20 +585,20 @@ class AppleContainerBackend:
                 stale.unlink()
             relay_only = set(relay_secret_envs) - set(secret_envs)
             for env_name in all_secret_envs:
-                value = os.environ.get(env_name)
+                value = provided.get(env_name)
                 if value is None:
                     if env_name in relay_only:
                         click.echo(
                             f"warning: protocol_relays env {env_name!r} "
-                            f"not set in host environment; the relay "
+                            f"not provided via --set-secret; the relay "
                             f"will fail to start with empty credentials",
                             err=True,
                         )
                     else:
                         click.echo(
                             f"warning: secret_injection env {env_name!r} "
-                            f"not set in host environment; placeholder will "
-                            f"NOT be substituted in cage requests",
+                            f"not provided via --set-secret; placeholder "
+                            f"will NOT be substituted in cage requests",
                             err=True,
                         )
                     continue
@@ -594,19 +611,28 @@ class AppleContainerBackend:
                     os.chmod(secret_file, 0o600)
                     continue
                 placeholder = placeholders.get(env_name)
-                if placeholder:
-                    secret_file = secrets_dir / env_name
-                    secret_file.write_text(value)
-                    os.chmod(secret_file, 0o600)
-                    argv += ["-e", f"{env_name}={placeholder}"]
-                else:
-                    # Pre-0.21.1 unit JSON: no placeholder map. Fall back
-                    # to cleartext-env delivery to preserve behavior for
-                    # cages last started under 0.21.0.
-                    argv += ["-e", f"{env_name}={value}"]
+                if not placeholder:
+                    # Unit JSON predates the placeholder map (pre-0.21.1).
+                    # Refuse to fall back to cleartext-env delivery — the
+                    # whole point of placeholders is to keep the raw value
+                    # off `container run`'s argv and out of the cage's
+                    # /proc/self/environ. Operator must `cage update` to
+                    # regenerate the unit JSON.
+                    click.echo(
+                        f"warning: secret_injection env {env_name!r} has "
+                        f"no placeholder in unit JSON (pre-0.21.1 cage); "
+                        f"run `agentcage cage update` to regenerate. "
+                        f"Skipping injection.",
+                        err=True,
+                    )
+                    continue
+                secret_file = secrets_dir / env_name
+                secret_file.write_text(value)
+                os.chmod(secret_file, 0o600)
+                argv += ["-e", f"{env_name}={placeholder}"]
             # Mount the per-cage secrets dir read-only into the microVM.
             # Only mount if any files were written (avoid mounting an empty
-            # dir when every secret env was missing host-side).
+            # dir when every secret env was unprovided).
             if any(secrets_dir.iterdir()):
                 argv += ["--volume", f"{secrets_dir}:/run/agentcage/secrets:ro"]
 

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -352,12 +352,14 @@ def _stage_set_secrets(
 
     if isolation in ("vm", "apple-container"):
         # Neither backend has access to host podman on macOS. Stage to a
-        # per-cage pending_secrets.json (0600) and let the backend pick it
-        # up at start time. v1 of apple-container reads the file but does
-        # not yet plumb secrets into the cage (Keychain integration is a
-        # follow-up — see #120) — the file's presence is enough to keep
-        # downstream code working; the secret values are effectively
-        # discarded until the Keychain path lands.
+        # per-cage pending_secrets.json (0600) and let the backend pick
+        # it up at start time. VM backend reads the file and creates
+        # podman secrets INSIDE the VM (then unlinks the file).
+        # apple-container backend reads the file at every start() to
+        # resolve `secret_injection` rules — the 0600 plaintext file IS
+        # the persistence mechanism (no host podman; Keychain is a
+        # follow-up, see #120). Values are NEVER read from the host
+        # shell's environment for the apple-container backend.
         if parsed:
             secrets_file = state.deployment_dir(cage_name) / "pending_secrets.json"
             # 0o600 — staged secret values must not be world-readable.

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -703,7 +703,13 @@ def test_start_argv_uses_file_delivery_when_placeholders_known(
     ``-e <env>={{<env>}}`` (the placeholder, NOT the cleartext value) to
     `container run`. This is the entire point — host `ps`, `container
     inspect`, and `cage exec ... -- env` all see only the placeholder.
+
+    Values come from ``<deployment_dir>/pending_secrets.json`` (written
+    by ``-s KEY=VAL``). The host shell environment is NEVER consulted.
     """
+    import agentcage.state as _state
+    monkeypatch.setattr(_state, "_DEPLOYMENTS_DIR", tmp_path / "cages")
+
     backend = AppleContainerBackend()
     unit_dir = tmp_path / "apple-container"
     unit_dir.mkdir()
@@ -719,8 +725,17 @@ def test_start_argv_uses_file_delivery_when_placeholders_known(
             "MISSING_KEY": "{{MISSING_KEY}}",
         },
     }))
-    monkeypatch.setenv("API_KEY", "sk-real-1234")
-    monkeypatch.delenv("MISSING_KEY", raising=False)
+    # Stage API_KEY via pending_secrets.json (the -s KEY=VAL path).
+    # Deliberately omit MISSING_KEY so we can assert it's skipped.
+    deploy_dir = _state.deployment_dir("demo")
+    deploy_dir.mkdir(parents=True, exist_ok=True)
+    (deploy_dir / "pending_secrets.json").write_text(
+        json.dumps([["API_KEY", "sk-real-1234"]])
+    )
+    # Also set them in the host env — this MUST be ignored. The whole
+    # point of this fix is that env is no longer an implicit secret source.
+    monkeypatch.setenv("API_KEY", "from-host-env-DO-NOT-USE")
+    monkeypatch.setenv("MISSING_KEY", "from-host-env-DO-NOT-USE")
 
     captured_argv = []
 
@@ -755,6 +770,8 @@ def test_start_argv_uses_file_delivery_when_placeholders_known(
     # The missing env has NO file (skipped) and isn't in argv.
     assert not (secrets_dir / "MISSING_KEY").exists()
     assert "MISSING_KEY=" not in " ".join(run_argv)
+    # Host-env value MUST NOT have leaked in for either secret.
+    assert "from-host-env-DO-NOT-USE" not in " ".join(run_argv)
     # The secrets dir itself is mode 0700 (only host user can read).
     assert oct(secrets_dir.stat().st_mode & 0o777) == "0o700"
 
@@ -766,6 +783,9 @@ def test_start_argv_drops_stale_secrets_from_prior_starts(
     that's been removed from cage.yaml doesn't linger in the bind mount
     after `cage update`. Keeps the secrets dir an accurate reflection
     of the current rule list."""
+    import agentcage.state as _state
+    monkeypatch.setattr(_state, "_DEPLOYMENTS_DIR", tmp_path / "cages")
+
     backend = AppleContainerBackend()
     unit_dir = tmp_path / "apple-container"
     unit_dir.mkdir()
@@ -778,7 +798,11 @@ def test_start_argv_drops_stale_secrets_from_prior_starts(
         "secret_envs": ["NEW_KEY"],
         "secret_env_placeholders": {"NEW_KEY": "{{NEW_KEY}}"},
     }))
-    monkeypatch.setenv("NEW_KEY", "new-value")
+    deploy_dir = _state.deployment_dir("demo")
+    deploy_dir.mkdir(parents=True, exist_ok=True)
+    (deploy_dir / "pending_secrets.json").write_text(
+        json.dumps([["NEW_KEY", "new-value"]])
+    )
 
     secrets_dir = tmp_path / "secrets"
     secrets_dir.mkdir()
@@ -801,11 +825,17 @@ def test_start_argv_drops_stale_secrets_from_prior_starts(
     assert (secrets_dir / "NEW_KEY").read_text() == "new-value"
 
 
-def test_start_argv_backcompat_pre_021_1_cleartext(tmp_path, monkeypatch):
-    """Backward compat: unit JSON without ``secret_env_placeholders``
-    (cage last started under 0.21.0) falls back to the old
-    ``-e NAME=value`` cleartext path so existing cages keep starting
-    after upgrade without a `cage update`."""
+def test_start_argv_pre_021_1_unit_json_refuses_cleartext_fallback(
+    tmp_path, monkeypatch,
+):
+    """Pre-0.21.1 unit JSON (no ``secret_env_placeholders``) MUST NOT
+    fall back to the old `-e NAME=value` cleartext path: that would
+    leak the secret onto host `ps -ef` and the cage workload's
+    /proc/self/environ. Operator gets a warning telling them to run
+    `cage update` to regenerate the unit JSON."""
+    import agentcage.state as _state
+    monkeypatch.setattr(_state, "_DEPLOYMENTS_DIR", tmp_path / "cages")
+
     backend = AppleContainerBackend()
     unit_dir = tmp_path / "apple-container"
     unit_dir.mkdir()
@@ -818,6 +848,14 @@ def test_start_argv_backcompat_pre_021_1_cleartext(tmp_path, monkeypatch):
         "secret_envs": ["API_KEY"],
         # no secret_env_placeholders — pre-0.21.1 shape
     }))
+    # Even with the value staged AND in the host env, no placeholder
+    # means we refuse to inject — the value is intentionally NOT routed
+    # through cleartext-env as a fallback.
+    deploy_dir = _state.deployment_dir("demo")
+    deploy_dir.mkdir(parents=True, exist_ok=True)
+    (deploy_dir / "pending_secrets.json").write_text(
+        json.dumps([["API_KEY", "sk-real-1234"]])
+    )
     monkeypatch.setenv("API_KEY", "sk-real-1234")
 
     captured_argv = []
@@ -826,17 +864,21 @@ def test_start_argv_backcompat_pre_021_1_cleartext(tmp_path, monkeypatch):
         captured_argv.append(list(argv))
         return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
+    secrets_dir = tmp_path / "secrets"
     with patch.object(backend, "unit_dir", return_value=unit_dir), \
          patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
-         patch.object(backend, "secrets_dir", return_value=tmp_path / "secrets"), \
+         patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
          patch.object(ac_cli, "run", side_effect=fake_run):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
-    # Backward-compat: cleartext value via -e, no bind mount.
-    assert "API_KEY=sk-real-1234" in run_argv
+    # Value MUST NOT appear anywhere on the `container run` argv.
+    assert "sk-real-1234" not in " ".join(run_argv)
+    assert "API_KEY=sk-real-1234" not in run_argv
+    # No secret file written, no bind mount.
+    assert not (secrets_dir / "API_KEY").exists()
     assert not any("secrets:ro" in a for a in run_argv)
 
 
@@ -901,9 +943,16 @@ def test_supervisor_umounts_secrets_after_restaging(tmp_path):
     assert 'die "could not unmount /run/agentcage/secrets' in sup
 
 
-def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
-    """start() reads secret_envs from the unit metadata and forwards each
-    via `-e NAME=value`. Missing env vars are skipped (with a warning)."""
+def test_start_argv_ignores_host_env_when_pending_secrets_missing(
+    tmp_path, monkeypatch,
+):
+    """Regression for the implicit-env-secret leak: even when the unit
+    JSON carries a placeholder map AND the host env has a value for the
+    secret, start() MUST NOT inject anything if pending_secrets.json
+    doesn't have a matching entry. Only --set-secret values are honored."""
+    import agentcage.state as _state
+    monkeypatch.setattr(_state, "_DEPLOYMENTS_DIR", tmp_path / "cages")
+
     backend = AppleContainerBackend()
     unit_dir = tmp_path / "apple-container"
     unit_dir.mkdir()
@@ -913,10 +962,11 @@ def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
         "cpus": "",
         "memory": "",
         "lifecycle": "interactive",
-        "secret_envs": ["API_KEY", "MISSING_KEY"],
+        "secret_envs": ["API_KEY"],
+        "secret_env_placeholders": {"API_KEY": "{{API_KEY}}"},
     }))
-    monkeypatch.setenv("API_KEY", "sk-real-1234")
-    monkeypatch.delenv("MISSING_KEY", raising=False)
+    # No pending_secrets.json. Host env IS set — must be ignored.
+    monkeypatch.setenv("API_KEY", "from-host-env-DO-NOT-USE")
 
     captured_argv = []
 
@@ -924,20 +974,24 @@ def test_start_argv_forwards_secret_envs(tmp_path, monkeypatch):
         captured_argv.append(list(argv))
         return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
-    logs_dir = tmp_path / "logs"
-
+    secrets_dir = tmp_path / "secrets"
     with patch.object(backend, "unit_dir", return_value=unit_dir), \
-         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
+         patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
          patch.object(ac_cli, "run", side_effect=fake_run):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
-    assert "-e" in run_argv
-    assert "API_KEY=sk-real-1234" in run_argv
-    # Missing env name MUST NOT appear (no `-e MISSING_KEY=` with empty value).
-    assert "MISSING_KEY=" not in " ".join(run_argv)
+    # Placeholder MUST NOT be present (no `-e API_KEY={{API_KEY}}`) because
+    # there's no real value to substitute — the proxy would otherwise pass
+    # the literal placeholder string through to upstream.
+    assert "API_KEY={{API_KEY}}" not in run_argv
+    # Host-env value MUST NOT leak anywhere.
+    assert "from-host-env-DO-NOT-USE" not in " ".join(run_argv)
+    # No secret file written.
+    assert not (secrets_dir / "API_KEY").exists()
 
 
 def test_nat_redirect_excludes_proxy_and_dns_not_only_uid_1000(tmp_path):


### PR DESCRIPTION
## Summary
- `apple_container.py:start()` now reads `secret_injection` values from `<deployment_dir>/pending_secrets.json` (written by `cage create -s KEY=VAL` and `run -s KEY=VAL`) instead of `os.environ.get(env_name)`. Resolves the user-visible warning `secret_injection env 'ANTHROPIC_API_KEY' not set in host environment` when `-s ANTHROPIC_API_KEY=...` was actually passed.
- Removes the pre-0.21.1 cleartext-env fallback (no `secret_env_placeholders` in unit JSON → used to route raw value through `-e NAME=value`, leaking onto host `ps -ef` and the cage's `/proc/self/environ`). Operator now gets a warning telling them to `cage update` to regenerate.
- Container + VM backends already source secrets explicitly (cage.yaml `source:` rules / podman secrets), so they're unchanged.

## Why this matters
The previous behavior silently dropped `-s` values on the apple-container backend (run.py:333 comment explicitly admitted this) AND silently substituted host-env values, which is the exact opposite of what an explicit secret flag implies. The new model: only `--set-secret`-provided values are honored. Missing values produce a warning and skip injection (no implicit fallback).

## Test plan
- [x] `pytest tests/test_apple_container.py tests/test_run.py -q` passes (125 tests)
- [x] New regression test: `test_start_argv_ignores_host_env_when_pending_secrets_missing` asserts that even when the host env has a value, start() refuses to inject if pending_secrets.json doesn't list the key
- [x] Updated tests: `test_start_argv_uses_file_delivery_when_placeholders_known`, `test_start_argv_drops_stale_secrets_from_prior_starts` now drive secrets via pending_secrets.json
- [x] Replaced backcompat test with `test_start_argv_pre_021_1_unit_json_refuses_cleartext_fallback` (asserts no cleartext leak on stale unit JSON)
- [ ] Manual: `export ANTHROPIC_API_KEY=` (unset), `agentcage run claude-code -s ANTHROPIC_API_KEY=sk-test` → no warning, secret reaches anthropic.com via proxy substitution
- [ ] Manual: `unset ANTHROPIC_API_KEY`, no `-s` → warning fires as expected ("not provided via --set-secret")