### PR TITLE
security(scaffolds): disable host ~/.<agent> bind-mounts by default

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -787,13 +787,12 @@ class AppleContainerBackend:
         #
         # capsh's `--user=` resolves by NAME via getpwnam (it does NOT
         # accept a numeric uid — `--user=1000` errors with "User [1000]
-        # not known"). The uid-1000 user's name varies by base image:
-        # `ubuntu` on ubuntu:24.04, `node` on node:*, `claude` on
-        # claude-code, `cage` on bases without a uid-1000 user (the
-        # Containerfile.wrapper.j2 useradd fallback). Resolve at
-        # exec time via a shell `getent` so we don't have to teach the
-        # CLI about every base image's user name. Same trick the
-        # supervisor uses at stage 90 (PR #140).
+        # not known"). The uid-1000 user's name varies by base image
+        # (e.g. `ubuntu` on ubuntu:24.04, `node` on node:*, `cage` on
+        # bases without a uid-1000 user via the Containerfile.wrapper.j2
+        # useradd fallback). Resolve at exec time via a shell `getent`
+        # so we don't have to teach the CLI about every base image's
+        # user name. Same trick the supervisor uses at stage 90 (PR #140).
         inner = (
             "CAGE_USER=$(getent passwd 1000 | cut -d: -f1) && "
             "exec capsh --no-new-privs --drop=all "

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -358,9 +358,9 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
     Examples:
       agentcage run claude-code
       agentcage run codex --project /path/to/repo
-      agentcage run claude-code -s ANTHROPIC_API_KEY=sk-...
+      agentcage run codex -s OPENAI_API_KEY=sk-...
       agentcage run claude-code --isolation vm
-      agentcage run claude-code --name my-session -- claude --help
+      agentcage run codex --name my-session -- codex --help
       agentcage run claude-code -i
     """
     from agentcage.run import execute

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -220,6 +220,30 @@ def load_scaffold_meta(scaffold: str) -> dict | None:
         return yaml.safe_load(f) or {}
 
 
+def scaffold_aliases() -> dict[str, str]:
+    """Return ``alias → scaffold-name`` for every scaffold declaring ``aliases``.
+
+    Read from each scaffold's ``scaffold.yaml`` so the alias list is
+    extensible — agentcage core has no hardcoded knowledge of which
+    scaffolds exist or how they prefer to be invoked.
+    """
+    out: dict[str, str] = {}
+    for name in list_scaffolds():
+        meta = load_scaffold_meta(name) or {}
+        for alias in meta.get("aliases") or []:
+            out[str(alias)] = name
+    return out
+
+
+def scaffold_name_prefix(scaffold: str) -> str:
+    """Return the cage-name prefix declared in a scaffold's ``scaffold.yaml``.
+
+    Falls back to the scaffold's own name when no prefix is declared.
+    """
+    meta = load_scaffold_meta(scaffold) or {}
+    return str(meta.get("name_prefix") or scaffold)
+
+
 def run_scaffold_setup(
     scaffold: str, name: str, dest: str, *, quiet: bool = False,
     isolation: str | None = None,

--- a/src/agentcage/lima/provisioning.py
+++ b/src/agentcage/lima/provisioning.py
@@ -104,11 +104,11 @@ def _extra_mounts_for_volumes(volumes: list[str]) -> list[dict]:
             continue
 
         # Lima only virtiofs-shares directories, so a file-source volume
-        # (e.g. the claude-code scaffold's ~/.claude.json) cannot be a
-        # Lima mount — `limactl create` would fail fatally with "refers
-        # to a non-directory path". Skip it here: it is not lost, the
-        # quadlet layer stages a copy into ~/.local/share/agentcage
-        # (already mounted) and bind-mounts that.
+        # (a scaffold mounting a single host dotfile) cannot be a Lima
+        # mount — `limactl create` would fail fatally with "refers to a
+        # non-directory path". Skip it here: it is not lost, the quadlet
+        # layer stages a copy into ~/.local/share/agentcage (already
+        # mounted) and bind-mounts that.
         if not os.path.isdir(host_path):
             continue
 

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -236,8 +236,9 @@ def _stage_vm_file_volume(real_path: str, deploy_name: str) -> str:
     """Stage a single-file volume source so the VM backend can mount it.
 
     Lima's virtiofs shares directories, not single files, so a volume
-    whose host source is a regular file (e.g. the claude-code scaffold's
-    ``~/.claude.json``) cannot be handed to the VM directly. Copy it into
+    whose host source is a regular file (e.g. a scaffold mounting a
+    single dotfile from the host) cannot be handed to the VM directly.
+    Copy it into
     ``~/.local/share/agentcage/<cage>/seed/`` instead — that directory is
     already virtiofs-mounted into the VM — and return the staged path for
     the cage quadlet to bind-mount.
@@ -322,10 +323,11 @@ def generate_quadlets(
             continue
 
         # VM backend: Lima's virtiofs shares directories, not single
-        # files, so a file-source volume (e.g. ~/.claude.json) cannot be
-        # mounted into the VM directly. Stage a copy into the cage's data
-        # dir — which is virtiofs-mounted — and bind-mount the staged
-        # path instead. Container mode bind-mounts files directly.
+        # files, so a file-source volume (a scaffold mounting a single
+        # host dotfile) cannot be mounted into the VM directly. Stage
+        # a copy into the cage's data dir — which is virtiofs-mounted —
+        # and bind-mount the staged path instead. Container mode
+        # bind-mounts files directly.
         if config.isolation == "vm" and not os.path.isdir(real):
             staged = _stage_vm_file_volume(real, deploy_name or name)
             container_part = expanded.split(":", 1)[1]

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -34,13 +34,15 @@ import click
 
 from agentcage import state
 from agentcage.backends import get_backend
-from agentcage.config import (
-    Config,
-    SecretInjectionRule,
-    load_config,
-    validate_config,
+from agentcage.config import load_config, validate_config
+from agentcage.init import (
+    list_scaffolds,
+    render_config,
+    resolve_scaffold,
+    run_scaffold_setup,
+    scaffold_aliases,
+    scaffold_name_prefix,
 )
-from agentcage.init import list_scaffolds, load_scaffold_meta, render_config, resolve_scaffold, run_scaffold_setup
 from agentcage.podman import Podman
 from agentcage.services import build_and_deploy, check_port_availability, destroy_cage
 
@@ -55,16 +57,6 @@ _ADJECTIVES = [
     "true", "vast",
 ]
 
-# Short aliases for scaffold names
-_SCAFFOLD_ALIASES: dict[str, str] = {
-    "claude": "claude-code",
-}
-
-# Short prefixes for auto-generated cage names
-_NAME_PREFIXES: dict[str, str] = {
-    "claude-code": "claude",
-}
-
 _NOUNS = [
     "ant", "bay", "bee", "cod", "cow", "dew", "doe", "elm",
     "elk", "emu", "ewe", "fig", "fox", "gem", "gnu", "hog",
@@ -77,8 +69,12 @@ _NOUNS = [
 
 
 def generate_name(scaffold: str) -> str:
-    """Generate a unique cage name like ``claude-bold-fox``."""
-    prefix = _NAME_PREFIXES.get(scaffold, scaffold)
+    """Generate a unique cage name like ``claude-bold-fox``.
+
+    The prefix comes from the scaffold's ``scaffold.yaml`` (``name_prefix``
+    field) and falls back to the scaffold name itself when not declared.
+    """
+    prefix = scaffold_name_prefix(scaffold)
     existing = set(state.list_deployments())
     for _ in range(100):
         adj = random.choice(_ADJECTIVES)
@@ -302,12 +298,11 @@ def _detect_isolation() -> str:
 def _ensure_volume_dirs(volumes: list[str]) -> None:
     """Create missing host directories for a cage's bind-mount volumes.
 
-    Scaffolds declare volumes for state persistence — the claude-code
-    scaffold mounts ``~/.claude`` so the agent's login survives across
-    sessions. On a fresh machine that directory does not exist yet;
-    podman cannot bind-mount a missing source, and the Lima/quadlet
-    layers would skip it (so a login inside the cage never round-trips
-    to the host). Create it up front instead.
+    Scaffolds may declare host bind-mounts for state persistence. On a
+    fresh machine the source directory may not exist yet; podman cannot
+    bind-mount a missing source, and the Lima/quadlet layers would skip
+    it (so a login inside the cage never round-trips to the host).
+    Create it up front instead.
 
     Only *directory* sources inside the home directory are created. A
     spec whose host path looks like a file (has an extension) or still
@@ -392,70 +387,6 @@ def _vm_podman_prefix(isolation: str, cage_name: str) -> list[str]:
     return []
 
 
-_CLAUDE_CODE_AUTH_HELP = """\
-No Claude Code authentication found.
-
-Claude Code inside a cage can't read the macOS Keychain, so the host's
-`claude login` doesn't carry over. Set up auth, then re-run:
-
-  Subscription — mint a token on the host (recommended):
-      claude setup-token
-      export CLAUDE_CODE_OAUTH_TOKEN=<token>
-      agentcage run claude-code
-
-  API key:
-      agentcage run claude-code -s ANTHROPIC_API_KEY\
-"""
-
-
-def _preflight_claude_code_auth(
-    cfg: Config, secrets: tuple[str, ...],
-) -> tuple[str, ...] | None:
-    """Verify a ``run`` claude-code cage will have working auth.
-
-    ``agentcage run claude-code`` drops the user straight into Claude
-    Code, so a cage with no credentials means a confusing in-session
-    failure. Check up front instead.
-
-    When ``CLAUDE_CODE_OAUTH_TOKEN`` is set in the environment it is wired
-    in automatically — the injection rule is added to *cfg* and the token
-    appended to *secrets* for staging. (The scaffold ships that rule
-    commented out: an active rule would make ``cage create`` demand the
-    secret.) Returns the possibly-extended *secrets* tuple. When no auth
-    path exists at all, prints setup guidance and returns ``None``.
-    """
-    secret_keys = {s.split("=", 1)[0] for s in secrets}
-    env_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
-
-    have_oauth = bool(env_token) or "CLAUDE_CODE_OAUTH_TOKEN" in secret_keys
-    have_api_key = "ANTHROPIC_API_KEY" in secret_keys
-    # A prior in-cage `claude login` persists here via the ~/.claude mount.
-    have_login = os.path.isfile(
-        os.path.expanduser("~/.claude/.credentials.json")
-    )
-
-    if not (have_oauth or have_api_key or have_login):
-        click.echo(_CLAUDE_CODE_AUTH_HELP, err=True)
-        return None
-
-    if have_oauth and not any(
-        r.env == "CLAUDE_CODE_OAUTH_TOKEN" for r in cfg.secret_injection
-    ):
-        # `run` strips injection rules whose secret was not provided, so
-        # adding the rule here is only effective alongside the staged
-        # secret below (or an explicit `-s CLAUDE_CODE_OAUTH_TOKEN`).
-        cfg.secret_injection.append(SecretInjectionRule(
-            env="CLAUDE_CODE_OAUTH_TOKEN",
-            placeholder="{{CLAUDE_CODE_OAUTH_TOKEN}}",
-            inject_to=["anthropic.com"],
-        ))
-    if env_token and "CLAUDE_CODE_OAUTH_TOKEN" not in secret_keys:
-        click.echo("Using CLAUDE_CODE_OAUTH_TOKEN from your environment.")
-        secrets = secrets + (f"CLAUDE_CODE_OAUTH_TOKEN={env_token}",)
-
-    return secrets
-
-
 def execute(
     scaffold: str,
     *,
@@ -474,8 +405,8 @@ def execute(
     """
     from agentcage import output
 
-    # Resolve scaffold aliases
-    scaffold = _SCAFFOLD_ALIASES.get(scaffold, scaffold)
+    # Resolve scaffold aliases declared in each scaffold's scaffold.yaml.
+    scaffold = scaffold_aliases().get(scaffold, scaffold)
 
     # Validate scaffold exists
     available = list_scaffolds()
@@ -533,18 +464,10 @@ def execute(
     for w in warnings:
         click.echo(f"warning: {w}", err=True)
 
-    # Claude Code drops the user straight into a session — make sure the
-    # cage will actually be authenticated before building it.
-    if scaffold == "claude-code":
-        checked = _preflight_claude_code_auth(cfg, secrets)
-        if checked is None:
-            shutil.rmtree(str(config_dir), ignore_errors=True)
-            return 1
-        secrets = checked
-
-    # Create missing bind-mount directories so state persists (e.g. the
-    # claude-code scaffold's ~/.claude — without this, a login inside the
-    # cage never round-trips to the host).
+    # Create missing bind-mount directories so state persists for any
+    # scaffold whose user has opted into host bind-mounts (e.g. a
+    # commented-out ~/.<agent> mount the user has chosen to enable).
+    # Without this, a login inside the cage never round-trips to the host.
     _ensure_volume_dirs(cfg.container.volumes)
 
     # Check port availability

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -10,7 +10,9 @@
 # Authentication — pick one:
 #   A — Subscription, log in inside the cage:
 #     agentcage cage exec {{ name }} -- claude login
-#     (follow the URL; the token is saved in the ~/.claude volume)
+#     (follow the URL; the token is saved under /home/node/.claude in the
+#     cage's writable layer. To persist it across image rebuilds, uncomment
+#     the ~/.claude host mount in `volumes` below — see security note there.)
 #
 #   B — Subscription, reuse your host login (no in-cage login):
 #     claude setup-token                  # on the host — mints a long-lived token
@@ -44,13 +46,18 @@ container:
   # Project directory — mount your repo here
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
-    # Auth & settings — mount host ~/.claude so login persists across sessions.
-    # Remove this line to isolate cage state from the host.
-    - "~/.claude:/home/node/.claude:rw"
+    # Auth & settings — uncomment to mount host ~/.claude so login persists
+    # across sessions. Disabled by default: the host ~/.claude tree contains
+    # credentials, OAuth tokens, transcripts, MCP configs, and project
+    # memory that the cage shouldn't see or be able to mutate. Prefer
+    # in-cage `claude login` (volume-backed) or CLAUDE_CODE_OAUTH_TOKEN.
+    #- "~/.claude:/home/node/.claude:rw"
     # ~/.claude.json (Claude Code's global UX config) is intentionally NOT
     # mounted by default. Uncomment if you want your host preferences (model
-    # choice, theme, etc.) to follow you into the cage. Auth tokens live in
-    # ~/.claude/.credentials.json and are already covered by the mount above.
+    # choice, theme, etc.) to follow you into the cage. Only enable this
+    # together with the ~/.claude mount above — without ~/.claude, the
+    # paths referenced in ~/.claude.json (projects, MCP servers, history)
+    # won't exist inside the cage.
     # Note: the VM backend stages a one-way copy (cage edits don't flow back).
     #- "~/.claude.json:/home/node/.claude.json:rw"
   #  # Git config (uncomment to enable)

--- a/src/agentcage/scaffolds/claude-code/scaffold.yaml
+++ b/src/agentcage/scaffolds/claude-code/scaffold.yaml
@@ -1,6 +1,15 @@
 description: "Anthropic Claude Code CLI agent"
 lifecycle: interactive
 
+# Short aliases — `agentcage run claude` resolves to this scaffold.
+aliases:
+  - claude
+
+# Prefix used by `agentcage run` when auto-generating a cage name.
+# Without this, cages are named `<scaffold>-<adj>-<noun>` (e.g.
+# `claude-code-bold-fox`); with it, they are `claude-bold-fox`.
+name_prefix: claude
+
 build:
   - image: "localhost/agentcage-scaffold-claude-code:latest"
     containerfile: "Containerfile"

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -34,9 +34,12 @@ container:
   # Project directory — mount your repo here
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
-    # Auth & settings — mount host ~/.codex so login persists across sessions.
-    # Remove this line to isolate cage state from the host.
-    - "~/.codex:/home/node/.codex:rw"
+    # Auth & settings — uncomment to mount host ~/.codex so login persists
+    # across sessions. Disabled by default: the host ~/.codex tree contains
+    # credentials, session history, and config that the cage shouldn't see
+    # or be able to mutate. Prefer in-cage `codex login` (volume-backed)
+    # or an injected API key.
+    #- "~/.codex:/home/node/.codex:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"

--- a/src/agentcage/scaffolds/pi/cage.yaml.j2
+++ b/src/agentcage/scaffolds/pi/cage.yaml.j2
@@ -11,7 +11,9 @@
 #   A — Interactive login inside the cage (subscription providers):
 #     agentcage cage exec {{ name }} -- pi
 #     # then type /login at the prompt
-#     # credentials are saved in the ~/.pi volume
+#     # credentials are saved under /home/node/.pi in the cage's writable
+#     # layer. To persist them across image rebuilds, uncomment the ~/.pi
+#     # host mount in `volumes` below — see security note there.
 #
 #   B — API key (Anthropic):
 #     agentcage secret set {{ name }} ANTHROPIC_API_KEY
@@ -45,11 +47,11 @@ container:
   # Project directory — mount your repo here
   volumes:
     - "${PROJECT_DIR}:/workspace:rw"
-    # Auth & settings — mount host ~/.pi so /login persists across sessions.
-    # Pi stores global config at ~/.pi/agent/settings.json and per-session
-    # state under ~/.pi/ as well. Remove this line to isolate cage state
-    # from the host.
-    - "~/.pi:/home/node/.pi:rw"
+    # Auth & settings — uncomment to mount host ~/.pi so /login persists
+    # across sessions. Disabled by default: the host ~/.pi tree contains
+    # credentials and per-session state that the cage shouldn't see or be
+    # able to mutate. Prefer in-cage `/login` (volume-backed).
+    #- "~/.pi:/home/node/.pi:rw"
   #  # Git config (uncomment to enable)
   #  - "~/.gitconfig:/home/node/.gitconfig:ro"
   #  - "~/.ssh/known_hosts:/home/node/.ssh/known_hosts:ro"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -6,10 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agentcage.config import Config
 from agentcage.run import (
     _ensure_volume_dirs,
-    _preflight_claude_code_auth,
     _stage_set_secrets,
     _vm_podman_prefix,
     generate_name,
@@ -100,58 +98,6 @@ class TestStageSetSecrets:
             dd.return_value = __import__("pathlib").Path(tempfile.mkdtemp())
             _stage_set_secrets("c", ("K=V",), "vm", podman)
         podman.secret_create.assert_not_called()
-
-
-class TestPreflightClaudeCodeAuth:
-    """`agentcage run claude-code` checks auth before building the cage."""
-
-    def _isolate(self, monkeypatch, tmp_path):
-        """No env token, no persisted login — a blank slate."""
-        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
-
-    def test_no_auth_returns_none(self, monkeypatch, tmp_path, capsys):
-        self._isolate(monkeypatch, tmp_path)
-        result = _preflight_claude_code_auth(Config(), ())
-        assert result is None
-        assert "claude setup-token" in capsys.readouterr().err
-
-    def test_env_token_is_staged_and_rule_added(self, monkeypatch, tmp_path):
-        self._isolate(monkeypatch, tmp_path)
-        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok-abc")
-        cfg = Config()
-        result = _preflight_claude_code_auth(cfg, ())
-        assert result == ("CLAUDE_CODE_OAUTH_TOKEN=tok-abc",)
-        assert [r.env for r in cfg.secret_injection] == ["CLAUDE_CODE_OAUTH_TOKEN"]
-        assert cfg.secret_injection[0].inject_to == ["anthropic.com"]
-
-    def test_explicit_oauth_secret_adds_rule_without_restaging(
-        self, monkeypatch, tmp_path,
-    ):
-        self._isolate(monkeypatch, tmp_path)
-        cfg = Config()
-        secrets = ("CLAUDE_CODE_OAUTH_TOKEN=tok-xyz",)
-        result = _preflight_claude_code_auth(cfg, secrets)
-        # `-s` value is kept as-is, not duplicated from the (absent) env.
-        assert result == secrets
-        assert [r.env for r in cfg.secret_injection] == ["CLAUDE_CODE_OAUTH_TOKEN"]
-
-    def test_api_key_secret_passes_without_oauth_rule(self, monkeypatch, tmp_path):
-        self._isolate(monkeypatch, tmp_path)
-        cfg = Config()
-        result = _preflight_claude_code_auth(cfg, ("ANTHROPIC_API_KEY=k",))
-        assert result == ("ANTHROPIC_API_KEY=k",)
-        assert cfg.secret_injection == []
-
-    def test_persisted_in_cage_login_passes(self, monkeypatch, tmp_path):
-        self._isolate(monkeypatch, tmp_path)
-        creds = tmp_path / ".claude" / ".credentials.json"
-        creds.parent.mkdir(parents=True)
-        creds.write_text("{}")
-        cfg = Config()
-        result = _preflight_claude_code_auth(cfg, ())
-        assert result == ()
-        assert cfg.secret_injection == []
 
 
 class TestGenerateName:

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -151,12 +151,6 @@ class TestCodingAgentScaffolds:
         cfg = load_config(str(p))
         validate_config(cfg)
 
-    def test_claude_code_mounts_host_claude_dir(self):
-        cfg_text = render_config("test-cc", scaffold="claude-code")
-        parsed = yaml.safe_load(cfg_text)
-        volumes = parsed.get("container", {}).get("volumes", [])
-        assert any(".claude:" in v for v in volumes)
-
     def test_claude_code_has_secret_injection(self):
         cfg_text = render_config("test-cc", scaffold="claude-code")
         parsed = yaml.safe_load(cfg_text)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.21.3"
+version = "0.21.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- The claude-code, codex, and pi scaffolds shipped with active host bind-mounts of `~/.claude`, `~/.codex`, and `~/.pi`. The host tree carries credentials, OAuth tokens, transcripts, MCP configs, and project memory — leaking any of that into the cage defeats the purpose of sandboxing the agent. Comment the mounts out and flip the surrounding docs to opt-in framing.
- The opt-out → opt-in switch surfaced a chain of claude-code-specific logic in agentcage core that this PR also cleans up: deleted `_preflight_claude_code_auth`, `_CLAUDE_CODE_AUTH_HELP`, the `if scaffold == "claude-code":` branch in `execute()`, and the hardcoded `_SCAFFOLD_ALIASES` / `_NAME_PREFIXES` dicts. Replaced with generic `scaffold_aliases()` / `scaffold_name_prefix()` helpers that read from each scaffold's `scaffold.yaml`.
- `scaffolds/claude-code/scaffold.yaml` declares `aliases: [claude]` and `name_prefix: claude` so `agentcage run claude` and `claude-bold-fox`-style cage names keep working via the generic mechanism.
- Genericized stale claude-code mentions in comments across `quadlets.py`, `lima/provisioning.py`, `backends/apple_container.py`, and CLI examples.

## Followup

With the host mount disabled, in-cage `claude login` tokens persist only in the cage's writable layer and are lost on `cage update` / image rebuild. Adding a podman named volume for `/home/node/.claude` (the same pattern openclaw uses with its `{{ name }}-state` volume) would give safe persistence without exposing host state. Not included here — behavior change, not a hardening fix.

## Test plan

- [x] `uv run pytest` — 1496 passed
- [x] `agentcage run --help` shows updated examples
- [x] `agentcage scaffold create test-claude --from claude-code` copies the hardened scaffold (mount commented out)
- [x] `scaffold_aliases()` returns `{'claude': 'claude-code'}` and `generate_name('claude-code')` still produces `claude-<adj>-<noun>`
- [ ] Manual: `agentcage run claude` resolves to claude-code on a real host

🤖 Generated with [Claude Code](https://claude.com/claude-code)