### PR TITLE
fix(e2e): patch_proxy_hosts uses awk + truncate, not sed -i

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -388,8 +388,15 @@ _patch_proxy_hosts() {
     block="${block}${mock_ip} ${domain}\n"
   done
   block="${block}# e2e-mock-end"
+  # podman bind-mounts /etc/hosts from a host-managed file, so `sed -i` —
+  # which writes a temp file and renames over the target — fails silently
+  # at the rename across the bind-mount boundary. Pre-#187 the proxy
+  # container restart on every domain add wiped /etc/hosts, masking it;
+  # now stale e2e-mock blocks accumulate and the proxy's resolver picks
+  # the first (dead) mock IP it finds. Use awk + cat-overwrite, which
+  # truncates the existing inode in place rather than renaming.
   podman exec --user root "${cage}-proxy" \
-    sh -c "sed -i '/# e2e-mock-start/,/# e2e-mock-end/d' /etc/hosts 2>/dev/null; printf '${block}\n' >> /etc/hosts" 2>/dev/null
+    sh -c "awk '/# e2e-mock-start/{skip=1; next} /# e2e-mock-end/{skip=0; next} !skip{print}' /etc/hosts > /tmp/.e2e-hosts.new && cat /tmp/.e2e-hosts.new > /etc/hosts && rm -f /tmp/.e2e-hosts.new; printf '${block}\n' >> /etc/hosts" 2>/dev/null
 }
 
 start_mock() {


### PR DESCRIPTION
## Summary

`_patch_proxy_hosts` in `tests/e2e/lib.sh` uses `sed -i` to delete the prior `e2e-mock-start … e2e-mock-end` block in the proxy container's `/etc/hosts` before appending a fresh one. `sed -i` writes a temp file and renames it over the target — and inside podman containers `/etc/hosts` is bind-mounted from a host-managed file, so the cross-mount rename fails silently. Two layers of `2>/dev/null` hid the failure.

Pre-#187 the proxy container was restarted on every `domain add`, which wiped `/etc/hosts` as a side effect — the broken cleanup never mattered because the file started fresh each time and the new block was the only one in it.

After #187 the proxy is no longer restarted, blocks accumulate across repatches, and the proxy's resolver picks the **first** matching entry it finds in `/etc/hosts`. In CI the first block is usually a stale mock IP from an earlier phase (`10.89.152.3`, from when the mock for phase 1 came up there) but by Phase 4 the mock has been recreated at `10.89.152.4`. The proxy connects to the dead `.3:80`, gets `RST` immediately, the request fails, and Phase 4.3 times out after 2 minutes:

```
proxy /etc/hosts:
  # e2e-mock-start
  10.89.152.3 httpbin.org    ← stale from phase 1, never cleaned up
  10.89.152.3 example.com
  # e2e-mock-end
  # e2e-mock-start
  10.89.152.3 httpbin.org    ← stale from phase 2, never cleaned up
  10.89.152.3 example.com
  # e2e-mock-end
  # e2e-mock-start
  10.89.152.4 httpbin.org    ← live entry, but resolver picks the first match (.3)
  ...
```

Switch to `awk` filtering out the markers + `cat /tmp/file > /etc/hosts`, which truncates the existing inode in place — no rename, no bind-mount boundary crossing. All accumulated e2e-mock blocks get cleaned per call, and the fresh block is the only one left.

## Why this surfaced now

Master's CI (currently failing): https://github.com/agentcage/agentcage/actions/runs/26480078418 — same Phase 4.3 timeout, same root cause.
PR #189 CI (currently failing): same.

## Test plan

- [x] Local sanity: `awk '/# e2e-mock-start/{skip=1;next} /# e2e-mock-end/{skip=0;next} !skip{print}'` on a synthetic /etc/hosts with three accumulated blocks deletes them all.
- [ ] CI: Phase 4.3 passes on this PR (was failing on master after #187).

🤖 Generated with [Claude Code](https://claude.com/claude-code)