### PR TITLE
fix(apple-container): wait for supervisor readiness before returning from start()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`agentcage cage create` / `agentcage run` on apple-container no longer return before the supervisor has finished booting** — race that caused the cage's next operator action to hit it before mitmproxy bound `127.0.0.1:8080`, iptables NAT applied, or secrets were re-staged into `/home/acproxy/secrets/`. Symptom: claude / curl gets "Invalid API key" or HTTP 401 going to `api.anthropic.com` because the literal `{{PLACEHOLDER}}` reaches upstream (the proxy that would substitute it isn't up yet). Apple's `container run -d` returns when the microVM boots — not when the user CMD (`supervisor.sh`) has progressed past its final stage. `AppleContainerBackend.start()` now polls a host-side virtiofs marker (`<logs_dir>/ready`) that supervisor.sh touches as the very last action before `exec capsh`. Stale markers from prior cage lifetimes are cleared before `container run -d`. If the cage exits before signaling ready (supervisor `die`d at some stage), `start()` raises immediately pointing at `container logs <name>` — no more silent "running but broken" cages. (#168)
+
 ## [0.21.5] - 2026-05-26
 
 Two cage-isolation fixes surfaced by an in-cage CTF red-team run on `claude-code` and `pi` scaffolds. **Upgrade recommended for any host that runs more than one cage, or that has ever logged in with Claude Code / Codex / pi-style agents on the host machine.** Existing cages need `cage update` (or recreate) to pick up the template changes.

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -638,9 +638,31 @@ class AppleContainerBackend:
 
         argv.append(image)
 
+        # Clear any stale readiness marker from a prior run BEFORE we kick
+        # `container run -d`. The supervisor will touch this file again as
+        # its final action of stage 90; we poll for it below.
+        ready_marker = self.logs_dir(name) / "ready"
+        try:
+            ready_marker.unlink()
+        except FileNotFoundError:
+            pass
+
         result = ac_cli.run(argv, check=False, capture_output=False)
         if result.returncode != 0:
             raise RuntimeError(f"`container run` failed (exit {result.returncode})")
+
+        # Wait for the supervisor to finish booting before returning. Apple's
+        # `container run -d` returns when the microVM is up — NOT when the
+        # user CMD (supervisor.sh) has progressed past stage 90. Without
+        # this poll, the next operator action (`cage exec`, `agentcage run`'s
+        # integrated claude exec, etc.) races the supervisor and may hit the
+        # cage before dnsmasq binds, mitmproxy listens, iptables NAT applies,
+        # or secrets are re-staged into /home/acproxy/secrets/. The supervisor
+        # `touch`es /var/log/agentcage/ready right before its `exec capsh`,
+        # which lands on the host-side virtiofs bind at logs_dir(name)/ready.
+        # See issue #168.
+        self._wait_supervisor_ready(name, ready_marker)
+
         # Install (or refresh) the launchd plist if the cage opted in to
         # autostart. Read from the unit metadata so plists stick across
         # reloads — the user-visible cage.yaml may have been edited since
@@ -650,6 +672,41 @@ class AppleContainerBackend:
             self._install_launchd_plist(name)
         if not quiet:
             click.echo(f"Started {name} (apple-container)")
