### PR TITLE
fix(apple-container): honor container.env: as `-e KEY=VAL` to container run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **apple-container honors `container.env:`.** The container backend wires `cc.env` to systemd Quadlet `Environment=` entries via `quadlets.py:338`, but the apple-container backend's `start()` never read `cfg.container.env` — every entry was silently dropped, and `validate_config`'s `_ac_silent_drops` list didn't include it either, so the operator got no warning. A cage.yaml with `container.env: {FOO: bar}` had `FOO` set on Linux/container and unset on apple-container. `generate_units` now persists `container.env` (with `$VAR` already expanded host-side, matching the quadlets behavior) into the per-cage unit JSON; `start()` reads it back and emits one `-e KEY=VAL` per entry to `container run`, sequenced before the `secret_injection` placeholder `-e` so the two never collide. Surfaced by torture-mac F1 against v0.21.13.
+
 ## [0.21.14] - 2026-05-26
 
 UX hardening pass driven by a live torture session against v0.21.13 on

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -495,6 +495,21 @@ class AppleContainerBackend:
                 # start) so a `cage update` controls the surface, matching
                 # how the rest of the runtime config flows.
                 "volumes": list(config.container.volumes),
+                # User-defined ``container.env:`` entries. Apple's
+                # `container run` accepts `-e KEY=VAL` like podman. The
+                # container backend wires these via quadlets.py:338;
+                # pre-this-fix apple-container ignored them silently (the
+                # cage workload's environ was just missing the keys, no
+                # warning). Expand $VAR in values to match the container
+                # backend's behavior. Placeholder-style values from
+                # ``secret_injection:`` go through a separate `-e KEY={{PH}}`
+                # path that lives in ``start()`` (using
+                # ``secret_env_placeholders`` above); the two never overlap
+                # because validate_config rejects a key listed in BOTH.
+                "env": {
+                    k: os.path.expandvars(str(v))
+                    for k, v in (config.container.env or {}).items()
+                },
             },
             indent=2,
             sort_keys=True,
@@ -593,6 +608,17 @@ class AppleContainerBackend:
             argv += ["--memory", _normalize_memory(str(memory_raw))]
         elif meta.get("mem_mb"):  # pre-0.20.6 unit JSON
             argv += ["--memory", f"{meta['mem_mb']}M"]
+
+        # User-defined ``container.env:`` entries — passed verbatim to
+        # ``container run`` as ``-e KEY=VAL``. Container backend wires
+        # the same shape via quadlets.py:338; apple-container ignored
+        # these silently pre-this-fix. Persisted under the ``env`` key
+        # in the unit JSON by ``generate_units`` (with $VAR already
+        # expanded host-side at unit-write time). secret_injection
+        # placeholders flow through ``secret_env_placeholders`` below
+        # and never collide (validate_config rejects shared keys).
+        for env_k, env_v in (meta.get("env") or {}).items():
+            argv += ["-e", f"{env_k}={env_v}"]
 
         # Secret-injection. For each env named in the cage's
         # `secret_injection:` rules:

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1773,6 +1773,85 @@ def test_unit_json_persists_user_volumes(tmp_path, monkeypatch):
     assert parsed["volumes"] == ["~/foo:/workspace:rw"]
 
 
