### PR TITLE
fix(cli): live-reload dnsmasq on domain add/rm — don't restart the cage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`fix(cli)`: `domain add` / `domain rm` no longer restart the cage on
+  the container backend.** They now write the updated allowlist files
+  and `pkill -HUP dnsmasq` inside the dns sidecar — the mitmproxy addon
+  already hot-reloads its config via mtime polling, and dnsmasq re-reads
+  `--servers-file` on SIGHUP. Net effect on container cages: a domain
+  change is roughly instant, and any interactive session inside the cage
+  (e.g. `agentcage run -i`) survives the update. Why `pkill` instead of
+  `podman kill --signal HUP`: PID 1 in the dns container is the
+  `dns-audit.sh` wrapper, not dnsmasq itself, so the signal would be
+  eaten by the wrapper. The VM and apple-container paths are unchanged
+  (Lima reverse-sshfs caches host file content past the SIGHUP, and the
+  apple-container allowlist is baked into the wrapper image — both still
+  require the restart cycle to pick up changes).
+
 ## [0.21.15] - 2026-05-26
 
 Two apple-container parity fixes surfaced by the torture-mac plan against v0.21.13.

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -3016,18 +3016,45 @@ def _ensure_dns_quadlet_current(cfg) -> bool:
 def _update_dns_quadlet(cfg) -> None:
     """Apply a domain-allowlist change to the dnsmasq sidecar.
 
-    Writes the allowlist sidecar file from cage.yaml and, if the cage is
-    running, restarts the dns/proxy/cage services in dependency order so
-    dnsmasq picks up the new file. The DNS quadlet itself almost never
-    needs rewriting — the allowlist isn't baked into it any more — so the
-    common path skips daemon-reload entirely. The migration safety check
-    in :func:`_ensure_dns_quadlet_current` covers cages whose on-disk
-    quadlet still has the old shape from a pre-upgrade install.
+    Rewrites the dns-allowlist sidecar and proxy-config files, then signals
+    the running daemons to pick them up.
 
-    Note on the cascade: a DNS-only restart cascades via the ``Requires=``
-    dependency chain (proxy Requires dns, cage Requires proxy) and would
-    leave proxy/cage stopped.  We stop all three explicitly, then start in
-    dependency order so everything comes back up cleanly.
+    Container backend (live-reload, no cage restart):
+      - dnsmasq runs with ``--servers-file=/etc/dnsmasq-allow.conf`` and
+        re-reads it on SIGHUP. We ``podman exec ... pkill -HUP dnsmasq``
+        rather than ``podman kill --signal HUP`` because PID 1 in the dns
+        container is the ``dns-audit.sh`` wrapper, not dnsmasq — a signal
+        to PID 1 would be eaten by the wrapper.
+      - The mitmproxy addon polls ``/etc/agentcage/config.yaml`` mtime on
+        every request and hot-reloads inspectors in-place (see
+        ``data/proxy/addon.py:_maybe_reload``). No signal needed.
+      - Net effect: the cage container is untouched. Any interactive
+        session inside it (e.g. ``agentcage run``) survives a domain
+        add/rm.
+
+    VM backend (Lima):
+      - Lima's reverse-sshfs mount (the default on Linux+QEMU) caches host
+        file content aggressively — a host-side rewrite of the allowlist
+        files is NOT visible inside the VM until the Lima mount itself is
+        reset. SIGHUP'ing dnsmasq inside the VM would just have it re-read
+        the same stale data. The legacy restart-all behavior had the same
+        underlying limitation (the bind mount source is the same cached
+        sshfs path), so we leave it in place rather than silently doing
+        nothing. Users wanting to reliably apply a VM domain change today
+        must restart the cage (``agentcage cage restart NAME``). Tracking
+        the proper fix (write into a VM-local path via ``inst.exec``) as
+        follow-up.
+
+    Apple-container backend:
+      - Allowlist is baked into the wrapper image at build time, so a
+        domain change requires rebuilding the image and restarting the
+        cage. The observability bridge (see #120) is expected to add a
+        bind-mounted allowlist path on apple-container, at which point
+        this branch can collapse.
+
+    The migration safety check in :func:`_ensure_dns_quadlet_current`
+    still covers cages whose on-disk quadlet has the old shape from a
+    pre-upgrade install.
     """
     state.save_dns_allowlist(cfg.name)
     _ensure_dns_quadlet_current(cfg)
@@ -3036,8 +3063,11 @@ def _update_dns_quadlet(cfg) -> None:
     name = cfg.name
 
     if cfg.isolation == "vm":
-        inst = LimaInstance(name)
+        # See docstring — Lima reverse-sshfs caching makes live-reload
+        # unreliable; keep the legacy restart-all path until the bind
+        # source moves to a VM-local file.
         if backend.is_running(name, "dns"):
