### PR TITLE
feat(apple-container): honor container.volumes: as --volume args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **apple-container honors `container.volumes:`.** Pre-fix the validator emitted `container.volumes: silently has no effect on apple-container (host bind mounts ... — the cage gets no host paths)` and the backend never passed the entries through. Apple's `container run` actually supports `--volume host:cage[:mode]` (we already use it for `/var/log/agentcage` and `/run/agentcage/secrets`), so the fix is to iterate `cfg.container.volumes` in `AppleContainerBackend.start()` and emit one `--volume` per entry. Volume entries are persisted in the per-cage unit JSON at `cage create` time (a `cage update` is the rebuild boundary, matching how the rest of the runtime config flows). Host-path safety mirrors the container backend's quadlet generator: `~` and `$VAR` are expanded; entries with unresolved variables, missing `:`, or whose host path resolves outside `$HOME` are skipped with a warning. This unblocks `agentcage run --project DIR` on apple-container — `${PROJECT_DIR}:/workspace:rw` from the scaffold j2 template now actually lands in the cage.
+
 ## [0.21.7] - 2026-05-26
 
 Re-release of 0.21.6 — GitHub Actions silently dropped the tag-push event for the v0.21.6 tag (twice; even after delete + re-push), so the wheel never reached PyPI. No code changes between 0.21.6 and 0.21.7; the only diff is a `workflow_dispatch:` fallback added to the Release workflow so future dropped events can be re-fired by hand. Use 0.21.7 instead of 0.21.6.

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -116,6 +116,53 @@ class AppleContainerBackend:
         """
         return self._state_dir(name) / "secrets"
 
+    @staticmethod
+    def _user_volume_argv(raw_entries: list[str]) -> list[str]:
+        """Expand and validate user-supplied ``container.volumes`` entries.
+
+        Returns a list of ``host:cage[:mode]`` strings ready to splice
+        into ``container run --volume <entry>``. Mirrors the quadlet
+        backend's safety rules so behavior is identical across backends:
+
+        - Expand ``~`` and ``$VAR`` in the host portion.
+        - Skip (with a warning) entries whose host path still contains an
+          unresolved ``$``.
+        - Reject (with a warning + skip) entries whose host path resolves
+          outside the operator's home directory — prevents bind-ing
+          ``/etc``, ``/var``, ``/root``, etc. by accident.
+        - Reject (warning + skip) entries with no ``:`` separator (no
+          target path).
+        """
+        out: list[str] = []
+        home = os.path.realpath(os.path.expanduser("~"))
+        for v in raw_entries:
+            if ":" not in v:
+                click.echo(
+                    f"warning: skipping volume {v!r} on apple-container "
+                    "(missing ':<cage-path>')",
+                    err=True,
+                )
+                continue
+            parts = v.split(":", 1)
+            host_part = os.path.expandvars(os.path.expanduser(parts[0]))
+            if "$" in host_part:
+                click.echo(
+                    f"warning: skipping volume {host_part!r} on apple-container "
+                    "(unresolved variable in host path)",
+                    err=True,
+                )
+                continue
+            real = os.path.realpath(host_part)
+            if not (real == home or real.startswith(home + os.sep)):
+                click.echo(
+                    f"warning: skipping volume {host_part!r} on apple-container "
+                    f"(host path resolves outside {home!r})",
+                    err=True,
+                )
+                continue
+            out.append(f"{real}:{parts[1]}")
+        return out
+
     def _launchd_plist_path(self, name: str) -> Path:
         """Host path of the per-cage launchd plist.
 
@@ -436,6 +483,13 @@ class AppleContainerBackend:
                 "secret_env_placeholders": secret_env_placeholders,
                 "relay_secret_envs": relay_secret_envs,
                 "autostart": bool(getattr(config, "apple_container_autostart", False)),
+                # User-defined host bind mounts. Apple's `container run`
+                # accepts `--volume host:cage[:mode]` just like podman, so
+                # we pass each through verbatim at start() time. Persisted
+                # in the unit JSON (rather than re-read from cage.yaml at
+                # start) so a `cage update` controls the surface, matching
+                # how the rest of the runtime config flows.
+                "volumes": list(config.container.volumes),
             },
             indent=2,
             sort_keys=True,
@@ -507,6 +561,14 @@ class AppleContainerBackend:
             "--cap-add", "CAP_NET_ADMIN",
             "--volume", f"{logs_dir}:/var/log/agentcage",
         ]
