### PR TITLE
v0.21.12 fix: cage update + VM secrets + cage name + cd warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.12] - 2026-05-26
+
+Bugfix release for the VM backend and `cage update` ergonomics. No security
+impact, no breaking changes. Affects every operator who has ever run a
+VM-mode cage on Linux with secrets or seen "cd: No such file or directory"
+chatter at start.
+
+### Fixed
+
+- **`fix(vm)`: `cage create -s KEY=VALUE` now delivers the secret verbatim
+  on the VM backend.** `limactl shell` defaults `--tty` to true when the
+  host's stdout is a terminal, and the resulting PTY's line discipline
+  cooks piped stdin (CR↔LF translation, control-character handling)
+  before `podman secret create -` reads it. The secret stored inside the
+  VM no longer matched what the operator typed; cages saw a mangled
+  value and 401d. `LimaInstance.exec` now pins `--tty=false` (alias `-y`)
+  so SSH stays in pipe mode, and adds an `input=` passthrough so every
+  caller benefits.
+- **`fix(vm)`: stop printing `bash: line 1: cd: <path>: No such file or
+  directory` on every VM operation.** `limactl shell` mirrors the host's
+  `$PWD` inside the VM, and only `~/.config/agentcage` /
+  `~/.local/share/agentcage` are mounted — every other cwd hit the cd
+  warning. `LimaInstance.exec` now pins `--workdir /`; commands run from
+  a known-mounted directory and the noise is gone. `VmPodman` and the
+  three remaining inline `subprocess.run(["limactl", "shell", ...],
+  input=...)` sites in `backends/vm.py` were refactored onto the helper
+  so the flags apply everywhere.
+- **`fix(cage update)`: `NAME` is now optional when `-c cage.yaml` is
+  given.** Mirrors `cage create`, which has never required a positional
+  `NAME` because the config's `name:` field is authoritative. Passing
+  both still works; mismatch still errors. Passing neither prints a
+  clear error.
+- **`fix(cage update)`: the pre-deploy secrets check is now backend-aware.**
+  Previously, on a Linux host with `podman` installed, every `cage update`
+  on a VM or apple-container cage with `secret_injection:` rules queried
+  host Podman, found nothing, and aborted with "missing secrets" — even
+  when the secrets were correctly stored inside the VM (via
+  `_create_pending_secrets`) or in `pending_secrets.json`
+  (apple-container). The check now routes through `VmPodman` when the
+  VM is running, reads `pending_secrets.json` for apple-container, and
+  skips for a stopped VM (where `backend.start()` will recreate from
+  the pending file before services come up).
+
+### Tests
+
+- `tests/test_lima_instance.py`: regression coverage that `exec` always
+  passes `--workdir /` + `--tty=false` and forwards `input=`.
+- `tests/test_cage_cli.py`: regression coverage that `cage update` works
+  with `-c` alone (no `NAME`), errors cleanly when neither is given, and
+  does not query host Podman for VM cages.
+
 ## [0.21.11] - 2026-05-26
 
 CRITICAL hotfix for both backends. **Upgrade immediately for any deployment with `secret_injection:` configured.** Real injected secrets were landing in `capture.jsonl` (mode 0644, cage-readable) — defeats the entire placeholder-injection trust model. Confirmed via real-format key bytes on disk in a local e2e test capture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.21.11"
+version = "0.21.12"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -362,10 +362,11 @@ class VmBackend:
             for key, value in pending:
                 full = f"{name}.{key}"
                 inst.exec(["podman", "secret", "rm", full], check=False)
-                subprocess.run(
-                    ["limactl", "shell", inst.name, "--",
-                     "podman", "secret", "create", full, "-"],
-                    input=value, text=True, check=True,
+                # Pipe stdin via inst.exec so we get --tty=false (no PTY
+                # cooking) and --workdir / (no spurious cd warnings).
+                inst.exec(
+                    ["podman", "secret", "create", full, "-"],
+                    input=value,
                 )
                 click.echo(f"  Secret '{full}' set in VM.")
         finally:
@@ -400,10 +401,9 @@ class VmBackend:
                         ["podman", "secret", "rm", secret_name],
                         check=False,
                     )