+            inst = LimaInstance(name)
             services = backend.service_names(name)
             for svc in services:
                 inst.exec(["systemctl", "--user", "stop", f"{name}-{svc}.service"],
@@ -3045,18 +3075,6 @@ def _update_dns_quadlet(cfg) -> None:
             for svc in reversed(services):
                 inst.exec(["systemctl", "--user", "start", f"{name}-{svc}.service"])
     elif _is_apple_container(cfg):
-        # On apple-container the dnsmasq + mitmproxy allowlists are baked
-        # into the wrapper image at build_artifacts() time — there's no
-        # bind-mounted allowlist file the running supervisor can re-read
-        # yet (that infra lands with the observability bridge in #120).
-        # A plain restart would re-execute the OLD allowlist; the change
-        # the user just saved to cage.yaml would silently not apply.
-        #
-        # Trigger the same build path `cage update` uses: rebuild the
-        # wrapper image (Apple's layer cache makes this ~1–2s on warm
-        # systems), then restart so the cage runs against the new image.
-        # Users no longer have to remember "now run cage update" — domain
-        # add/rm behaves like container/vm: change saved → effect applied.
         was_running = backend.is_running(name, "cage")
         if was_running:
             backend.stop(name)
@@ -3065,15 +3083,8 @@ def _update_dns_quadlet(cfg) -> None:
             backend.start(name, quiet=True)
     else:
         if backend.is_running(name, "dns"):
-            # Stop most-dependent first, start dependencies first.
-            services = backend.service_names(name)
-            for svc in services:
-                try:
-                    systemd.stop_unit(f"{name}-{svc}.service")
-                except Exception:
-                    pass
-            for svc in reversed(services):
-                systemd.start_unit(f"{name}-{svc}.service")
+            Podman().container_exec(f"{name}-dns",
+                                    ["pkill", "-HUP", "dnsmasq"])
 
 
 @domain.command("add")

--- a/tests/test_dns_live_reload.py
+++ b/tests/test_dns_live_reload.py
@@ -1,0 +1,197 @@
+"""Tests for live-reload of the dnsmasq allowlist via _update_dns_quadlet.
+
+A domain add/rm must not restart the cage container — interactive sessions
+inside the cage (e.g. ``agentcage run``) need to survive a config update.
+
+Container backend: SIGHUP dnsmasq via ``podman exec ... pkill -HUP dnsmasq``;
+                   proxy hot-reloads via mtime poll.
+VM backend:        same, routed through ``limactl shell -- podman exec ...``.
+Apple-container:   image bake — must rebuild + restart (no bind-mount yet).
+
+Why pkill instead of `podman kill --signal HUP`: the dns container's PID 1
+is dns-audit.sh (the audit-log wrapper), not dnsmasq. A signal to PID 1
+would be eaten by the wrapper. pkill targets the dnsmasq process directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _mock_cfg(isolation: str, name: str = "demo") -> MagicMock:
+    cfg = MagicMock()
+    cfg.isolation = isolation
+    cfg.name = name
+    return cfg
+
+
+class TestContainerBackendLiveReload:
+    """On the container (rootless podman) backend, a domain change SIGHUPs
+    the dnsmasq sidecar — the proxy addon hot-reloads via mtime poll, and
+    the cage container is never touched."""
+
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_signals_dnsmasq_via_pkill(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_podman_cls,
+    ):
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("container")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+        podman = mock_podman_cls.return_value
+
+        _update_dns_quadlet(cfg)
+
+        # pkill -HUP dnsmasq runs inside the dns container — not a
+        # `podman kill --signal HUP` (which would hit dns-audit.sh PID 1)
+        # and not a stop_unit/start_unit of the cage.
+        podman.container_exec.assert_called_once_with(
+            "demo-dns", ["pkill", "-HUP", "dnsmasq"],
+        )
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_does_not_stop_or_start_any_unit(
+        self, mock_state, mock_get_backend, _mock_ensure,
+        _mock_podman_cls, mock_systemd,
+    ):
+        """Cage interactive sessions must survive a domain add — i.e. NO
+        systemctl stop/start of {name}-cage.service, -proxy.service, or
+        -dns.service."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("container")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        mock_systemd.stop_unit.assert_not_called()
+        mock_systemd.start_unit.assert_not_called()
+
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_skips_signal_when_dns_not_running(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_podman_cls,
+    ):
+        """If the cage isn't running, the file is rewritten but no signal
+        is sent — there's no dnsmasq to reload."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("container")
+        backend = MagicMock()
+        backend.is_running.return_value = False
+        mock_get_backend.return_value = backend
+        podman = mock_podman_cls.return_value
+
+        _update_dns_quadlet(cfg)
+
+        podman.container_exec.assert_not_called()
+        # Allowlist file IS rewritten — next start picks it up
+        mock_state.save_dns_allowlist.assert_called_once_with("demo")
+
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_rewrites_allowlist_file(
+        self, mock_state, mock_get_backend, _mock_ensure, _mock_podman_cls,
+    ):
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("container")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        mock_state.save_dns_allowlist.assert_called_once_with("demo")
+
+
+class TestVmBackendKeepsLegacyRestart:
+    """On VM (Lima), live-reload via SIGHUP would not actually take effect:
+    Lima's reverse-sshfs mount caches host file contents, so dnsmasq inside
+    the VM would re-read the same stale bytes regardless of signal. The
+    legacy restart-all behavior had the same limitation but is documented
+    and what existing users expect, so we keep it. Regression guard: a
+    domain add on a running VM cage still issues a stop/start cycle of
+    all infra services."""
+
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_restarts_all_services(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+    ):
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+
+        _update_dns_quadlet(cfg)
+
+        # Stops cage, proxy, dns (in that order); starts dns, proxy, cage.
+        argv_list = [c.args[0] for c in inst.exec.call_args_list]
+        stops = [a for a in argv_list if "stop" in a]
+        starts = [a for a in argv_list if "start" in a]
+        assert ["systemctl", "--user", "stop", "demo-cage.service"] in stops
+        assert ["systemctl", "--user", "stop", "demo-proxy.service"] in stops
+        assert ["systemctl", "--user", "stop", "demo-dns.service"] in stops
+        assert ["systemctl", "--user", "start", "demo-dns.service"] in starts
+        assert ["systemctl", "--user", "start", "demo-proxy.service"] in starts
+        assert ["systemctl", "--user", "start", "demo-cage.service"] in starts
+
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_skips_restart_when_dns_not_running(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+    ):
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = False
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        mock_lima_cls.assert_not_called()
+        mock_state.save_dns_allowlist.assert_called_once_with("demo")
+
+
+class TestAppleContainerBackendStillRebuilds:
+    """The apple-container path is unchanged — its allowlist is baked into
+    the wrapper image at build time, so a domain change still requires
+    rebuilding the image and restarting the cage. Regression guard."""
+
+    @patch("agentcage.cli._is_apple_container", return_value=True)
+    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_apple_container_path_unchanged(
+        self, mock_state, mock_get_backend, _mock_ensure, _mock_is_apple,
+    ):
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("apple-container")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+
+        _update_dns_quadlet(cfg)
+
+        backend.stop.assert_called_once_with("demo")
+        backend.build_artifacts.assert_called_once()
+        backend.start.assert_called_once()


### PR DESCRIPTION
## Summary

`agentcage domain add` and `domain rm` on the container backend currently stop and restart all three of the cage's systemd services (`-cage`, `-proxy`, `-dns`). For a user with an `agentcage run` session open inside the cage, that means the `podman exec -it` connection dies the moment they add a domain — they get kicked out of the shell they were just using.

This PR makes domain add/rm a live-reload on the container backend:

- **dnsmasq:** `podman exec <cage>-dns pkill -HUP dnsmasq`. dnsmasq re-reads its `--servers-file=/etc/dnsmasq-allow.conf` on SIGHUP. We use `pkill` instead of `podman kill --signal HUP <cage>-dns` because PID 1 in the dns container is the `dns-audit.sh` wrapper, not dnsmasq itself — a signal to the wrapper is eaten before it reaches dnsmasq.
- **mitmproxy:** no signal needed. The addon already polls `/etc/agentcage/config.yaml` mtime on every request and reloads inspectors in-place via `_maybe_reload` (`data/proxy/addon.py:355`).

Net effect: the cage container is never touched. Interactive sessions inside it survive the update.

The VM (Lima) and apple-container paths are unchanged. On VM, Lima's reverse-sshfs mount caches host file contents past the SIGHUP — even a full service restart inside the VM doesn't reliably pick up host-side allowlist changes today, so live-reload would just have dnsmasq re-read stale bytes. The proper VM fix is to write the file into a VM-local path via `inst.exec`, tracked as follow-up. On apple-container the allowlist is baked into the wrapper image, so a domain change still requires `build_artifacts() + restart`.

## Test plan

- [x] `tests/test_dns_live_reload.py` — 7 new unit tests across the three backends (container `pkill -HUP`, no systemctl, no-op when dns not running; VM legacy restart preserved; apple-container rebuild path unchanged).
- [x] Full suite: 1581 → 1588 passed locally.
- [x] End-to-end on a real container cage (`torture-c`): cage PID unchanged across add/rm, dnsmasq + proxy both pick up the new entry immediately (verified via `cat /etc/dnsmasq-allow.conf` inside the dns container and dnsmasq's own "using nameserver ... for domain X" log line on SIGHUP).
- [x] End-to-end on a real VM cage (`torture-vm`): legacy restart still happens (cage PID changes), confirming we haven't regressed the VM path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)