### PR TITLE
fix(destroy): no-op when no state and no backend artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`agentcage cage destroy` no longer crashes with `FileNotFoundError: 'podman'` on Mac** when the stored deployment config is missing. Pre-fix, `destroy_cage` caught the load failure and fell back unconditionally to `ContainerBackend`, which calls `podman network rm ...` — failing on macOS where podman isn't installed even though the cage is an apple-container artifact. Two real triggers: (a) destroying a name that doesn't exist (e.g. typo); (b) destroying after `agentcage run` exits, since ephemeral mode wipes the deployment dir on the way out. Now each backend exposes `has_resources(name)` (filesystem-based, tool-free) and the destroy path probes apple-container / vm / container in order, dispatches to the one that claims the name, or no-ops cleanly with "Nothing to remove" when nothing exists. An orphaned state dir is still cleaned up.
+
 ## [0.21.3] - 2026-05-25
 
 Two more security fixes for apple-container, follow-ups to the 0.21.2 capsh work. **Upgrade recommended for any apple-container deployment that uses `agentcage run -s KEY=VAL` to pass secrets, or where the `agentcage run` entry point opens an interactive cage session.**

--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -54,6 +54,19 @@ class Backend(Protocol):
         """Remove backend-specific resources. Return list of removed items."""
         ...
 
+    def has_resources(self, name: str) -> bool:
+        """Return True if this backend may own any artifacts for ``name``.
+
+        Used by :func:`agentcage.services.destroy_cage` to pick a backend
+        when the stored deployment config is missing — destroying then
+        falling back to the default backend would call podman on a Mac
+        that doesn't have it. Implementations should be cheap and must
+        not raise on missing tools (return ``False`` if uncertain). It is
+        fine to be conservative: false-positive triggers ``destroy_resources``
+        which is itself idempotent.
+        """
+        ...
+
     def is_running(self, name: str, service: str) -> bool:
         """Check if a specific service of a cage is running."""
         ...

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -688,6 +688,13 @@ class AppleContainerBackend:
             removed.append(f"state:{state}")
         return removed
 
+    def has_resources(self, name: str) -> bool:
+        if (self.unit_dir() / f"{name}.json").exists():
+            return True
+        if self._state_dir(name).exists():
+            return True
+        return False
+
     def is_running(self, name: str, service: str) -> bool:  # noqa: ARG002
         data = ac_cli.inspect(name)
         if not data:

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -181,6 +181,18 @@ class ContainerBackend:
 
         return removed
 
+    def has_resources(self, name: str) -> bool:
+        quadlet_dir = self.unit_dir()
+        quadlet_files = [
+            f"{name}-cage.container",
+            f"{name}-proxy.container",
+            f"{name}-dns.container",
+            f"{name}-net.network",
+            f"{name}-certs.volume",
+            f"{name}-podman-storage.volume",
+        ]
+        return any((quadlet_dir / f).exists() for f in quadlet_files)
+
     def is_running(self, name: str, service: str) -> bool:
         return self._podman.container_running(f"{name}-{service}")
 

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import os
 import shlex
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -488,6 +489,14 @@ class VmBackend:
             removed.append(f"quadlets:{quadlets_dir}")
 
         return removed
+
+    def has_resources(self, name: str) -> bool:
+        if shutil.which("limactl") is None:
+            return False
+        try:
+            return self._instance(name).exists()
+        except (FileNotFoundError, OSError):
+            return False
 
     def is_running(self, name: str, service: str) -> bool:
         inst = self._instance(name)

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -288,6 +288,25 @@ def restart_cage(name: str, cfg=None):
     backend.restart(name)
 
 
