### PR TITLE
security(proxy): redact injected secrets from capture before disk write

### DIFF
--- a/src/agentcage/data/apple-container/allowlist_addon.py
+++ b/src/agentcage/data/apple-container/allowlist_addon.py
@@ -602,6 +602,68 @@ class AllowlistAddon:
                     transforms[rule["env"]] = rule["transform"]
         return injected, transforms
 
+    def _maybe_redact_request(self, flow: http.HTTPFlow) -> list[str]:
+        """Replace real secret values with placeholders on the (already-sent)
+        outbound REQUEST, so the capture writer never serializes raw
+        secret bytes to ``capture.jsonl``.
+
+        Mirror of ``_maybe_inject`` for the request path, but RUN AFTER
+        the proxy has already forwarded the mutated request upstream —
+        we are restoring the placeholder form on the in-memory flow
+        object before ``CaptureWriter.snapshot_request`` / the legacy
+        headers-only fallback reads ``flow.request.headers`` and
+        ``flow.request.content`` for disk serialization.
+
+        Why this exists: ``capture.jsonl`` is bind-mounted into the cage
+        rootfs (mode 0644, world-readable so ``agentcage cage har`` can
+        read it from the host). Without this redaction, the OUTBOUND
+        capture snapshot — by design "what went out on the wire" —
+        would land real ``ANTHROPIC_API_KEY`` (or whichever rule's value)
+        on disk where the cage workload can ``cat`` it. That defeats
+        the placeholder-injection trust model: the proxy held the raw
+        key precisely so the cage wouldn't see it; capture brings it
+        right back.
+
+        Host scope, sort order, binary-skip and ``inject_to`` semantics
+        match ``_maybe_redact`` (the response-side redactor) for
+        symmetry. Returns the list of env names that had at least one
+        substitution performed.
+        """
+        auth_host = _authoritative_host(flow)
+        host = (auth_host or flow.request.pretty_host).lower()
+        redacted: list[str] = []
+        # Sort longest value first so a secret that is a substring of
+        # another secret doesn't leave a partial leak behind.
+        sorted_rules = sorted(
+            self._resolved_secrets,
+            key=lambda r: len(r["value"]),
+            reverse=True,
+        )
+        for rule in sorted_rules:
+            value = rule["value"]
+            if not value:  # defensive — _resolved_secrets already filters
+                continue
+            if not self._host_matches_inject_to(host, rule["inject_to"]):
+                continue
+            placeholder = rule["placeholder"]
+            replaced_any = False
+            # Request headers
+            for name, val in list(flow.request.headers.items()):
+                if value in val:
+                    flow.request.headers[name] = val.replace(value, placeholder)
+                    replaced_any = True
+            # Request body — text only; binary bodies pass through.
+            try:
+                body_text = flow.request.get_text(strict=False)
+            except (UnicodeDecodeError, ValueError):
+                body_text = None
+            if body_text and value in body_text:
+                flow.request.set_text(body_text.replace(value, placeholder))
+                replaced_any = True
+            if replaced_any:
+                redacted.append(rule["env"])
+        return redacted
+
     def _maybe_redact(self, flow: http.HTTPFlow) -> list[str]:
         """Replace real secret values with placeholders on inbound responses.
 
@@ -947,6 +1009,39 @@ class AllowlistAddon:
             except Exception as exc:  # pragma: no cover
                 ctx.log.warn(
                     f"[agentcage] capture outbound-response snapshot failed: {exc}"
+                )
+
+        # ── REQUEST-side redaction (CRITICAL) ──────────────────
+        # At this point the upstream has already received the
+        # secret-substituted bytes (mitmproxy forwards the request after
+        # the ``request`` hook returns). Now we restore placeholder form
+        # on ``flow.request.headers`` / ``flow.request.content`` so the
+        # capture serialization that follows — both the legacy headers-
+        # only path and the rich CaptureWriter ``snapshot_request`` /
+        # the stashed ``pending["outbound_req"]`` — does NOT land raw
+        # secret bytes in ``capture.jsonl``. capture.jsonl is bind-
+        # mounted into the cage rootfs (mode 0644) so anything serialized
+        # post-inject is readable by the cage workload. The injected
+        # request is already on the wire to the upstream, so mutating
+        # ``flow.request`` here is purely cosmetic for downstream
+        # serializers — no traffic effect.
+        self._maybe_redact_request(flow)
+        # Refresh the stashed outbound-request snapshot with the redacted
+        # form, overwriting the post-inject snapshot the ``request()``
+        # hook stashed (which still held the raw secret bytes — that
+        # snapshot was the leak point).
+        if (
+            self._capture_writer is not None
+            and pending is not None
+        ):
+            try:
+                pending["outbound_req"] = (
+                    self._capture_writer.snapshot_request(flow)
+                )
+            except Exception as exc:  # pragma: no cover
+                ctx.log.warn(
+                    f"[agentcage] capture outbound-request re-snapshot "
+                    f"failed: {exc}"
                 )
 
         # Redact BEFORE inbound capture so the inbound view never sees raw values.

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -562,6 +562,35 @@ class Agentcage:
             self._cap_pending.pop(flow.id, None)
             return
 
+        # ── REQUEST-side secret redaction (CRITICAL) ──────────
+        # The upstream has already received the secret-substituted
+        # request bytes (mitmproxy forwarded after the ``request`` hook
+        # returned). Now we restore placeholder form on
+        # ``flow.request.url`` / ``.headers`` / ``.content`` so the
+        # capture serialization below — both the staged
+        # ``pending["outbound_req"]`` snapshot from the ``request()``
+        # hook AND any fresh snapshot taken here — does NOT write raw
+        # secret bytes to ``capture.jsonl``. The capture file is
+        # bind-mounted into the cage rootfs (mode 0644, world-readable)
+        # so anything serialized post-inject is readable by the cage
+        # workload — defeating the whole placeholder-injection trust
+        # model. The redaction is purely cosmetic for downstream
+        # serializers; the real request is already on the wire.
+        self.injector.redact_request(flow)
+        # Refresh the staged outbound-request snapshot with the redacted
+        # form, overwriting the post-inject snapshot the ``request()``
+        # hook stashed (which still held the raw secret bytes — that
+        # snapshot was the leak point).
+        if self._capture and flow.id in self._cap_pending:
+            try:
+                self._cap_pending[flow.id]["outbound_req"] = (
+                    self._capture.snapshot_request(flow)
+                )
+            except Exception as e:  # pragma: no cover
+                ctx.log.warn(
+                    f"agentcage: outbound-request re-snapshot failed: {e}"
+                )
+
         is_reverse = isinstance(
             getattr(flow.client_conn, "proxy_mode", None), ReverseMode
         )

--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -301,6 +301,73 @@ class SecretInjector:
                 names.append(rule.name)
         return names
 
+    def redact_request(self, flow: http.HTTPFlow) -> list[str]:
+        """Replace real secret values with placeholders in the outbound
+        REQUEST after it has been forwarded upstream — so the capture
+        writer never serializes raw secret bytes to ``capture.jsonl``.
+
+        This is the request-side mirror of ``redact_response``. It must
+        run AFTER ``inject_request`` has put the real secrets on the wire
+        (mitmproxy forwards on ``request`` hook return) and BEFORE any
+        capture serialization reads ``flow.request.url`` /
+        ``flow.request.headers`` / ``flow.request.content``. The capture
+        file is bind-mounted into the cage at mode 0644; without this
+        step the OUTBOUND request snapshot (by design "what went out
+        on the wire") would land the raw ``ANTHROPIC_API_KEY`` on disk
+        where the cage workload can read it.
+
+        Distinct from the ``redact_to`` path: ``_redact_request`` runs
+        at injection time for explicitly tagged ``redact_to`` domains
+        (the cage agent shouldn't see its own secret echoed back from
+        a non-trusted upstream). ``redact_request`` runs for EVERY rule
+        on EVERY domain after the upstream send, purely to scrub the
+        in-memory flow before disk serialization. Rules are processed
+        longest real-value first to avoid partial-match issues.
+
+        Returns the list of secret names that were redacted.
+        """
+        if not self.rules:
+            return []
+
+        sorted_rules = sorted(
+            self.rules, key=lambda r: len(r.real_value), reverse=True
+        )
+
+        names: list[str] = []
+        for rule in sorted_rules:
+            real = rule.real_value
+            real_bytes = real.encode()
+            ph = rule.placeholder
+            ph_bytes = ph.encode()
+
+            found = False
+
+            # Redact URL (rules that injected into query strings).
+            if real in flow.request.url:
+                flow.request.url = flow.request.url.replace(real, ph)
+                found = True
+
+            # Redact headers.
+            for k in list(flow.request.headers.keys()):
+                v = flow.request.headers[k]
+                if real in v:
+                    flow.request.headers[k] = v.replace(real, ph)
+                    found = True
+
+            # Redact body — only when the bytes are actually present;
+            # avoid touching ``flow.request.content`` otherwise so we
+            # don't churn binary bodies that legitimately contain no
+            # secret material.
+            if flow.request.content and real_bytes in flow.request.content:
+                flow.request.content = flow.request.content.replace(
+                    real_bytes, ph_bytes
+                )
+                found = True
+
+            if found:
+                names.append(rule.name)
+        return names
+
     def redact_response(self, flow: http.HTTPFlow) -> list[str]:
         """Replace real secret values with placeholders in the response.
 

--- a/tests/test_addon_capture_redaction.py
+++ b/tests/test_addon_capture_redaction.py
@@ -1,0 +1,319 @@
+"""End-to-end tests for the container-backend addon's request-side
+secret redaction in the capture pipeline.
+
+CTF-derived fix (apple-container 0.21.10):
+
+``SecretInjector.inject_request`` substitutes the real secret value
+into the outbound request URL, headers, and body so the upstream
+receives a working key. The capture writer then snapshots the flow
+into ``capture.jsonl`` — a file bind-mounted into the cage rootfs at
+mode 0644. Without a symmetric ``redact_request`` running between the
+upstream send and the capture write, raw ``ANTHROPIC_API_KEY`` bytes
+land on disk where the cage workload can recover them via
+``grep sk- /var/log/agentcage/capture.jsonl``. That defeats the
+placeholder-injection trust model: the proxy held the raw key
+precisely so the cage wouldn't see it; capture brought it right back.
+
+These tests instantiate the addon (``Agentcage()`` from
+``data/proxy/addon.py``), run the full request → inject →
+upstream-sent → response → redact_request → capture pipeline, and
+grep the on-disk ``capture.jsonl`` line for the real value. The
+assertion is binary: real value present in capture file = leak.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ── Stub mitmproxy before importing addon ────────────────
+
+
+_mitmproxy = types.ModuleType("mitmproxy")
+_mitmproxy.__path__ = []
+_mitmproxy.ctx = MagicMock()
+_mitmproxy.http = MagicMock()
+_proxy = types.ModuleType("mitmproxy.proxy")
+_proxy.__path__ = []
+_mode_specs = types.ModuleType("mitmproxy.proxy.mode_specs")
+_mitmproxy.proxy = _proxy
+_proxy.mode_specs = _mode_specs
+sys.modules.setdefault("mitmproxy", _mitmproxy)
+sys.modules.setdefault("mitmproxy.ctx", _mitmproxy.ctx)
+sys.modules.setdefault("mitmproxy.http", _mitmproxy.http)
+sys.modules.setdefault("mitmproxy.proxy", _proxy)
+sys.modules.setdefault("mitmproxy.proxy.mode_specs", _mode_specs)
+
+
+class _StubReverseMode:
+    """Standin so ``isinstance(x, ReverseMode)`` evaluates cleanly.
+
+    conftest.py stubbed ``ReverseMode`` as a MagicMock at collection
+    time, which makes the ``isinstance(proxy_mode, ReverseMode)`` call
+    in addon.request() / addon.response() crash with TypeError. We
+    overwrite it with a real class BEFORE importing the addon module
+    so the import binds ``ReverseMode`` to a proper type. No test flow
+    sets ``proxy_mode`` to an instance of this class, so the addon
+    correctly treats every flow as outbound transparent-mode traffic.
+    """
+
+
+# Important: replace the stub BEFORE the addon module is imported
+# below (the addon does ``from mitmproxy.proxy.mode_specs import
+# ReverseMode`` at module load and caches the binding).
+sys.modules["mitmproxy.proxy.mode_specs"].ReverseMode = _StubReverseMode
+
+# Stage the proxy/ dir so ``from addon import Agentcage`` etc. resolve.
+_PROXY_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "agentcage" / "data" / "proxy"
+)
+if str(_PROXY_DIR) not in sys.path:
+    sys.path.insert(0, str(_PROXY_DIR))
+
+# Drop any previously-imported addon module so it re-imports with the
+# patched ReverseMode binding.
+for _mod in ("addon", "capture", "secret_injector"):
+    sys.modules.pop(_mod, None)
+
+from addon import Agentcage  # noqa: E402
+from capture import CaptureWriter  # noqa: E402
+from secret_injector import InjectionRule, SecretInjector  # noqa: E402
+
+
+# ── Shared test helpers ─────────────────────────────────
+
+
+class _Headers(dict):
+    """dict subclass with mitmproxy.Headers-like methods.
+
+    - ``items(multi=True)`` — CaptureWriter walks this for snapshot
+      serialization.
+    - ``get(key, default)`` — case-insensitive lookup; CaptureWriter
+      calls ``headers.get("content-type", "")``.
+    - ``keys()`` returns a list copy so iter+mutate doesn't blow up.
+    """
+
+    def items(self, multi=False):  # noqa: ARG002
+        return list(super().items())
+
+    def get(self, key, default=None):  # type: ignore[override]
+        kl = key.lower()
+        for k, v in super().items():
+            if k.lower() == kl:
+                return v
+        return default
+
+    def keys(self):  # type: ignore[override]
+        return list(super().keys())
+
+
+def _build_addon_with_capture(tmp_path, *, rules, capture_domains=None):
+    """Construct an Agentcage with the secret_injector + capture wired up.
+
+    Skips the full ``load()`` config-parsing path (it expects a YAML
+    file on disk and a baked-in inspector chain we don't need for this
+    test). Instead we set the attributes load() would set, in the
+    same order, and point the capture writer at tmp_path.
+    """
+    addon = Agentcage()
+    addon.cfg = {}
+    addon.log_allowed = False
+    addon.inspectors = []
+    addon._rl_rate = 0.0  # disable rate limiter
+    addon._rl_burst = 0
+    addon._rl_buckets = {}
+    addon._audit_file = (tmp_path / "audit.jsonl").open("a")
+    addon._cap_pending = {}
+
+    addon.injector = SecretInjector()
+    addon.injector.rules = list(rules)
+    addon.injector.redact_to = []
+
+    cap_cfg: dict = {
+        "max_body_size": 10485760,
+        "domains": list(capture_domains) if capture_domains else [],
+    }
+    addon._capture = CaptureWriter(cap_cfg, str(tmp_path / "capture.jsonl"))
+    return addon
+
+
+def _make_flow(
+    *,
+    url="https://api.anthropic.com/v1/messages",
+    host="api.anthropic.com",
+    method="POST",
+    headers=None,
+    body=b"",
+    content_type="application/json",
+):
+    """Mock HTTPFlow shaped for the addon's request/response hooks."""
+    flow = MagicMock()
+    flow.id = "test-flow-leak"
+    flow.metadata = {}
+    flow.request.url = url
+    flow.request.host = host
+    flow.request.pretty_host = host
+    flow.request.pretty_url = url
+    flow.request.path = "/v1/messages"
+    flow.request.port = 443
+    flow.request.method = method
+    flow.request.http_version = "HTTP/1.1"
+    h = dict(headers or {})
+    h.setdefault("Content-Type", content_type)
+    flow.request.headers = _Headers(h)
+    flow.request.content = body if isinstance(body, bytes) else body.encode()
+    flow.request.get_text.side_effect = (
+        lambda strict=False: flow.request.content.decode(
+            "utf-8", errors="replace",
+        )
+    )
+    # client_conn — not a ReverseMode → addon treats as outbound.
+    flow.client_conn.proxy_mode = MagicMock()
+    flow.client_conn.tls_established = True
+    flow.client_conn.address = ("127.0.0.1", 12345)
+
+    # Response stub the test will populate as needed.
+    flow.response = None
+    return flow
+
+
+def _attach_response(flow, *, body=b'{"ok": true}', status=200,
+                     content_type="application/json"):
+    flow.response = MagicMock()
+    flow.response.status_code = status
+    flow.response.reason = "OK"
+    flow.response.http_version = "HTTP/1.1"
+    flow.response.headers = _Headers({"Content-Type": content_type})
+    flow.response.content = body if isinstance(body, bytes) else body.encode()
+    flow.response.get_text.side_effect = (
+        lambda strict=False: flow.response.content.decode(
+            "utf-8", errors="replace",
+        )
+    )
+
+
+# ── End-to-end: capture.jsonl must never carry the real value ──
+
+
+_FAKE_REAL = "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-CONTAINER-1234567890"
+
+
+def test_capture_jsonl_does_not_contain_real_secret_after_inject(tmp_path):
+    """The exact CTF F4 regression: cage sends a request with the
+    placeholder in the body, addon injects the real value upstream,
+    response comes back, addon writes the capture entry. The on-disk
+    ``capture.jsonl`` must NOT contain the raw ``sk-ant-api03-...``
+    bytes — only the placeholder."""
+    rule = InjectionRule(
+        name="ANTHROPIC_API_KEY",
+        placeholder="{{ANTHROPIC_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["anthropic.com"],
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    req_body = (
+        '{"model": "claude", "x-api-key": "{{ANTHROPIC_API_KEY}}"}'
+    )
+    flow = _make_flow(body=req_body)
+    addon.request(flow)
+    # Sanity: the upstream got the real value (inject worked).
+    assert _FAKE_REAL.encode() in flow.request.content
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert _FAKE_REAL not in cap_text, (
+        "real-key bytes leaked into capture.jsonl: "
+        f"{cap_text[:500]!r}..."
+    )
+    # Both perspectives should now show the placeholder, not the real
+    # bytes. inbound is what the cage sent; outbound was "what went on
+    # the wire" — post-fix that view also serializes the redacted form.
+    entry = json.loads(cap_text.splitlines()[0])
+    assert "{{ANTHROPIC_API_KEY}}" in entry["inbound"]["request"]["body"]
+    assert "{{ANTHROPIC_API_KEY}}" in entry["outbound"]["request"]["body"]
+    assert _FAKE_REAL not in entry["inbound"]["request"]["body"]
+    assert _FAKE_REAL not in entry["outbound"]["request"]["body"]
+
+
+def test_capture_jsonl_does_not_contain_real_secret_in_headers(tmp_path):
+    """Same as above but the placeholder lives in an Authorization
+    header (the common case for API key auth). Header-only requests
+    are the leak shape the live-Mac e2e-vm proof captured."""
+    rule = InjectionRule(
+        name="ANTHROPIC_API_KEY",
+        placeholder="{{ANTHROPIC_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["anthropic.com"],
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    flow = _make_flow(
+        headers={"Authorization": "Bearer {{ANTHROPIC_API_KEY}}"},
+        body=b"",
+    )
+    addon.request(flow)
+    assert flow.request.headers["Authorization"] == f"Bearer {_FAKE_REAL}"
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert _FAKE_REAL not in cap_text, (
+        f"real-key bytes leaked via header into capture.jsonl: "
+        f"{cap_text[:500]!r}..."
+    )
+    entry = json.loads(cap_text.splitlines()[0])
+    inbound_auth = next(
+        v for k, v in entry["inbound"]["request"]["headers"]
+        if k.lower() == "authorization"
+    )
+    outbound_auth = next(
+        v for k, v in entry["outbound"]["request"]["headers"]
+        if k.lower() == "authorization"
+    )
+    assert inbound_auth == "Bearer {{ANTHROPIC_API_KEY}}"
+    assert outbound_auth == "Bearer {{ANTHROPIC_API_KEY}}"
+
+
+def test_redact_request_round_trip_through_addon_response(tmp_path):
+    """Full pipeline cross-check: after addon.request() the flow has
+    the real value (inject was meant to put it on the wire), and after
+    addon.response() the flow is restored to placeholder form. This is
+    the key invariant that makes the capture-time snapshot safe.
+    """
+    rule = InjectionRule(
+        name="ANTHROPIC_API_KEY",
+        placeholder="{{ANTHROPIC_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["anthropic.com"],
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    flow = _make_flow(
+        headers={"Authorization": "Bearer {{ANTHROPIC_API_KEY}}"},
+        body='{"k": "{{ANTHROPIC_API_KEY}}"}',
+    )
+    addon.request(flow)
+    # On the wire upstream: real value present in BOTH places.
+    assert flow.request.headers["Authorization"] == f"Bearer {_FAKE_REAL}"
+    assert _FAKE_REAL.encode() in flow.request.content
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    # In memory after response(): placeholder restored everywhere.
+    assert flow.request.headers["Authorization"] == (
+        "Bearer {{ANTHROPIC_API_KEY}}"
+    )
+    assert _FAKE_REAL.encode() not in flow.request.content
+    assert b"{{ANTHROPIC_API_KEY}}" in flow.request.content

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1999,6 +1999,288 @@ def test_response_redaction_skips_binary_body(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# allowlist_addon: REQUEST-side redaction (capture-leak fix)
+#
+# ``_maybe_inject`` substitutes the real secret value into both request
+# headers and request body so the upstream sees a working key. Without
+# a symmetric ``_maybe_redact_request`` running BEFORE the capture
+# writer serializes the flow, those real-value bytes land on disk in
+# ``capture.jsonl`` — which is bind-mounted into the cage rootfs at
+# mode 0644 (cage-readable). A cage workload can ``grep sk- /var/log/
+# agentcage/capture.jsonl`` and recover the live ``ANTHROPIC_API_KEY``,
+# defeating the whole placeholder-injection trust model. The proxy held
+# the raw key precisely so the cage wouldn't see it; capture brought it
+# right back.
+#
+# These tests cover the addon's new ``_maybe_redact_request`` method
+# directly and end-to-end through the request→response capture pipeline.
+# ---------------------------------------------------------------------------
+
+
+def _make_request_redact_flow(*, host, headers=None, body=""):
+    """Mock flow shaped for ``_maybe_redact_request``.
+
+    Provides the get_text/set_text pair that backs body editing, and a
+    headers dict whose ``items()`` returns a list (the addon calls it
+    with no kwargs — matching the inject path).
+    """
+    flow = MagicMock()
+    flow.request.pretty_host = host
+    flow.client_conn.sni = host
+
+    class _Headers(dict):
+        def items(self, multi=False):  # noqa: ARG002
+            return list(super().items())
+
+    flow.request.headers = _Headers(dict(headers or {}))
+
+    state = {"text": body}
+    flow.request.get_text.side_effect = lambda strict=True: state["text"]
+
+    def _set_text(new):
+        state["text"] = new
+        flow.request.content = new.encode()
+
+    flow.request.set_text.side_effect = _set_text
+    flow.request.content = body.encode() if isinstance(body, str) else body
+    return flow
+
+
+def test_maybe_redact_request_replaces_value_in_headers(tmp_path, monkeypatch):
+    """The new request-side redactor scrubs the raw secret out of the
+    Authorization header before the capture writer reads it."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_request_redact_flow(
+        host="httpbin.org",
+        headers={"Authorization": "Bearer redact-test-xyz"},
+    )
+
+    redacted = addon._maybe_redact_request(flow)
+
+    assert redacted == ["AGENTCAGE_REDACT_SECRET"]
+    assert flow.request.headers["Authorization"] == (
+        "Bearer {{AGENTCAGE_REDACT_SECRET}}"
+    )
+
+
+def test_maybe_redact_request_replaces_value_in_body(tmp_path, monkeypatch):
+    """Body-bearing requests (POST JSON, etc) also get the real value
+    swapped back to the placeholder."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    flow = _make_request_redact_flow(
+        host="httpbin.org",
+        body='{"x-api-key": "redact-test-xyz"}',
+    )
+
+    redacted = addon._maybe_redact_request(flow)
+
+    assert redacted == ["AGENTCAGE_REDACT_SECRET"]
+    assert flow.request.content == (
+        b'{"x-api-key": "{{AGENTCAGE_REDACT_SECRET}}"}'
+    )
+
+
+def test_maybe_redact_request_scoped_to_inject_to_host(tmp_path, monkeypatch):
+    """Mirror of response-side scoping: a request to a host outside the
+    rule's ``inject_to`` is NOT scanned. Otherwise unrelated allowlisted
+    upstreams would have legitimate text mangled (e.g. UUIDs that
+    happen to match a secret value as substring). This also matches the
+    inject path's host gate — symmetry is the whole point."""
+    _, addon = _build_addon(
+        monkeypatch, tmp_path,
+        inject_to=("httpbin.org",),
+        allowlist=("httpbin.org", "example.com"),
+    )
+    flow = _make_request_redact_flow(
+        host="example.com",  # allowlisted but NOT in inject_to
+        body="coincidence: redact-test-xyz appears here",
+    )
+
+    redacted = addon._maybe_redact_request(flow)
+
+    assert redacted == []
+    assert b"redact-test-xyz" in flow.request.content
+
+
+def test_maybe_redact_request_skips_binary_body(tmp_path, monkeypatch):
+    """Binary request bodies (uploads, etc) pass through unchanged —
+    same defensive try/except shape as ``_maybe_inject`` and
+    ``_maybe_redact``. Headers still scanned."""
+    _, addon = _build_addon(monkeypatch, tmp_path)
+    binary = bytes([0xff, 0xd8]) + b"redact-test-xyz" + bytes([0x00])
+    flow = _make_request_redact_flow(
+        host="httpbin.org",
+        headers={"X-Trace": "Bearer redact-test-xyz"},
+    )
+    # Override get_text to raise — mimics mitmproxy on undecodable bytes.
+    flow.request.get_text.side_effect = UnicodeDecodeError(
+        "utf-8", binary, 0, 1, "binary body",
+    )
+    flow.request.content = binary
+
+    redacted = addon._maybe_redact_request(flow)
+
+    # Body untouched (binary skip), but header still got scrubbed.
+    assert flow.request.content == binary
+    assert flow.request.headers["X-Trace"] == (
+        "Bearer {{AGENTCAGE_REDACT_SECRET}}"
+    )
+    assert redacted == ["AGENTCAGE_REDACT_SECRET"]
+
+
+def test_maybe_redact_request_keyed_on_authoritative_host(tmp_path, monkeypatch):
+    """Symmetric to the inject path: the host used for ``inject_to``
+    matching is the SNI (authoritative), NOT the attacker-controlled
+    Host header. A spoof that sneaks past the addon's request hook
+    shouldn't be able to trick the request-side redactor either."""
+    _, addon = _build_addon(
+        monkeypatch, tmp_path,
+        inject_to=("httpbin.org",),
+        allowlist=("httpbin.org",),
+    )
+    flow = _make_request_redact_flow(
+        host="example.com",  # cage-claimed Host header
+        body="value: redact-test-xyz",
+    )
+    # SNI says the bytes actually went to httpbin.org — the authoritative
+    # host. Redaction should fire (matches inject_to=httpbin.org).
+    flow.client_conn.sni = "httpbin.org"
+
+    redacted = addon._maybe_redact_request(flow)
+
+    assert redacted == ["AGENTCAGE_REDACT_SECRET"]
+    assert flow.request.content == b"value: {{AGENTCAGE_REDACT_SECRET}}"
+
+
+def test_capture_jsonl_never_contains_real_secret_value(tmp_path, monkeypatch):
+    """End-to-end: the load-bearing assertion. Run the addon's full
+    request→response pipeline with capture enabled and a body that
+    contains the placeholder. The upstream will see the substituted
+    real value (inject_request worked), but the on-disk capture.jsonl
+    must NOT contain the real value — only the placeholder.
+
+    Uses a clearly-synthetic ``sk-ant-api03-FAKE-...`` value so no
+    real-key shape can possibly leak into the test fixture."""
+    fake_real = "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-1234567890"
+    _, addon = _build_addon_with_capture(
+        monkeypatch, tmp_path,
+        capture_cfg={
+            "enable_har": True,
+            "max_body_size": 10485760,
+            "domains": ["api.anthropic.com"],
+        },
+        allowlist=("api.anthropic.com",),
+    )
+    # Wire a rule so _maybe_inject substitutes on outbound and
+    # _maybe_redact_request restores placeholder pre-capture.
+    monkeypatch.setenv("AGENTCAGE_LEAK_SECRET", fake_real)
+    addon._resolved_secrets = [{
+        "env": "AGENTCAGE_LEAK_SECRET",
+        "placeholder": "{{AGENTCAGE_LEAK_SECRET}}",
+        "value": fake_real,
+        "inject_to": ["api.anthropic.com"],
+        "transform": "",
+        "transform_fn": None,
+    }]
+
+    req_body = (
+        '{"model": "claude", "x-api-key": "{{AGENTCAGE_LEAK_SECRET}}"}'
+    )
+    flow = _make_flow_with_bodies(
+        host="api.anthropic.com",
+        req_body=req_body,
+        resp_body='{"ok": true}',
+        path="/v1/messages",
+        req_content_type="application/json",
+    )
+    # Mock get_text/set_text on the request side so _maybe_inject and
+    # _maybe_redact_request can mutate the body in place.
+    req_state = {"text": req_body}
+    flow.request.get_text.side_effect = lambda strict=True: req_state["text"]
+
+    def _set_req_text(new):
+        req_state["text"] = new
+        flow.request.content = new.encode()
+
+    flow.request.set_text.side_effect = _set_req_text
+    # SNI matches authoritative host so the addon's inject + redact
+    # both fire for this rule.
+    flow.client_conn.sni = "api.anthropic.com"
+
+    addon.request(flow)
+    # Sanity: the upstream actually received the substituted value —
+    # this is what the existing inject path was designed for. We only
+    # care that the capture file below does NOT carry these bytes.
+    assert fake_real in flow.request.content.decode()
+
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert fake_real not in cap_text, (
+        f"real-key bytes leaked into capture.jsonl: {cap_text!r}"
+    )
+    # Both the inbound (cage-visible) and outbound (wire) snapshots
+    # should now show the placeholder.
+    cap_entry = json.loads(cap_text.splitlines()[0])
+    assert "{{AGENTCAGE_LEAK_SECRET}}" in cap_entry["inbound"]["request"]["body"]
+    assert "{{AGENTCAGE_LEAK_SECRET}}" in cap_entry["outbound"]["request"]["body"]
+
+
+def test_capture_jsonl_legacy_path_never_contains_real_value(
+    tmp_path, monkeypatch,
+):
+    """The legacy headers-only capture path (capture.enable_har: false,
+    or no capture config) is the fallback that ships pre-this-PR. It
+    serializes ``flow.request.headers.items()`` AFTER ``_maybe_inject``
+    has run. Without the new ``_maybe_redact_request`` running first,
+    real secret bytes from injected headers land in the legacy
+    capture.jsonl too. Symmetric coverage to the rich HAR path above."""
+    fake_real = "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-1234567890"
+    _, addon = _build_addon(
+        monkeypatch, tmp_path,
+        secret_value=fake_real,
+        inject_to=("api.anthropic.com",),
+        allowlist=("api.anthropic.com",),
+    )
+    # legacy path: no CaptureWriter — addon writes lean entries via
+    # self._capture_fh. Confirm we're on that path.
+    assert addon._capture_writer is None
+    assert addon._capture_fh is not None
+
+    # Build a request flow that carries the placeholder in the header.
+    flow = _make_request_flow(
+        pretty_host="api.anthropic.com",
+        sni="api.anthropic.com",
+        method="POST",
+        path="/v1/messages",
+        headers={
+            "x-api-key": "{{AGENTCAGE_REDACT_SECRET}}",
+            "Content-Type": "application/json",
+        },
+    )
+    addon.request(flow)
+    # Sanity: inject worked — header now has the real bytes on the wire.
+    assert flow.request.headers["x-api-key"] == fake_real
+
+    # Attach a response so the legacy capture path fires.
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.reason = "OK"
+    resp.headers = {}
+    resp.content = b'{"ok": true}'
+    resp.get_text.side_effect = lambda strict=True: '{"ok": true}'
+    flow.response = resp
+
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert fake_real not in cap_text, (
+        f"real-key bytes leaked into legacy capture.jsonl: {cap_text!r}"
+    )
+    assert "{{AGENTCAGE_REDACT_SECRET}}" in cap_text
+
+
+# ---------------------------------------------------------------------------
 # allowlist_addon: Host-header spoofing bypass (CTF F1)
 #
 # Regression coverage for the CTF finding: with mitmproxy running in

--- a/tests/test_secret_injector.py
+++ b/tests/test_secret_injector.py
@@ -433,6 +433,208 @@ class TestRedactRequest:
         assert names == ["KEY"]
 
 
+# ── Post-upstream request redaction (capture-leak fix) ──
+#
+# ``inject_request`` mutates ``flow.request`` in place, substituting the
+# real secret value into headers, URL, and body so the upstream sees the
+# real key. Without a symmetric ``redact_request`` running BEFORE the
+# capture writer serializes the flow, those real-value bytes land on
+# disk in ``capture.jsonl`` — which is bind-mounted into the cage
+# rootfs at mode 0644 (cage-readable). A cage workload can then
+# ``grep sk- /var/log/agentcage/capture.jsonl`` and recover the live
+# ``ANTHROPIC_API_KEY``, defeating the entire placeholder-injection
+# trust model.
+#
+# ``redact_request`` is the inverse of ``inject_request``: AFTER the
+# proxy has forwarded the mutated request upstream, it restores
+# placeholder form on the in-memory flow so subsequent serialization
+# (capture writer, addon logging) never sees the raw secret bytes.
+
+
+class TestRedactRequestPostUpstream:
+    def test_redacts_real_value_in_request_body(self):
+        """Symmetric to ``inject_request``: a real value injected into
+        the body is replaced with the placeholder."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(content="payload with sk-real-secret here")
+        names = inj.redact_request(flow)
+        assert flow.request.content == b"payload with {{KEY}} here"
+        assert names == ["KEY"]
+
+    def test_redacts_real_value_in_request_headers(self):
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(headers={"Authorization": "Bearer sk-real-secret"})
+        names = inj.redact_request(flow)
+        assert flow.request.headers["Authorization"] == "Bearer {{KEY}}"
+        assert names == ["KEY"]
+
+    def test_redacts_real_value_in_request_url(self):
+        """URL-injected secrets (query string) are also redacted."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            url="https://api.anthropic.com/v1?key=sk-real-secret",
+        )
+        names = inj.redact_request(flow)
+        assert flow.request.url == (
+            "https://api.anthropic.com/v1?key={{KEY}}"
+        )
+        assert names == ["KEY"]
+
+    def test_redacts_regardless_of_domain(self):
+        """Post-upstream redaction applies to all destinations, not just
+        ``inject_to``. The flow object is about to be serialized to disk
+        — any real-value byte that made it there for any reason has to
+        be scrubbed before the cage can read the file."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            url="https://other.com/api",
+            host="other.com",
+            content="leaked: sk-real-secret",
+        )
+        names = inj.redact_request(flow)
+        assert flow.request.content == b"leaked: {{KEY}}"
+        assert names == ["KEY"]
+
+    def test_longest_first_ordering(self):
+        """When one real value is a substring of another, the longer one
+        is replaced first — same defensive ordering as ``redact_response``."""
+        inj = _injector_with_rules([
+            InjectionRule("SHORT", "{{SHORT}}", "secret", inject_to=[]),
+            InjectionRule("LONG", "{{LONG}}", "secret-long-value",
+                          inject_to=[]),
+        ])
+        flow = _make_flow(content="the value is secret-long-value here")
+        names = inj.redact_request(flow)
+        assert flow.request.content == b"the value is {{LONG}} here"
+        assert "LONG" in names
+
+    def test_noop_when_no_rules(self):
+        inj = SecretInjector()
+        flow = _make_flow(content="clean body")
+        names = inj.redact_request(flow)
+        assert flow.request.content == b"clean body"
+        assert names == []
+
+    def test_noop_when_no_real_value_present(self):
+        """Body that doesn't contain any rule's real value isn't mutated."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(content="no secret in here")
+        names = inj.redact_request(flow)
+        assert flow.request.content == b"no secret in here"
+        assert names == []
+
+    def test_inject_then_redact_round_trip(self):
+        """Full round-trip: inject_request mutates → redact_request
+        restores. After the pair, the flow looks placeholder-form again
+        — exactly what the capture writer needs to see before serializing.
+        """
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
+                          inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            url="https://api.anthropic.com/v1?k={{KEY}}",
+            headers={"Authorization": "Bearer {{KEY}}"},
+            content="{{KEY}} in body",
+        )
+        # Inject — real value substituted in all three places.
+        injected = inj.inject_request(flow)
+        assert injected == ["KEY"]
+        assert "sk-real-secret" in flow.request.url
+        assert flow.request.headers["Authorization"] == (
+            "Bearer sk-real-secret"
+        )
+        assert flow.request.content == b"sk-real-secret in body"
+
+        # Redact — placeholder restored everywhere.
+        redacted = inj.redact_request(flow)
+        assert redacted == ["KEY"]
+        assert "sk-real-secret" not in flow.request.url
+        assert "sk-real-secret" not in flow.request.headers["Authorization"]
+        assert b"sk-real-secret" not in flow.request.content
+        assert flow.request.url == "https://api.anthropic.com/v1?k={{KEY}}"
+        assert flow.request.headers["Authorization"] == "Bearer {{KEY}}"
+        assert flow.request.content == b"{{KEY}} in body"
+
+    def test_capture_serializes_only_placeholders_after_redact(self, tmp_path):
+        """End-to-end: snapshot_request AFTER inject+redact must contain
+        only placeholders, never the real value. This is the load-bearing
+        assertion — what actually lands in ``capture.jsonl``."""
+        import json
+        import sys
+        from pathlib import Path
+        # Stage the proxy/ dir on sys.path so ``from capture import
+        # CaptureWriter`` resolves at runtime — same trick the addon
+        # uses inside the cage.
+        capture_src = (
+            Path(__file__).resolve().parent.parent
+            / "src" / "agentcage" / "data" / "proxy"
+        )
+        if str(capture_src) not in sys.path:
+            sys.path.insert(0, str(capture_src))
+        from capture import CaptureWriter  # type: ignore
+
+        inj = _injector_with_rules([
+            InjectionRule(
+                "ANTHROPIC_API_KEY",
+                "{{ANTHROPIC_API_KEY}}",
+                "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-1234567890",
+                inject_to=["anthropic.com"],
+            ),
+        ])
+
+        class _Headers(dict):
+            # CaptureWriter.snapshot_request calls items(multi=True);
+            # a plain dict's items() doesn't accept the kwarg.
+            def items(self, multi=False):  # noqa: ARG002
+                return list(super().items())
+
+        flow = _make_flow(
+            url="https://api.anthropic.com/v1/messages",
+            content='{"key": "{{ANTHROPIC_API_KEY}}"}',
+        )
+        flow.request.headers = _Headers(
+            {"x-api-key": "{{ANTHROPIC_API_KEY}}"},
+        )
+
+        # Wire shape: inject (real value goes out), THEN redact (in-memory
+        # flow restored to placeholder form), THEN serialize.
+        injected = inj.inject_request(flow)
+        assert injected == ["ANTHROPIC_API_KEY"]
+
+        redacted = inj.redact_request(flow)
+        assert redacted == ["ANTHROPIC_API_KEY"]
+
+        # Need an http_version attribute for snapshot_request — it reads
+        # it directly. Real mitmproxy flows always have it; mock doesn't
+        # autovalue meaningfully.
+        flow.request.http_version = "HTTP/1.1"
+        writer = CaptureWriter(
+            {"max_body_size": 0}, str(tmp_path / "capture.jsonl"),
+        )
+        snap = writer.snapshot_request(flow)
+        line = json.dumps(snap)
+        assert "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION" not in line, (
+            f"real-key bytes leaked into capture snapshot: {line!r}"
+        )
+        assert "{{ANTHROPIC_API_KEY}}" in line
+
+
 # ── Config format (dict vs list) ────────────────────────
 
 


### PR DESCRIPTION
## Summary

CTF F4 on apple-container 0.21.10: the proxy addons substitute the
real secret value into outbound requests so the upstream sees a
working key (``ANTHROPIC_API_KEY``, etc.), but the capture writer
then serializes the mutated flow into ``capture.jsonl`` with no
symmetric request-side redaction. ``capture.jsonl`` is bind-mounted
into the cage rootfs at mode 0644 (cage-readable) so the cage
workload can recover the live key via:

    cat /var/log/agentcage/capture.jsonl | grep sk-

This defeats the entire placeholder-injection trust model: the proxy
held the raw key precisely so the cage wouldn't see it; capture
brought it right back. Existing ``_maybe_redact`` / ``redact_response``
covered the response path; there was no request-side counterpart.

**Live evidence on the test host:** ``~/.local/share/agentcage/e2e-vm/
capture/capture.jsonl`` (mode 0644) contained two entries with
real-format ``sk-ant-api03-...`` (89 chars) in both
``inbound.request.body`` and ``outbound.request.body``. Verified at
the start of the session that produced this PR. The operator-side
cleanup of that on-disk artifact is out of scope for this PR.

## Fix

Both backends now add a symmetric request-side redactor:

- **Apple-container** (``data/apple-container/allowlist_addon.py``):
  new ``_maybe_redact_request(flow)`` mirroring ``_maybe_redact`` —
  same authoritative-host scope (TLS SNI, NOT the attacker-controlled
  Host header — same gate ``_maybe_inject`` uses from #175),
  longest-value-first sort, header+body coverage, defensive binary
  skip. Called at the start of ``response()``, with the staged
  outbound-request snapshot from ``request()`` re-snapshotted to
  overwrite the stale post-inject snapshot.

- **Container backend** (``data/proxy/secret_injector.py``,
  ``data/proxy/addon.py``): new ``SecretInjector.redact_request(flow)``
  (distinct from the existing inject-time ``_redact_request`` /
  ``redact_to`` path), wired into ``Agentcage.response()`` before the
  capture writer reads the flow. Redacts URL (for query-string
  injection), headers, and body.

**Critical placement:** redaction must run AFTER mitmproxy forwards
the mutated request upstream (so wire traffic is unaffected — the
upstream still gets a working key) and BEFORE the capture writer
serializes ``flow.request.headers`` / ``flow.request.content``. The
``response`` hook fires post-upstream-send, so that's where the
redactor lives.

The WebSocket path was unaffected: ``websocket_message`` buffers the
frame for capture via ``add_ws_message`` BEFORE ``inject_ws_content``
mutates the bytes, so the capture buffer already holds placeholder
form.

## Context

Companion fixes from recent CTF iterations:
- #175 security(apple-container): block Host-header spoof bypass of
  allowlist + secret-injection
- #176 security(dns): scope recursion to allowlisted zones
- #177 security(proxy): block non-HTTP TCP bypass of L7 policy hooks

This PR closes a fourth distinct exfil channel surfaced during the
same CTF runs — secrets leak through the cage's own capture log
rather than through unfiltered network egress.

## Test plan

- [x] 9 new ``SecretInjector.redact_request`` unit tests in
      ``tests/test_secret_injector.py`` (body / headers / URL /
      scoping / round-trip / serialization check)
- [x] 7 new apple-container addon tests in
      ``tests/test_apple_container.py``
      (``_maybe_redact_request`` direct + end-to-end through the rich
      HAR capture path AND the legacy headers-only fallback path)
- [x] 3 new end-to-end orchestrator tests in
      ``tests/test_addon_capture_redaction.py`` covering the full
      container-backend ``Agentcage`` request → inject →
      response → redact → capture pipeline, grepping the on-disk
      ``capture.jsonl`` for the real value (must be absent)
- [x] ``uv run pytest -q --ignore=tests/e2e`` from repo root:
      **1559 passed** (1540 prior + 19 new)
- [x] All test fixtures use clearly-synthetic
      ``sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-...`` strings so no
      real-key shape is committed

## Notes

- No version bump, no CHANGELOG edit — release is separate.
- Existing response-side redaction (``_maybe_redact`` /
  ``redact_response``) is untouched.
- The fix is purely in-memory — wire traffic to upstreams is identical.
- Operator-side cleanup of the existing on-disk leak in
  ``e2e-vm/capture/capture.jsonl`` is out of scope for this PR.