+
+    # Polling interval and total timeout for the supervisor readiness wait.
+    # Module-level so tests can monkeypatch them to ~0 without subclassing.
+    _READY_POLL_INTERVAL_S = 0.1
+    _READY_TIMEOUT_S = 30.0
+
+    def _wait_supervisor_ready(self, name: str, marker: Path) -> None:
+        """Block until ``marker`` exists or the cage exits.
+
+        Raises ``RuntimeError`` if the cage exits before signaling ready
+        (so the operator sees a real error, not a successful return that
+        then 401s on the first request).
+        """
+        import time as _time
+
+        deadline = _time.monotonic() + self._READY_TIMEOUT_S
+        while _time.monotonic() < deadline:
+            if marker.exists():
+                return
+            # If the cage exited (supervisor `die`d at some stage, or the
+            # workload itself crashed before we got a chance to wait), we'd
+            # otherwise loop until timeout. Detect it and surface the error.
+            data = ac_cli.inspect(name)
+            status = (data or {}).get("status") or (data or {}).get("Status")
+            if data is not None and status not in ("running", None):
+                raise RuntimeError(
+                    f"cage {name!r} exited before becoming ready "
+                    f"(status={status!r}); see `container logs {name}`"
+                )
+            _time.sleep(self._READY_POLL_INTERVAL_S)
+        raise RuntimeError(
+            f"cage {name!r} did not signal ready within "
+            f"{self._READY_TIMEOUT_S:.0f}s; see `container logs {name}` "
+            f"for the supervisor's last stage"
+        )
 
     def stop(self, name: str) -> None:
         ac_cli.run(["stop", name], check=False)

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -300,6 +300,16 @@ log "stage 90: dropping caps, switching to cage user '${CAGE_USER}' (uid 1000)"
 #   --user=$CAGE_USER → setuid+setgid+initgroups to the uid-1000 user. The
 #                     uid 0→1000 transition clears CapEff/CapPrm/CapInh.
 #                     CapBnd is already empty from --drop=all above.
