### PR TITLE
fix(apple-container): agentcage run wraps cage workload in capsh — match cage exec hardening (#163)

### DIFF
--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -727,9 +727,20 @@ def execute(
 
     try:
         if is_apple:
-            from agentcage.apple_container import cli as ac_cli
-            container_bin = ac_cli.container_binary() or "container"
-            cmd = [container_bin, "exec"] + exec_flags + [container_name] + exec_cmd
+            # Route through AppleContainerBackend.exec_argv() so the
+            # interactive session is wrapped in capsh: NoNewPrivs + drop=all
+            # + --user=$CAGE_USER (uid 1000). A raw `container exec` would
+            # inherit the wrapper image's USER (root) because supervisor
+            # hardening only applies to the cage workload at stage 90, not
+            # to fresh `exec` sessions. See PR #163 for the cage-exec fix —
+            # this is the same fix applied to the `agentcage run` path.
+            from agentcage.backends.apple_container import AppleContainerBackend
+            backend = AppleContainerBackend()
+            cmd = backend.exec_argv(
+                container_name, "cage", exec_cmd,
+                interactive=bool(exec_flags),
+                as_root=False,
+            )
         else:
             cmd = (
                 podman_prefix + ["podman", "exec"]


### PR DESCRIPTION
## Summary
- `agentcage run` on the apple-container backend was bypassing the capsh hardening that PR #163 added to `cage exec`. `src/agentcage/run.py:execute()` was constructing a raw `container exec` argv inline, which inherits the wrapper Containerfile's `USER root` — so `claude` (and any other scaffold's interactive entrypoint) ran as **uid 0** with the full container cap set.
- Routed the apple-container branch through `AppleContainerBackend.exec_argv()` so the session is wrapped in `capsh --no-new-privs --drop=all --user=$CAGE_USER` (uid 1000, CapBnd empty, NNP=1). Same primitive the supervisor uses at stage 90 and PR #163 uses for `cage exec`.
- Container + VM backends are unaffected (their image USER is already non-root via the scaffold's Containerfile; no wrapper-image USER override).

## Why this matters
The whole point of the cage on apple-container is that the cage workload runs unprivileged. A user invoking `agentcage run claude-code` (the most common entry point) was getting a root-shelled `claude` — same `whoami=root`, same CAP_SYS_ADMIN/CAP_NET_ADMIN as the supervisor — silently. This is a defense-in-depth gap: even if the supervisor's stage-90 capsh drops apply to the cage CMD launched at boot, fresh `exec` sessions opened by `agentcage run` need the same drop.

## Test plan
- [x] `pytest tests/test_apple_container.py tests/test_run.py -q` passes (existing `exec_argv()` tests cover the capsh wrapping invariants)
- [ ] Manual on macOS 26 with apple-container backend: `agentcage run claude-code`, then in the session run `id` — must show `uid=1000`, `cap_*` empty, `NoNewPrivs: 1` in `/proc/self/status`
- [ ] Manual: confirm `cage exec` still works as before (this PR doesn't touch that path)
- [ ] Manual: confirm container + vm backends unaffected (`agentcage run claude-code --isolation container` if a Linux box is available, `--isolation vm` on Mac)