+def _find_owning_backend(name: str):
+    """Return the backend that owns artifacts for ``name``, or None.
+
+    Used by :func:`destroy_cage` when the stored deployment config can't
+    be loaded — see comment there.
+    """
+    from agentcage.backends.apple_container import AppleContainerBackend
+    from agentcage.backends.container import ContainerBackend
+    from agentcage.backends.vm import VmBackend
+
+    for backend in (AppleContainerBackend(), VmBackend(), ContainerBackend()):
+        try:
+            if backend.has_resources(name):
+                return backend
+        except Exception:
+            continue
+    return None
+
+
 def destroy_cage(
     name: str,
     *,
@@ -304,8 +323,20 @@ def destroy_cage(
         cfg = state.load_deployment_config(name)
         backend = get_backend(cfg)
     except Exception:
-        from agentcage.backends.container import ContainerBackend
-        backend = ContainerBackend()
+        # No stored config — ask each backend whether it owns artifacts for
+        # ``name`` and dispatch to the one that does. Without this probe the
+        # default fell back to ContainerBackend, which calls ``podman`` —
+        # crashing on macOS where podman isn't installed even when the cage
+        # is an apple-container artifact (e.g. cleanup after ``agentcage run``
+        # which wipes the deployment dir on exit).
+        backend = _find_owning_backend(name)
+        if backend is None:
+            _echo(f"Nothing to remove for '{name}' "
+                  "(no stored config and no backend resources).")
+            if state.deployment_exists(name):
+                state.remove_deployment(name)
+                return [f"state:{name}"]
+            return []
 
     _echo("Stopping services...")
     backend.stop(name)

--- a/tests/test_destroy_cage.py
+++ b/tests/test_destroy_cage.py
@@ -1,0 +1,141 @@
+"""Tests for ``services.destroy_cage`` dispatch when state is missing.
+
+Before this fix, a ``destroy`` on a name with no stored deployment config
+fell back to ``ContainerBackend``, which calls ``podman`` — crashing on
+macOS where podman isn't installed even when the cage was an
+apple-container artifact. The fix probes each backend via
+``has_resources(name)`` and dispatches to the one that owns artifacts,
+or no-ops cleanly when nothing exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agentcage.services import destroy_cage
+
+
+def test_destroy_unknown_cage_is_clean_noop_without_calling_backends():
+    """Destroying a name with no state and no backend artifacts must not
+    invoke ``podman`` (or any tool). Reproduces the macOS crash."""
+    messages: list[str] = []
+
+    with (
+        patch("agentcage.state.load_deployment_config",
+              side_effect=FileNotFoundError("no config")),
+        patch("agentcage.state.deployment_exists", return_value=False),
+        patch("agentcage.backends.container.ContainerBackend.has_resources",
+              return_value=False) as container_probe,
+        patch("agentcage.backends.apple_container.AppleContainerBackend.has_resources",
+              return_value=False) as apple_probe,
+        patch("agentcage.backends.vm.VmBackend.has_resources",
+              return_value=False) as vm_probe,
+        patch("agentcage.backends.container.ContainerBackend.stop") as container_stop,
+    ):
+        removed = destroy_cage("ghost", echo=messages.append)
+
+    assert removed == []
+    assert any("Nothing to remove" in m for m in messages)
+    # The probe must happen, but no backend ``stop``/``destroy_resources``
+    # should be called when nothing claims the name.
+    assert container_probe.called or apple_probe.called or vm_probe.called
+    container_stop.assert_not_called()
+
+
+def test_destroy_dispatches_to_apple_container_when_it_owns_the_name():
+    """When apple-container claims the name (e.g. agentcage run wiped the
+    deployment dir but left the launchd plist / state dir), dispatch must
+    go there, not to the container backend's podman path."""
+    with (
+        patch("agentcage.state.load_deployment_config",
+              side_effect=FileNotFoundError("no config")),
+        patch("agentcage.state.deployment_exists", return_value=False),
+        patch("agentcage.backends.apple_container.AppleContainerBackend.has_resources",
+              return_value=True),
+        patch("agentcage.backends.apple_container.AppleContainerBackend.stop") as ac_stop,
+        patch(
+            "agentcage.backends.apple_container.AppleContainerBackend.destroy_resources",
+            return_value=["container:c"],
+        ) as ac_destroy,
+        patch("agentcage.backends.container.ContainerBackend.has_resources",
+              return_value=False),
+        patch("agentcage.backends.container.ContainerBackend.stop") as container_stop,
+    ):
+        removed = destroy_cage("c", echo=lambda _: None)
+
+    assert removed == ["container:c"]
+    ac_stop.assert_called_once_with("c")
+    ac_destroy.assert_called_once()
+    container_stop.assert_not_called()
+
+
+def test_destroy_with_stored_config_skips_probe_and_uses_get_backend():
+    """The happy path (stored config present) must not change: dispatch
+    via ``get_backend(cfg)`` without consulting ``has_resources``."""
+    from agentcage.config import Config, ContainerConfig
+
+    cfg = Config(name="c", isolation="container",
+                 container=ContainerConfig(image="x:latest"))
+    with (
+        patch("agentcage.state.load_deployment_config", return_value=cfg),
+        patch("agentcage.state.deployment_exists", return_value=False),
+        patch("agentcage.backends.container.ContainerBackend.has_resources") as probe,
+        patch("agentcage.backends.container.ContainerBackend.stop"),
+        patch(
+            "agentcage.backends.container.ContainerBackend.destroy_resources",
+            return_value=[],
+        ),
+    ):
+        destroy_cage("c", echo=lambda _: None)
+
+    probe.assert_not_called()
+
+
+def test_destroy_orphan_state_dir_is_cleaned_even_without_backend_resources():
+    """If the stored config is corrupt/missing but the deployment dir
+    still exists, the no-op path should still clean up ``state:<name>``."""
+    with (
+        patch("agentcage.state.load_deployment_config",
+              side_effect=FileNotFoundError("no config")),
+        patch("agentcage.state.deployment_exists", return_value=True),
+        patch("agentcage.state.remove_deployment") as remove_state,
+        patch("agentcage.backends.container.ContainerBackend.has_resources",
+              return_value=False),
+        patch("agentcage.backends.apple_container.AppleContainerBackend.has_resources",
+              return_value=False),
+        patch("agentcage.backends.vm.VmBackend.has_resources",
+              return_value=False),
+    ):
+        removed = destroy_cage("c", echo=lambda _: None)
+
+    assert removed == ["state:c"]
+    remove_state.assert_called_once_with("c")
+
+
+def test_apple_container_has_resources_uses_filesystem_only(tmp_path, monkeypatch):
+    """``has_resources`` must be tool-free — no ``container`` CLI calls."""
+    from agentcage.backends.apple_container import AppleContainerBackend
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = AppleContainerBackend()
+    assert backend.has_resources("nope") is False
+
+    unit = backend.unit_dir() / "mine.json"
+    unit.parent.mkdir(parents=True, exist_ok=True)
+    unit.write_text("{}")
+    assert backend.has_resources("mine") is True
+
+
+def test_container_has_resources_uses_filesystem_only(tmp_path, monkeypatch):
+    """``has_resources`` on container backend must not shell out to podman."""
+    from agentcage.backends.container import ContainerBackend
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    backend = ContainerBackend()
+    assert backend.has_resources("nope") is False
+
+    unit_dir = backend.unit_dir()
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    (unit_dir / "mine-cage.container").write_text("")
+    assert backend.has_resources("mine") is True

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.21.1"
+version = "0.21.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Fixes `agentcage cage destroy` crashing with `FileNotFoundError: 'podman'` on macOS when the stored deployment config is missing.
- Adds `Backend.has_resources(name) -> bool` (filesystem-based, tool-free) so `destroy_cage` can probe each backend and dispatch to the one that owns the name, instead of always falling back to `ContainerBackend`.
- Cleanly no-ops with "Nothing to remove" when nothing claims the name; still cleans up orphaned state dirs.

## Why

Today `destroy_cage` looks like:

```python
try:
    cfg = state.load_deployment_config(name)
    backend = get_backend(cfg)
except Exception:
    from agentcage.backends.container import ContainerBackend
    backend = ContainerBackend()   # Mac-blind fallback
```

That falls through to `container.py:168 → self._podman.network_remove(...)` → `subprocess.run(["podman", ...])` → `FileNotFoundError` on macOS.

Two real triggers in production:

1. **Destroying a name that doesn't exist** (typo or scripted cleanup) — `agentcage cage destroy doesnotexist -y` produces a Python traceback.
2. **Destroying after `agentcage run` exits** — ephemeral mode wipes the deployment dir on the way out, so any follow-up `cage destroy <same>` (e.g. cleanup harnesses, or just running the same name twice) trips the same fallback. The cage is already gone, but the user sees a confusing podman crash.

Cosmetic on Mac (no data loss, no leftover state), but it hides any real exception during config load behind a misleading podman traceback — and it surfaced during the 0.21.3 security-fix verification on a fresh Mac install, which is what brought it to our attention.

## Design

- `has_resources(name)` is a Protocol method with a docstring contract: must be cheap, must not raise on missing tools (return `False` if uncertain), false positives are safe because `destroy_resources` is itself idempotent.
- Implementations are filesystem-only — no tool calls — so they work on any platform regardless of what's installed:
  - **container**: looks for any quadlet file (`<name>-cage.container`, etc.) in `unit_dir()`.
  - **apple-container**: looks for `<unit_dir>/<name>.json` or `<state>/<name>/`.
  - **vm**: gated on `shutil.which("limactl")`; only probes `_instance(name).exists()` if `limactl` is on PATH.
- `_find_owning_backend` iterates `(AppleContainerBackend, VmBackend, ContainerBackend)` and returns the first that claims `name`, or `None`.
- The happy path (stored config present) is unchanged: still dispatches via `get_backend(cfg)`, no probing.

## Test plan

- [x] 6 new tests in `tests/test_destroy_cage.py` cover:
  - No-op path doesn't invoke `podman` (the macOS crash repro)
  - Apple-container backend is dispatched to when it owns the artifacts
  - Happy path (stored config) skips probing entirely
  - Orphaned state dir is still cleaned up in the no-op path
  - `has_resources` on apple-container and container backends is filesystem-only
- [x] Full suite: 1502 passing locally on Linux
- [ ] Verify on Mac: `agentcage cage destroy doesnotexist -y` produces "Nothing to remove" without traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)