+# Readiness marker — the LAST thing supervisor does before handoff. The
+# host-side `AppleContainerBackend.start()` polls for this file on the
+# virtiofs-shared /var/log/agentcage mount, so it can return only after
+# every stage (proxy listening, iptables NAT, secrets staged) has
+# completed. Without this, the next `container exec` (or `agentcage run`
+# claude-code) races the supervisor and sees missing /home/acproxy/secrets,
+# no proxy on 127.0.0.1:8080, or no iptables NAT — leading to "Invalid
+# API key" / placeholder-leaks-to-upstream symptoms. See issue #168.
+touch /var/log/agentcage/ready
+
 exec capsh \
   --no-new-privs \
   --drop=all \

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -751,7 +751,8 @@ def test_start_argv_uses_file_delivery_when_placeholders_known(
          patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
@@ -817,7 +818,8 @@ def test_start_argv_drops_stale_secrets_from_prior_starts(
          patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     # OLD_KEY removed; NEW_KEY present.
@@ -870,7 +872,8 @@ def test_start_argv_pre_021_1_unit_json_refuses_cleartext_fallback(
          patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
@@ -980,7 +983,8 @@ def test_start_argv_ignores_host_env_when_pending_secrets_missing(
          patch.object(backend, "secrets_dir", return_value=secrets_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
@@ -1336,7 +1340,8 @@ def test_start_argv_includes_normalized_cpus_memory(tmp_path):
     with patch.object(backend, "unit_dir", return_value=unit_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
@@ -1392,7 +1397,8 @@ def test_start_creates_logs_dir_and_bind_mounts_it(tmp_path):
          patch.object(backend, "logs_dir", return_value=logs_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     # Host logs dir created.
@@ -1438,11 +1444,144 @@ def test_start_argv_backward_compat_pre_0_20_6_mem_mb(tmp_path):
     with patch.object(backend, "unit_dir", return_value=unit_dir), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
          patch.object(ac_cli, "inspect", return_value=None), \
-         patch.object(ac_cli, "run", side_effect=fake_run):
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
         backend.start("demo", quiet=True)
 
     run_argv = next(a for a in captured_argv if a[0] == "run")
     assert run_argv[run_argv.index("--memory") + 1] == "4096M"
+
+
+def test_start_waits_for_supervisor_ready_marker(tmp_path, monkeypatch):
+    """`start()` must block until supervisor.sh signals readiness via
+    ``logs_dir(name)/ready`` — the host-side virtiofs view of the
+    in-cage ``touch /var/log/agentcage/ready`` at the end of stage 90.
+    Without this wait the operator's next action races the supervisor
+    and sees missing /home/acproxy/secrets, no proxy, etc. (issue #168)."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo", "user_image": "x", "cpus": 1,
+        "memory": "1G", "lifecycle": "interactive",
+    }))
+    logs_dir = tmp_path / "logs"
+
+    # Speed up the poll so a missed signal would fail fast in CI.
+    monkeypatch.setattr(AppleContainerBackend, "_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(AppleContainerBackend, "_READY_TIMEOUT_S", 1.0)
+
+    def fake_run(argv, **_kwargs):
+        # Mirror real supervisor.sh: touch the marker as the LAST thing
+        # before the cage workload starts. The marker file is the contract
+        # between supervisor and backend.
+        if argv and argv[0] == "run":
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            (logs_dir / "ready").touch()
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value={"status": "running"}), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        # Returns cleanly when the marker is present.
+        backend.start("demo", quiet=True)
+
+
+def test_start_clears_stale_ready_marker_before_run(tmp_path, monkeypatch):
+    """A leftover marker from a prior cage lifetime must NOT be honored:
+    `start()` deletes it BEFORE `container run -d`, then re-polls. Otherwise
+    a restart would return instantly while the new supervisor was still
+    booting — the original race."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo", "user_image": "x", "cpus": 1,
+        "memory": "1G", "lifecycle": "interactive",
+    }))
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    # Stale marker from a previous run.
+    stale = logs_dir / "ready"
+    stale.touch()
+
+    monkeypatch.setattr(AppleContainerBackend, "_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(AppleContainerBackend, "_READY_TIMEOUT_S", 0.5)
+
+    deleted = {"happened": False}
+
+    def fake_run(argv, **_kwargs):
+        if argv and argv[0] == "run":
+            # At this point, start() should already have unlinked the stale
+            # marker (mirroring real cage start). Record + re-create.
+            deleted["happened"] = not stale.exists()
+            stale.touch()
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value={"status": "running"}), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        backend.start("demo", quiet=True)
+
+    assert deleted["happened"], \
+        "start() must unlink stale ready marker BEFORE container run"
+
+
+def test_start_raises_when_supervisor_dies_before_ready(tmp_path, monkeypatch):
+    """If the cage exits before signaling ready (supervisor `die`d at some
+    stage), `start()` must raise immediately with a pointer to
+    `container logs` — not silently return so the operator hits a confusing
+    "Invalid API key" / "connection refused" later."""
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo", "user_image": "x", "cpus": 1,
+        "memory": "1G", "lifecycle": "interactive",
+    }))
+    logs_dir = tmp_path / "logs"
+
+    monkeypatch.setattr(AppleContainerBackend, "_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(AppleContainerBackend, "_READY_TIMEOUT_S", 1.0)
+
+    def fake_run(argv, **_kwargs):
+        # No marker touched; cage will be reported as exited.
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=logs_dir), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value={"status": "exited"}), \
+         patch.object(ac_cli, "run", side_effect=fake_run):
+        with pytest.raises(RuntimeError, match="exited before becoming ready"):
+            backend.start("demo", quiet=True)
+
+
+def test_supervisor_touches_ready_marker_before_capsh():
+    """supervisor.sh must touch ``/var/log/agentcage/ready`` as its LAST
+    action before `exec capsh`. Mis-placement (before iptables / before
+    proxy listening) would re-introduce the race. Static check of the
+    supervisor source."""
+    import re
+    sup_path = (Path(__file__).resolve().parent.parent
+                / "src/agentcage/data/apple-container/supervisor.sh")
+    text = sup_path.read_text()
+    touch_idx = text.find("touch /var/log/agentcage/ready")
+    capsh_idx = text.rfind("exec capsh")
+    assert touch_idx != -1, "supervisor.sh must touch the readiness marker"
+    assert capsh_idx != -1, "supervisor.sh must end with `exec capsh`"
+    assert touch_idx < capsh_idx, \
+        "touch /var/log/agentcage/ready must come BEFORE exec capsh"
+    # Make sure no other stage marker (`stage NN:`) comes between the touch
+    # and the capsh — i.e. it really is the last thing.
+    between = text[touch_idx:capsh_idx]
+    later_stages = re.findall(r'^log "stage \d+:', between, re.MULTILINE)
+    assert not later_stages, \
+        f"no stages may run between ready-touch and capsh; found {later_stages}"
 
 
 def test_run_streaming_pauses_active_spinner():


