### PR TITLE
fix(quadlets): drop broad /agentcage mount — sibling resolv config leak

### DIFF
--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -15,7 +15,14 @@ Environment="NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem"
 Environment="SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem"
 Environment="AGENTCAGE_VERSION={{ agentcage_version }}"
 Volume={{ name }}-certs.volume:/certs:ro,Z
-Volume={{ patches_host_dir }}:/agentcage:ro,Z
+{# NOTE: do NOT reintroduce a broad `Volume={{ patches_host_dir }}:/agentcage`
+   bind here. That mount used to expose every sibling cage's resolv-<name>.conf
+   inside this cage (cage name + DNS sidecar IP — any cage could `ls /agentcage/`
+   to enumerate its host neighbours). The runtime only needs the cage's own
+   resolv.conf (mounted at /etc/resolv.conf on the next line) and, in
+   nested-containers mode, the specific files under <patches_host_dir>/nested/
+   mounted at fixed cage paths below (/etc/containers, /usr/local/bin/docker).
+   No cage-side /agentcage/ directory is required. #}
 Volume={{ patches_host_dir }}/resolv-{{ name }}.conf:/etc/resolv.conf:ro,Z
 {% for vol in volumes %}
 Volume={{ vol }}

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -778,9 +778,51 @@ class TestCageQuadlet:
         assert 'NODE_OPTIONS' not in content
         assert 'Environment="AGENTCAGE_VERSION=' in content
         assert "Volume=test-certs.volume:/certs:ro,Z" in content
-        assert "Volume=/home/patches:/agentcage:ro,Z" in content
+        # The broad `<patches_host_dir>:/agentcage` bind was removed — it
+        # leaked every sibling cage's resolv-<name>.conf to this cage.
+        assert "Volume=/home/patches:/agentcage:ro,Z" not in content
         assert "nsenter" in content
         assert f"ip route replace default via {addrs['ip_proxy']}" in content
+
+    def test_cage_no_broad_patches_mount(self, minimal_yaml):
+        """Regression guard for the resolv-leak finding: the cage quadlet
+        must NOT bind-mount the entire patches_host_dir at /agentcage.
+        That directory holds per-cage resolv-<name>.conf for every cage
+        on the host, so a broad RO mount let any cage enumerate its
+        siblings' names + DNS sidecar IPs."""
+        cfg = load_config(minimal_yaml)
+        files = generate_quadlets(cfg, "/c.yaml", "/home/patches")
+        content = files["test-cage.container"]
+
+        # No volume directive may map `<patches_host_dir>` (or its expansion)
+        # to a bare `/agentcage` target. The narrower per-file mounts under
+        # `/agentcage/<...>` (e.g. nested/docker → /usr/local/bin/docker)
+        # are fine — only the top-level directory bind is forbidden.
+        for line in content.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("Volume="):
+                continue
+            spec = stripped[len("Volume="):]
+            # Parse `source:target[:opts]` — the target is the second field.
+            parts = spec.split(":")
+            if len(parts) < 2:
+                continue
+            target = parts[1]
+            assert target != "/agentcage", (
+                f"broad /agentcage mount reintroduced: {line!r}"
+            )
+
+    def test_cage_resolv_conf_still_mounted(self, minimal_yaml):
+        """The cage's own resolv.conf must still arrive via a direct
+        bind at /etc/resolv.conf — independent of the broad /agentcage
+        mount that we removed."""
+        cfg = load_config(minimal_yaml)
+        files = generate_quadlets(cfg, "/c.yaml", "/home/patches")
+        content = files["test-cage.container"]
+        assert (
+            "Volume=/home/patches/resolv-test.conf:/etc/resolv.conf:ro,Z"
+            in content
+        )
 
     def test_cage_defaults_hardening(self, minimal_yaml):
         cfg = load_config(minimal_yaml)


### PR DESCRIPTION
## Summary

The cage quadlet template was bind-mounting the entire `~/.local/share/agentcage/patches/` host dir into every cage at `/agentcage/:ro`. That dir contains one `resolv-<name>.conf` per cage the operator has ever created, plus historical `proxy-fetch.mjs` / `node_modules/` / `package.json` left over from the pre-0.6.3 Node fetch monkey-patch. Any cage could `ls /agentcage/` and enumerate the names + DNS sidecar IPs of every sibling cage on the same host.

The current runtime has no consumer of `/agentcage/`:
- `proxy-fetch.mjs` was removed from active use in 0.6.3 (see CHANGELOG: *"proxy-fetch patches were removed in 0.6.3"*) — no `NODE_OPTIONS=--import` or `--require` is set anywhere, and `tests/test_quadlets.py` already asserts `NODE_OPTIONS not in content`. `ensure_patches()` doesn't stage proxy-fetch either; it only copies `nested/`.
- The cage's own `resolv-<name>.conf` is mounted directly at `/etc/resolv.conf` on the next line — independent of the broad mount.
- The four `nested/*` files (`containers.conf`, `storage.conf`, `registries.conf`, `docker`) are individually bind-mounted at `/etc/containers/*` and `/usr/local/bin/docker` later in the same template (lines ~69–72) — not consumed via `/agentcage/nested/`.

So the broad mount has no operative use and is pure information disclosure. This PR drops it.

## Changes

- `src/agentcage/templates/cage.container.j2`: remove the `Volume={{ patches_host_dir }}:/agentcage:ro,Z` line; replace with a Jinja comment (stripped from rendered output) warning maintainers not to reintroduce it.
- `tests/test_quadlets.py`:
  - Update `test_cage_basics`: the assertion that previously pinned the broad mount now asserts its absence.
  - Add `test_cage_no_broad_patches_mount`: scans every `Volume=` line in the rendered quadlet and forbids any directive targeting `/agentcage`.
  - Add `test_cage_resolv_conf_still_mounted`: pins the per-cage `resolv.conf` bind so a future cleanup of the surrounding template can't silently break DNS.

## Side effects

- **Closes** the sibling-resolv-config information leak (cages can no longer enumerate other cages on the same host via `ls /agentcage/`).
- **Moots** the dispatcher-class bypass in the unused `proxy-fetch.mjs` (the file is no longer mounted, so the dead code is also no longer reachable from inside the cage).

## Test plan

- [x] `uv run pytest tests/test_quadlets.py -q` — 96 passed
- [x] `uv run pytest -q --ignore=tests/e2e` — 1504 passed, 0 failed
- [x] Smoke-rendered the cage quadlet with a minimal config; output structurally correct (no broken-line artifacts from comment stripping)
- [ ] CI: wait for E2E Container + E2E OpenClaw + test (3.12/3.13/3.14) — autofills below

🤖 Generated with [Claude Code](https://claude.com/claude-code)