+        # User-defined bind mounts. Each entry is `host:cage[:mode]`; we
+        # expand ~ / $VAR in the host path, validate it lives under $HOME
+        # (same containment rule the container backend's quadlet template
+        # enforces — prevents accidental /etc, /var, /root bind-ins), and
+        # pass through verbatim. Unresolved $VAR yields a warning + skip
+        # to match quadlets.py's behavior for parity.
+        for vol_entry in self._user_volume_argv(meta.get("volumes") or []):
+            argv += ["--volume", vol_entry]
         # Apple's `container run --cpus / --memory` has stricter input
         # acceptance than podman: --cpus requires an integer (fractional
         # like "0.5" or "1.5" → "Help: --cpus <cpus> ..." rejection), and

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -944,9 +944,12 @@ def validate_config(config: Config) -> list[str]:
         # Each entry: (field-path, predicate-on-config-that-says-"non-default",
         # human-readable summary of what the field's effect would be elsewhere).
         _ac_silent_drops: list[tuple[str, bool, str]] = [
-            ("container.volumes", bool(config.container.volumes),
-             "host bind mounts (apple-container has no bind-mount support yet — "
-             "the cage gets no host paths)"),
+            # container.volumes is no longer silently dropped — it now
+            # flows through `AppleContainerBackend.start()` as per-entry
+            # `--volume host:cage[:mode]` argv, with the same containment
+            # rule the container backend's quadlet enforces (host path
+            # must live under $HOME). See backends/apple_container.py
+            # `_user_volume_argv`.
             ("container.named_volumes", bool(config.container.named_volumes),
              "podman named volumes (no equivalent on apple-container)"),
             ("container.tmpfs", bool(config.container.tmpfs),

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1584,6 +1584,98 @@ def test_supervisor_touches_ready_marker_before_capsh():
         f"no stages may run between ready-touch and capsh; found {later_stages}"
 
 
+def test_start_passes_user_volumes_as_container_run_args(tmp_path, monkeypatch):
+    """`container.volumes` entries flow through `start()` as
+    `--volume host:cage[:mode]` argv. Was silently dropped pre-this-PR
+    (config.py used to warn via _ac_silent_drops). Verifies the unit
+    JSON persists them and start() reads them back."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    # Two volumes — one rw, one ro — to ensure mode strings pass through.
+    rw_host = tmp_path / "rw-src"
+    rw_host.mkdir()
+    ro_host = tmp_path / "ro-src"
+    ro_host.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo", "user_image": "x", "cpus": 1,
+        "memory": "1G", "lifecycle": "interactive",
+        "volumes": [f"{rw_host}:/workspace:rw", f"{ro_host}:/readonly:ro"],
+    }))
+    captured_argv: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
+         patch.object(backend, "secrets_dir", return_value=tmp_path / "secrets"), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a and a[0] == "run")
+    # Both volumes are present, in order, with their modes preserved.
+    assert f"{rw_host}:/workspace:rw" in run_argv
+    assert f"{ro_host}:/readonly:ro" in run_argv
+    # Each --volume arg is paired with a flag (smoke check for argv shape).
+    vol_positions = [i for i, a in enumerate(run_argv) if a == "--volume"]
+    for pos in vol_positions:
+        assert pos + 1 < len(run_argv), \
+            "stray --volume with no value in argv"
+
+
+def test_user_volume_argv_skips_unresolved_var():
+    """`$VAR` that didn't expand → skip + warn, not crash. Mirrors quadlets.py."""
+    out = AppleContainerBackend._user_volume_argv(["$UNSET_VAR/foo:/cage:rw"])
+    assert out == []
+
+
+def test_user_volume_argv_skips_path_outside_home(tmp_path, monkeypatch):
+    """Host path outside $HOME → skip + warn. Prevents `/etc:/...` style bind-ins."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = AppleContainerBackend._user_volume_argv(["/etc:/cage:rw"])
+    assert out == []
+
+
+def test_user_volume_argv_skips_missing_separator():
+    """Entry without `:` (no cage path) → skip + warn, not silently pass through."""
+    out = AppleContainerBackend._user_volume_argv(["/just/a/path"])
+    assert out == []
+
+
+def test_user_volume_argv_accepts_home_relative_paths(tmp_path, monkeypatch):
+    """`~/path:/cage` expands to an absolute host path under $HOME and is accepted."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / "work"
+    target.mkdir()
+    out = AppleContainerBackend._user_volume_argv(["~/work:/cage:rw"])
+    assert out == [f"{target}:/cage:rw"]
+
+
+def test_unit_json_persists_user_volumes(tmp_path, monkeypatch):
+    """`generate_units` must include `volumes` in the unit JSON so a
+    subsequent `start()` (which only reads the unit JSON, not the
+    cage.yaml) can re-emit them as --volume args. Was missing pre-fix."""
+    from agentcage.config import Config, ContainerConfig
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(
+            image="localhost/test:latest",
+            volumes=["~/foo:/workspace:rw"],
+        ),
+    )
+    backend = AppleContainerBackend()
+    out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
+    parsed = json.loads(out["demo.json"])
+    assert parsed["volumes"] == ["~/foo:/workspace:rw"]
+
+
 def test_run_streaming_pauses_active_spinner():
     """``ac_cli.run(capture_output=False)`` must wrap subprocess.run in
     ``output.pause_active_spinner()`` so Apple's CLI progress doesn't fight

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1719,7 +1719,10 @@ class TestAppleContainerSilentDrops:
              patch("agentcage.config.platform.machine", return_value="arm64"):
             return cfg, validate_config(cfg)
 
-    def test_volumes_warns(self, tmp_path):
+    def test_volumes_no_longer_warns(self, tmp_path):
+        """`container.volumes` is wired through `AppleContainerBackend.start()`
+        as of feat/apple-volume-mounts — no longer in the silent-drops list.
+        Regression test against any future reintroduction of the warning."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -1727,12 +1730,11 @@ class TestAppleContainerSilentDrops:
             container:
               image: localhost/test:latest
               volumes:
-                - "/host:/cage:rw"
+                - "~/some-path:/cage:rw"
         """))
         _, warnings = self._validate_under_apple(str(p))
-        assert any(
-            "container.volumes" in w and "apple-container" in w and "#120" in w
-            for w in warnings
+        assert not any(
+            "container.volumes" in w for w in warnings
         ), warnings
 
     def test_named_volumes_warns(self, tmp_path):


### PR DESCRIPTION
## Summary

- Apple's `container run` supports `--volume host:cage[:mode]` (we already use it for `/var/log/agentcage` and `/run/agentcage/secrets`). Pre-fix, the validator silently warned that `container.volumes:` had no effect on apple-container and the backend ignored the entries. This PR wires them through.
- Unblocks `agentcage run --project DIR` on apple-container — `${PROJECT_DIR}:/workspace:rw` from the scaffold j2 template now actually lands in the cage.
- Same host-path safety as the container backend's quadlet generator: `~`/`$VAR` expansion, host path must resolve under `$HOME`, malformed entries are warned + skipped.

## Why

Discovered while running the agentcage-ctf prompt unattended via `agentcage run claude-code --project ~/ctf-test/workspace ...` — the CTF prompt instructed the agent to read agentcage source from `/workspace/agentcage`, but the cage saw an empty `/workspace`. Every cage create on apple-container printed the warning:

```
warning: container.volumes: silently has no effect on apple-container
(host bind mounts (apple-container has no bind-mount support yet — the
cage gets no host paths)). See issue #120 for the parity plan.
```

The "no bind-mount support yet" framing was wrong: we already use `--volume` for agentcage's own bind mounts. It was just never plumbed for user volumes.

## Design

- `generate_units` now writes `volumes` into the per-cage unit JSON so `cage update` is the rebuild boundary (matching how cpus / memory / secret_env_placeholders flow).
- `start()` calls a new `_user_volume_argv` helper that mirrors the safety rules from `quadlets.py:285-310`: expand `~`/`$VAR`, reject entries with unresolved variables, missing `:` separator, or host paths outside `$HOME`. Each surviving entry becomes a `--volume host:cage[:mode]` argv pair, in the same order the user listed them.
- `container.volumes` removed from `_ac_silent_drops` in `config.py`; comment block points future readers at the wiring in `apple_container.py`.

## Test plan

- [x] 5 new tests in `tests/test_apple_container.py`:
  - `test_start_passes_user_volumes_as_container_run_args` — end-to-end argv shape (both rw and ro entries).
  - `test_user_volume_argv_skips_unresolved_var` — `$UNSET_VAR/foo:/cage` → skipped.
  - `test_user_volume_argv_skips_path_outside_home` — `/etc:/cage` → skipped.
  - `test_user_volume_argv_skips_missing_separator` — `/just/a/path` → skipped.
  - `test_user_volume_argv_accepts_home_relative_paths` — `~/work:/cage` → expanded and passed through.
  - `test_unit_json_persists_user_volumes` — `generate_units` round-trip.
- [x] Old `test_volumes_warns` converted to `test_volumes_no_longer_warns` (regression).
- [x] Full suite: 1513 passing on Linux.
- [ ] **Manual macOS verification (next):** `agentcage run claude-code --project ~/ctf-test/workspace` → cage's `/workspace` now contains the host-side content (agentcage repo clone for the CTF white-box framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)