-                    subprocess.run(
-                        ["limactl", "shell", inst.name, "--",
-                         "podman", "secret", "create", secret_name, "-"],
-                        input=value, text=True, check=True,
+                    inst.exec(
+                        ["podman", "secret", "create", secret_name, "-"],
+                        input=value,
                     )
                     click.echo(f"  Bridged secret (decrypted): {secret_name}")
                 except Exception as e:
@@ -443,10 +443,9 @@ class VmBackend:
                     check=False,
                 )
                 # Pipe value via stdin to avoid shell injection
-                subprocess.run(
-                    ["limactl", "shell", inst.name, "--",
-                     "podman", "secret", "create", secret_name, "-"],
-                    input=value, text=True, check=True,
+                inst.exec(
+                    ["podman", "secret", "create", secret_name, "-"],
+                    input=value,
                 )
                 click.echo(f"  Bridged secret: {secret_name}")
             except Exception as e:

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -594,7 +594,7 @@ def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool,
 
 
 @cage.command("update")
-@click.argument("name")
+@click.argument("name", required=False)
 @click.option("-c", "--config", "config_path", type=click.Path(exists=True))
 @click.option("--no-cache", is_flag=True,
               help="Force a full image rebuild (ignore podman's layer cache). "
@@ -604,10 +604,20 @@ def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool,
               help="Force re-pull of the base image from the registry "
                    "(--pull=always). Combine with --no-cache for a fully "
                    "clean rebuild.")
-def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
-    """Rebuild and restart an existing cage."""
-    if not state.deployment_exists(name):
-        click.echo(f"error: cage '{name}' does not exist", err=True)
+def cage_update(name: str | None, config_path: str | None,
+                no_cache: bool, pull: bool):
+    """Rebuild and restart an existing cage.
+
+    NAME is optional when ``-c`` is given — the cage to update is taken
+    from the config's ``name:`` field. Mirrors ``cage create``, which
+    has never required a positional NAME for the same reason.
+    """
+    if name is None and config_path is None:
+        click.echo(
+            "error: either NAME or -c/--config is required (the cage to "
+            "update must be identifiable)",
+            err=True,
+        )
         sys.exit(1)
 
     if config_path:
@@ -619,11 +629,16 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
             sys.exit(1)
         for w in warnings:
             click.echo(f"warning: {w}", err=True)
-        if cfg.name != name:
+        if name is None:
+            name = cfg.name
+        elif cfg.name != name:
             click.echo(
                 f"error: config name '{cfg.name}' does not match cage '{name}'",
                 err=True,
             )
+            sys.exit(1)
+        if not state.deployment_exists(name):
+            click.echo(f"error: cage '{name}' does not exist", err=True)
             sys.exit(1)
         state.save_deployment(name, config_path)
         # Copy the Containerfile and its sibling build inputs into the state
@@ -634,6 +649,9 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
             if src_cf.is_file():
                 _stage_build_context(src_cf.parent, state.deployment_dir(name))
     else:
+        if not state.deployment_exists(name):
+            click.echo(f"error: cage '{name}' does not exist", err=True)
+            sys.exit(1)
         # Auto-resolve latest image tags for stored configs
         from agentcage.init import (
             infer_scaffold_from_image,
@@ -762,8 +780,38 @@ def cage_update(name: str, config_path: str | None, no_cache: bool, pull: bool):
 
     podman = Podman()
 
-    # Check secrets (requires host Podman — skip for VM mode if unavailable)
-    missing = _check_secrets(podman, name, cfg) if cfg.isolation == "container" or shutil.which("podman") else []
+    # Check secrets against the store that actually backs this cage.
+    # The container backend keeps secrets on host Podman. The VM backend
+    # keeps them inside the VM's Podman — querying host Podman there
+    # always reports "missing" and blocks every cage update on Linux
+    # hosts that have podman installed. The apple-container backend
+    # reads pending_secrets.json at start(), so existence on disk is
+    # what counts; check_secrets's host-Podman path can't see that.
+    missing: list[str] = []
+    if cfg.isolation == "container":
+        missing = _check_secrets(podman, name, cfg)
+    elif cfg.isolation == "vm":
+        inst = LimaInstance(name)
+        if inst.is_running():
+            from agentcage.lima.podman import VmPodman
+            missing = _check_secrets(VmPodman(name), name, cfg)
+        # VM is stopped: backend.start() will recreate any pending
+        # secrets from pending_secrets.json before services come up,
+        # so a stopped VM is not a "missing secrets" condition.
+    elif cfg.isolation == "apple-container":
+        from agentcage import state as _state
+        pending = _state.deployment_dir(name) / "pending_secrets.json"
+        if pending.is_file():
+            try:
+                provided = {
+                    k for k, _ in json.loads(pending.read_text())
+                }
+            except Exception:
+                provided = set()
+        else:
+            provided = set()
+        from agentcage.services import expected_secrets
+        missing = [k for k in expected_secrets(cfg) if k not in provided]
     if missing:
         click.echo(f"error: missing secrets for cage '{name}':", err=True)
         for key in missing:

--- a/src/agentcage/lima/instance.py
+++ b/src/agentcage/lima/instance.py
@@ -67,13 +67,32 @@ class LimaInstance:
         check: bool = True,
         capture_output: bool = True,
         text: bool = True,
+        input: str | bytes | None = None,
     ) -> CompletedProcess:
-        """Run a command inside the Lima VM."""
+        """Run a command inside the Lima VM.
+
+        ``--workdir /`` pins the guest cwd to ``/`` so the SSH shell does
+        not try to ``cd`` into the host's current directory. By default
+        ``limactl shell`` mirrors the host cwd inside the VM, which only
+        the explicitly-mounted ``~/.config/agentcage`` /
+        ``~/.local/share/agentcage`` paths can satisfy — every other
+        invocation prints a spurious ``cd: <path>: No such file or
+        directory`` and runs from $HOME anyway.
+
+        ``--tty=false`` (``-y``) keeps SSH from allocating a PTY. Without
+        it, piping ``input=`` while stdout is attached to a terminal
+        causes Lima to default to a PTY and the kernel line discipline
+        cooks the stream (CR↔LF translation, control-char handling),
+        which silently mangles secret values fed to ``podman secret
+        create -``.
+        """
         return subprocess.run(
-            ["limactl", "shell", self.name, "--"] + cmd,
+            ["limactl", "shell", "--workdir", "/", "--tty=false",
+             self.name, "--"] + cmd,
             check=check,
             capture_output=capture_output,
             text=text,
+            input=input,
         )
 
     def _list_json(self) -> dict:

--- a/src/agentcage/lima/podman.py
+++ b/src/agentcage/lima/podman.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
-
 from agentcage.lima.instance import LimaInstance
 from agentcage.podman import filter_secrets_by_prefix
 
@@ -13,53 +11,47 @@ class VmPodman:
 
     Mirrors the subset of agentcage.podman.Podman methods used by the
     CLI for secret management, so the CLI can use either host Podman
-    or VM Podman transparently.
+    or VM Podman transparently. All ``limactl shell`` invocations go
+    through ``LimaInstance.exec`` so they share the ``--tty=false``
+    (no PTY cooking of piped secret values) and ``--workdir /`` (no
+    spurious ``cd: No such file or directory`` warnings) flags.
     """
 
     def __init__(self, cage_name: str) -> None:
         self._inst = LimaInstance(cage_name)
 
-    def _run(self, cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-        """Run a podman command inside the VM."""
-        return subprocess.run(
-            ["limactl", "shell", self._inst.name, "--", *cmd],
-            **kwargs,
-        )
-
     def secret_list(self, prefix: str = "") -> list[dict]:
-        r = self._run(
+        r = self._inst.exec(
             ["podman", "secret", "ls", "--noheading", "--format", "{{.Name}}"],
-            capture_output=True, text=True,
+            check=False,
         )
         if r.returncode != 0 or not r.stdout.strip():
             return []
         return filter_secrets_by_prefix(r.stdout.strip().splitlines(), prefix)
 
     def secret_exists(self, name: str) -> bool:
-        r = self._run(
+        r = self._inst.exec(
             ["podman", "secret", "inspect", name],
-            capture_output=True,
+            check=False,
         )
         return r.returncode == 0
 
     def secret_create(self, name: str, value: str) -> None:
-        self._run(
+        self._inst.exec(
             ["podman", "secret", "create", name, "-"],
-            input=value, text=True, check=True,
-            stdout=subprocess.DEVNULL,
+            input=value,
         )
 
     def secret_read(self, name: str) -> str:
-        r = self._run(
+        r = self._inst.exec(
             ["podman", "secret", "inspect", "--showsecret",
              "--format", "{{.SecretData}}", name],
-            capture_output=True, text=True, check=True,
         )
         return r.stdout.strip()
 
     def secret_remove(self, name: str) -> bool:
-        r = self._run(
+        r = self._inst.exec(
             ["podman", "secret", "rm", name],
-            capture_output=True,
+            check=False,
         )
         return r.returncode == 0

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -81,6 +81,103 @@ class TestCageUpdate:
         assert result.exit_code != 0
         assert "does not match" in result.output
 
+    def test_update_requires_name_or_config(self):
+        """Either positional NAME or -c must be supplied — without one of
+        them there is no way to identify which cage to update."""
+        result = _runner().invoke(main, ["cage", "update"])
+        assert result.exit_code != 0
+        assert "NAME or -c/--config is required" in result.output
+
+    @patch("agentcage.cli._build_and_deploy")
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli._check_secrets", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._build_container_image")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_update_infers_name_from_config(
+        self, mock_state, MockPodman, mock_systemd, mock_build, mock_backend,
+        _check_secrets, _check_ports, _build_deploy, tmp_path,
+    ):
+        """`cage update -c cage.yaml` must work without a positional NAME —
+        cfg.name is authoritative when -c is given (matches cage create)."""
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: inferred-from-config
+            container:
+              image: test:latest
+        """))
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.load_metadata.return_value = {}
+        mock_state.load_deployment_config.return_value = Config(
+            name="inferred-from-config",
+            isolation="container",
+            container=ContainerConfig(
+                image="test:latest",
+                build=BuildConfig(containerfile=None, args={}),
+            ),
+        )
+        result = _runner().invoke(main, ["cage", "update", "-c", str(p)])
+        assert result.exit_code == 0, result.output
+        # state.save_deployment should be called with the inferred name.
+        save_calls = [c for c in mock_state.save_deployment.call_args_list]
+        assert save_calls, "save_deployment was not called"
+        assert save_calls[0].args[0] == "inferred-from-config"
+
+    @patch("agentcage.cli._build_and_deploy")
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_update_vm_does_not_query_host_podman_for_secrets(
+        self, mock_state, MockPodman, mock_systemd, mock_backend,
+        _check_ports, _build_deploy, tmp_path,
+    ):
+        """For VM cages, secrets live in the VM's podman, not on the host.
+        Querying host podman (the historical bug) always reported the
+        secret as missing and blocked every `cage update` on a Linux host
+        that happened to have podman installed. The fix routes the check
+        through VmPodman (when the VM is running) or skips it (when the
+        VM is stopped — backend.start() will re-create from
+        pending_secrets.json before services come up)."""
+        from agentcage.config import (
+            Config, ContainerConfig, BuildConfig, SecretInjectionRule,
+        )
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.load_metadata.return_value = {}
+        mock_state.load_raw_config.return_value = {
+            "name": "test",
+            "container": {"image": "test:latest", "build": {"args": {}}},
+        }
+        mock_state.load_deployment_config.return_value = Config(
+            name="test",
+            isolation="vm",
+            container=ContainerConfig(
+                image="test:latest",
+                build=BuildConfig(containerfile=None, args={}),
+            ),
+            secret_injection=[
+                SecretInjectionRule(env="OPENAI_API_KEY", placeholder="X"),
+            ],
+        )
+        # Host Podman returns "no secret" for everything — the historical
+        # blocker. The fix must NOT consult it for VM cages.
+        host_podman = MockPodman.return_value
+        host_podman.secret_exists.return_value = False
+        # VM is stopped → no VmPodman to query → check is skipped.
+        with patch("agentcage.cli.LimaInstance") as MockLima:
+            MockLima.return_value.is_running.return_value = False
+            result = _runner().invoke(main, ["cage", "update", "test"])
+        assert result.exit_code == 0, result.output
+        assert "missing secrets" not in result.output
+
 
 class TestCageUpdateNoCache:
     """`agentcage cage update --no-cache` must propagate the flag down to

--- a/tests/test_lima_instance.py
+++ b/tests/test_lima_instance.py
@@ -90,12 +90,14 @@ class TestExec:
         inst = LimaInstance("mycage")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="output", stderr="")
-            result = inst.exec(["echo", "hello"])
+            inst.exec(["echo", "hello"])
             mock_run.assert_called_once_with(
-                ["limactl", "shell", "agentcage-mycage", "--", "echo", "hello"],
+                ["limactl", "shell", "--workdir", "/", "--tty=false",
+                 "agentcage-mycage", "--", "echo", "hello"],
                 check=True,
                 capture_output=True,
                 text=True,
+                input=None,
             )
 
     def test_exec_default_flags(self):
@@ -121,9 +123,36 @@ class TestExec:
         fake_result = MagicMock()
         fake_result.returncode = 0
         fake_result.stdout = "hello\n"
-        with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("subprocess.run", return_value=fake_result):
             result = inst.exec(["echo", "hello"])
             assert result is fake_result
+
+    def test_exec_pins_workdir_and_disables_tty(self):
+        """Without --workdir / --tty=false, limactl shell mirrors the host
+        cwd (often unmounted in the VM → 'cd: No such file or directory')
+        and allocates a PTY when stdout is a terminal, whose line
+        discipline cooks piped stdin (mangles secret values fed to
+        `podman secret create -`)."""
+        inst = LimaInstance("mycage")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            inst.exec(["ls"])
+            args, _ = mock_run.call_args
+            argv = args[0]
+            assert "--workdir" in argv
+            assert argv[argv.index("--workdir") + 1] == "/"
+            assert "--tty=false" in argv
+
+    def test_exec_pipes_stdin_via_input(self):
+        inst = LimaInstance("mycage")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            inst.exec(
+                ["podman", "secret", "create", "name", "-"],
+                input="secret-value\n",
+            )
+            _, kwargs = mock_run.call_args
+            assert kwargs["input"] == "secret-value\n"
 
 
 class TestIsRunning:


### PR DESCRIPTION
## Summary

Two clusters of papercuts. No security impact, no breaking changes.

**VM backend (`fix(vm)`):**
- `cage create -s KEY=VALUE` for a VM cage was silently mangled because `limactl shell` allocated a PTY whose line discipline cooked piped stdin before `podman secret create -` could read it. Cages saw garbage values and 401d.
- Every VM operation printed `bash: line 1: cd: <host-cwd>: No such file or directory` because `limactl shell` mirrors `$PWD` and only the two agentcage state dirs are mounted.
- Both fixed in `LimaInstance.exec` by pinning `--workdir /` and `--tty=false`, plus an `input=` passthrough. `VmPodman` and three inline `subprocess.run` sites in `backends/vm.py` were refactored onto the helper so the flags apply everywhere.

**`cage update`:**
- `NAME` was required even when `-c cage.yaml` was given. `cfg.name` is authoritative when `-c` is passed; mirror `cage create`.
- The pre-deploy secrets check always queried host Podman. For VM and apple-container cages on a Linux host with podman installed, every update with `secret_injection:` rules failed "missing secrets" because the secret was correctly stored inside the VM or in `pending_secrets.json`, not on the host. Now routes through `VmPodman` for running VMs, reads `pending_secrets.json` for apple-container, and skips for stopped VMs (where `backend.start()` will recreate from the pending file).

## Test Coverage

Tests: 1545 → 1564 (+19 upstream, +5 new in this PR).

**New regression tests:**
- `tests/test_lima_instance.py::test_exec_pins_workdir_and_disables_tty` — proves `--workdir /` and `--tty=false` are on every call.
- `tests/test_lima_instance.py::test_exec_pipes_stdin_via_input` — proves `input=` is forwarded.
- `tests/test_cage_cli.py::test_update_requires_name_or_config` — proves the new no-arg error.
- `tests/test_cage_cli.py::test_update_infers_name_from_config` — proves `cage update -c cage.yaml` works without `NAME`.
- `tests/test_cage_cli.py::test_update_vm_does_not_query_host_podman_for_secrets` — proves the old "missing secrets" block is gone for VM cages with a stopped VM.

## Test plan

- [x] Full test suite passes: `uv run pytest -q` — 1564 passed
- [x] `agentcage cage update --help` shows `[NAME]` as optional
- [x] `agentcage cage update` with no args prints the new error and exits non-zero
- [ ] Manual verification on a real VM cage with `-s KEY=value` (requires Lima — done in dev, full CI lane will exercise the unit-test path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)