+def test_start_passes_user_env_as_container_run_args(tmp_path, monkeypatch):
+    """`container.env:` entries flow through `start()` as `-e KEY=VAL`
+    argv. Was silently dropped pre-this-fix: `cfg.container.env` was
+    never read on the apple-container backend (only the container
+    backend's quadlets wired it). Verifies the unit JSON persists them
+    and start() reads them back."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = AppleContainerBackend()
+    unit_dir = tmp_path / "apple-container"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps({
+        "name": "demo", "user_image": "x", "cpus": 1,
+        "memory": "1G", "lifecycle": "interactive",
+        "env": {"TORTURE_T7": "hello-from-mac", "DEPLOY_ENV": "ctf"},
+    }))
+    captured_argv: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        captured_argv.append(list(argv))
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "unit_dir", return_value=unit_dir), \
+         patch.object(backend, "logs_dir", return_value=tmp_path / "logs"), \
+         patch.object(backend, "secrets_dir", return_value=tmp_path / "secrets"), \
+         patch.object(ac_cli, "image_inspect", return_value={"config": {}}), \
+         patch.object(ac_cli, "inspect", return_value=None), \
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "_wait_supervisor_ready", lambda *a, **k: None):
+        backend.start("demo", quiet=True)
+
+    run_argv = next(a for a in captured_argv if a and a[0] == "run")
+    # Each env var rendered as `-e KEY=VAL`, preserving values verbatim.
+    assert "TORTURE_T7=hello-from-mac" in run_argv
+    assert "DEPLOY_ENV=ctf" in run_argv
+    # Each -e is paired with its KEY=VAL value (argv shape sanity).
+    e_positions = [i for i, a in enumerate(run_argv) if a == "-e"]
+    for pos in e_positions:
+        assert pos + 1 < len(run_argv) and "=" in run_argv[pos + 1], \
+            f"stray -e at position {pos} in argv"
+
+
+def test_unit_json_persists_user_env_with_var_expansion(monkeypatch):
+    """`generate_units` must persist `container.env` into the unit JSON,
+    expanding $VAR in values host-side (matching container backend's
+    quadlets.py:338 behavior). A subsequent `start()` only reads the
+    unit JSON, not the cage.yaml — so the expansion has to happen at
+    generate-units time."""
+    from agentcage.config import Config, ContainerConfig
+    monkeypatch.setenv("DEPLOY_HOST", "ctf-mac")
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(
+            image="localhost/test:latest",
+            env={"GREETING": "hello", "DEPLOY_ON": "$DEPLOY_HOST"},
+        ),
+    )
+    backend = AppleContainerBackend()
+    out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
+    parsed = json.loads(out["demo.json"])
+    assert parsed["env"] == {"GREETING": "hello", "DEPLOY_ON": "ctf-mac"}
+
+
+def test_unit_json_empty_env_when_container_env_unset():
+    """Backward compat: cages with no `container.env:` get an empty
+    dict, not a None / missing key — so `meta.get('env') or {}` always
+    iterates cleanly."""
+    from agentcage.config import Config, ContainerConfig
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(image="localhost/test:latest"),
+    )
+    backend = AppleContainerBackend()
+    out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
+    parsed = json.loads(out["demo.json"])
+    assert parsed["env"] == {}
+
+
 def test_run_streaming_pauses_active_spinner():
     """``ac_cli.run(capture_output=False)`` must wrap subprocess.run in
     ``output.pause_active_spinner()`` so Apple's CLI progress doesn't fight


### PR DESCRIPTION
## Summary

- `cfg.container.env` was never read on the apple-container backend — entries silently dropped, no warning. Container backend wires the same field via `quadlets.py:338`, so a cage.yaml that worked on Linux had env vars silently absent on Mac.
- `generate_units` now persists `container.env` into the per-cage unit JSON (with `\$VAR` expanded host-side, matching quadlets); `start()` emits `-e KEY=VAL` per entry to `container run`, sequenced before secret-injection placeholders.

## Why

Surfaced as **F1** in the torture-mac findings on v0.21.13. T7 of the plan added `TORTURE_T7: "hello-from-mac"` to `cage.yaml`'s `container.env:`, ran `cage update`, then `printenv TORTURE_T7` inside the cage — got nothing. Tracing through the code: `grep -rn 'container\\.env\\|cc\\.env' src/agentcage/backends/apple_container.py src/agentcage/apple_container/wrapper.py` returned **zero hits**. The container backend's `quadlets.py:338` is the only place that consumes it. Worse, `_ac_silent_drops` in `config.py` didn't list `container.env`, so the operator got no diagnostic.

## Test plan

- [x] 3 new tests in `tests/test_apple_container.py`:
  - `test_start_passes_user_env_as_container_run_args` — verifies argv shape (`-e KEY=VAL` per entry, no stray `-e`)
  - `test_unit_json_persists_user_env_with_var_expansion` — `\$VAR` expanded at generate-units time
  - `test_unit_json_empty_env_when_container_env_unset` — backward compat (always emit a dict)
- [x] Full suite: 140 apple-container tests pass locally
- [ ] Manual macOS verification: re-run torture T7 — `printenv TORTURE_T7` should print \`hello-from-mac\`

## Notes

- secret-injection placeholders (`-e KEY={{PH}}`) and user env (`-e KEY=VAL`) never collide in practice because validate_config rejects an env name appearing in both. Sequencing user env first means a future schema bug where they DO collide would have user-env overridden by the placeholder (safer default — the secret-injection path is the security-sensitive one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)