### PR DESCRIPTION
## Summary

- Fixes the race tracked in #168: `agentcage cage create` / `agentcage run` on apple-container returned before supervisor.sh finished its boot sequence, so the operator's next action (claude exec, etc.) hit a half-up cage and produced misleading "Invalid API key" symptoms.
- Adds a host-side virtiofs marker (`<logs_dir>/ready`) that supervisor.sh touches as the very last action of stage 90. `AppleContainerBackend.start()` polls for it with a 30s timeout; stale markers cleared before `container run -d`.
- 4 new tests covering the readiness wait, stale-marker cleanup, early-exit detection, and a static check that the supervisor touches the marker BEFORE `exec capsh`.

## Why

Apple's `container run -d` returns when the microVM boots — NOT when the user CMD (`supervisor.sh`) has reached stage 90 (capsh-drop + exec user binary). Stages still pending after `start()` returned:

| Stage | What it does | If raced |
|---|---|---|
| 30 | dnsmasq up | DNS resolution fails inside cage |
| 35 | re-stage secrets → `/home/acproxy/secrets`, umount the bind | `/home/acproxy/secrets/` missing; addon has no value to substitute |
| 40 | mitmproxy on 127.0.0.1:8080 | Egress hits upstream directly with literal placeholder → 401 |
| 80 | iptables NAT REDIRECT to proxy | Traffic bypasses proxy entirely |
| 90 | capsh-drop + exec user CMD | Cage workload not running as uid 1000 with empty caps |

For `agentcage run` the race window was large because it builds → `start()` → immediately exec-claude. Reproduced fresh on 0.21.4 on m1@62.210.193.28 while running the agentcage-ctf prompt.

## Design

- supervisor.sh stage 90: `touch /var/log/agentcage/ready` immediately before `exec capsh ...`. The directory is bind-mounted from the host via virtiofs, so the marker appears host-side without needing `container exec`.
- `AppleContainerBackend.start()`:
  - Before `container run -d`: `unlink(logs_dir/ready)` (defensive — old marker from prior cage life mustn't fool the poll).
  - After `container run -d`: `_wait_supervisor_ready(name, marker)` polls `marker.exists()` every 100ms up to 30s. If the cage `inspect` status flips to non-running before the marker appears, raises `RuntimeError` immediately pointing at `container logs <name>` (no more silent "running but broken" cages).
- Test-side opt-out: `patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None)` added to the 7 existing `start()` tests so they don't time out waiting for a real cage.

## Verified end-to-end

Built a wheel with this branch, deployed to the same Mac that reproduced the bug:
- Smoke test: `agentcage run claude-code -- --dangerously-skip-permissions -p "respond with exactly the word PONG"` → `PONG` between separators ✓
- Full CTF prompt: cage came up, claude made the API call, Anthropic returned a real response (it was blocked by Anthropic's cyber-content policy classifier, but that's separate — the network/secret-injection chain worked) ✓

## Test plan

- [x] 4 new tests in `tests/test_apple_container.py`: `test_start_waits_for_supervisor_ready_marker`, `test_start_clears_stale_ready_marker_before_run`, `test_start_raises_when_supervisor_dies_before_ready`, `test_supervisor_touches_ready_marker_before_capsh` (static source check).
- [x] Full suite: 1502 passing on Linux.
- [x] Manual macOS verification on fresh Mac: race symptom gone; no false-positive readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)