### PR TITLE
restore(cli): bring back agentcage cage edit with validation, backup, live-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agentcage cage edit NAME` — restored, with teeth.** Opens the stored
+  `cage.yaml` in `$EDITOR`, then on save (1) validates the edited YAML
+  through the same `validate_config` path that `cage create` runs —
+  rejected edits land in `cage.yaml.rejected` so they aren't lost, and the
+  original `cage.yaml` is untouched on failure; (2) backs up the previous
+  good config to `cage.yaml.bak`; (3) writes the new config atomically
+  (temp file + `rename`) so a crash mid-edit cannot corrupt cage state;
+  (4) shows a unified diff of what changed; (5) live-applies domain
+  changes via the dnsmasq SIGHUP path landed in #187 — no cage restart,
+  any interactive session inside the cage survives; (6) refreshes
+  `proxy-config.yaml` so the mitmproxy addon's mtime poller hot-reloads
+  inspector / rate-limit / logging changes; (7) prints the exact next
+  command (`cage restart` vs. `cage update`) for changes that need one.
+  Aliased as `cage config`. Removed in #74 on the grounds it was a
+  "trivial `click.edit` wrapper"; the restored version earns its keep by
+  doing validation + atomic-write + auto-reload that a bare
+  `$EDITOR ~/.config/agentcage/cages/NAME/cage.yaml` can't.
+
 ### Removed
 
 - **`agentcage run -i / --interactive-domains` flag.** The feature has

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,6 +99,7 @@ Subdomains are collapsed to their parent domain (e.g. `api.stripe.com` prompts f
 |---|---|
 | `cage create -c CONFIG` | Build images, generate quadlets, install, and start a new cage |
 | `cage update NAME [-c CONFIG]` | Rebuild images and restart an existing cage |
+| `cage edit NAME` | Edit a cage's stored config in `$EDITOR` with validation, backup, and live-reload |
 | `cage list` | List all cages with status |
 | `cage destroy NAME [-y] [--keep-secrets]` | Stop containers, remove quadlets, state, and scoped secrets |
 | `cage prune [-y]` | Remove all exited interactive and ephemeral cages |
@@ -114,7 +115,7 @@ Subdomains are collapsed to their parent domain (e.g. `api.stripe.com` prompts f
 | `cage backup NAME [OPTIONS]` | Create a backup tarball of a cage |
 | `cage restore TARBALL [OPTIONS]` | Restore a cage from a backup tarball |
 
-**Aliases:** `ls` → `list`, `ps` → `list`, `status` → `list`, `rm` → `destroy`, `delete` → `destroy`, `reload` → `restart`, `describe` → `show`, `inspect` → `show`
+**Aliases:** `ls` → `list`, `ps` → `list`, `status` → `list`, `rm` → `destroy`, `delete` → `destroy`, `reload` → `restart`, `describe` → `show`, `inspect` → `show`, `config` → `edit`
 
 ## `secret` -- Manage cage-scoped secrets
 
@@ -191,6 +192,27 @@ Stops the running services before rebuilding, then starts them again.
 |---|---|
 | `--no-cache` | Force a full image rebuild, ignoring podman's layer cache. Use after pulling a fresh agentcage release that changed the `Containerfile` or its build context. |
 | `--pull` | Force a re-pull of the base image from the registry (`--pull=always`). Invalidates the base-image cache, independent of `--no-cache`. Combine both for a fully clean rebuild. |
+
+## `cage edit`
+
+```
+agentcage cage edit <name>
+```
+
+Opens the cage's stored `cage.yaml` in your `$EDITOR` (falls back to `vi`). On save:
+
+1. Parses the edited YAML and runs the same `validate_config` checks that `cage create` runs. If parsing or validation fails, the edits are written to `cage.yaml.rejected` and the original `cage.yaml` is left untouched — exits non-zero.
+2. Backs up the prior good config to `cage.yaml.bak`.
+3. Writes the new config atomically (temp file + `rename`) so a crash mid-edit cannot corrupt cage state.
+4. Shows a unified diff of what changed.
+5. **Live-applies domain changes** by re-rendering the dnsmasq allowlist and `pkill -HUP dnsmasq` inside the dns sidecar — no cage restart, any interactive session inside the cage survives.
+6. For changes the proxy can hot-reload (`inspectors`, `rate_limit`, `logging`, etc.), rewrites `proxy-config.yaml` — the mitmproxy addon picks it up on the next request via mtime polling.
+7. For changes that need a service restart (`container.*`, `secrets`, etc.), tells you to run `agentcage cage restart NAME`.
+8. For changes that need a full rebuild (`isolation`, `vm.*`), tells you to run `agentcage cage update NAME`.
+
+This is safer than `$EDITOR ~/.config/agentcage/cages/NAME/cage.yaml` because a malformed YAML or invalid field there silently breaks the cage at the next `cage start` / `cage update`. With `cage edit`, the validation runs *before* the file is written.
+
+Aliased as `cage config`.
 
 ## `cage list`
 

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -375,7 +375,7 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
 # ── cage group ────────────────────────────────────────────
 
 
-@main.group(cls=AliasGroup, aliases={"ls": "list", "rm": "destroy", "ps": "list", "status": "list", "reload": "restart", "delete": "destroy", "describe": "show", "inspect": "show"})
+@main.group(cls=AliasGroup, aliases={"ls": "list", "rm": "destroy", "ps": "list", "status": "list", "reload": "restart", "delete": "destroy", "describe": "show", "inspect": "show", "config": "edit"})
 def cage():
     """Manage cages."""
 
@@ -1336,6 +1336,213 @@ def cage_restart(name: str):
 
     _restart_cage(name, cfg)
     click.echo(f"Restarted cage '{name}'")
+
+
+# Fields the proxy hot-reloads via mtime polling on proxy-config.yaml.
+# A change here only needs `save_proxy_config()` — no cage restart.
+_PROXY_HOT_RELOAD_KEYS = frozenset({
+    "max_request_body", "entropy", "content_type", "inspectors",
+    "rate_limit", "logging", "secret_injection", "capture", "protocol_relays",
+})
+
+# Fields that need a destroy + recreate (image rebuild, network changes, etc).
+_REBUILD_KEYS = frozenset({"isolation", "vm"})
+
+
+def _yaml_dump(raw: dict) -> str:
+    """Render a raw config dict as YAML with the project's conventions."""
+    import yaml
+    return yaml.safe_dump(raw, default_flow_style=False, sort_keys=False)
+
+
+def _classify_changes(before: dict, after: dict) -> tuple[set[str], set[str], set[str]]:
+    """Bucket top-level config-key changes into (live, restart, rebuild) sets.
+
+    - live: applied in-place without a cage restart (domains via SIGHUP,
+      proxy keys via mtime polling).
+    - restart: needs `agentcage cage restart NAME` to take effect.
+    - rebuild: needs `agentcage cage destroy + create` (image, isolation).
+    """
+    changed = {
+        k for k in set(before) | set(after)
+        if before.get(k) != after.get(k)
+    }
+    live: set[str] = set()
+    restart: set[str] = set()
+    rebuild: set[str] = set()
+    for k in changed:
+        if k == "domains":
+            live.add(k)
+        elif k in _PROXY_HOT_RELOAD_KEYS:
+            live.add(k)
+        elif k in _REBUILD_KEYS:
+            rebuild.add(k)
+        else:
+            restart.add(k)
+    return live, restart, rebuild
+
+
+@cage.command("edit")
+@click.argument("name")
+def cage_edit(name: str):
+    """Edit a cage's stored config in $EDITOR, with validation and safe save.
+
+    Unlike `$EDITOR ~/.config/agentcage/cages/NAME/cage.yaml`, this command:
+
+      - Validates the edited YAML before saving (rejected edits are written
+        to cage.yaml.rejected so you don't lose them).
+      - Writes atomically (temp file + rename) so a crash mid-edit cannot
+        corrupt your cage state.
+      - Backs up the previous good config to cage.yaml.bak.
+      - Shows a unified diff of what changed.
+      - Auto-applies domain changes via dnsmasq SIGHUP (no cage restart).
+      - Tells you exactly which next command will pick up other changes.
+    """
+    import difflib
+    import yaml
+
+    if not state.deployment_exists(name):
+        click.echo(f"error: cage '{name}' does not exist", err=True)
+        sys.exit(1)
+
+    state_dir = state.deployment_dir(name)
+    config_path = state_dir / "cage.yaml"
+    rejected_path = state_dir / "cage.yaml.rejected"
+    backup_path = state_dir / "cage.yaml.bak"
+
+    original_text = config_path.read_text()
+    original_raw = state.load_raw_config(name)
+
+    # click.edit returns the edited text when given `text=`, or None if the
+    # user exited without saving / made no changes. We pass the text so we
+    # can detect "no change" without depending on editor mtime semantics.
+    edited_text = click.edit(text=original_text, extension=".yaml",
+                             require_save=True)
+
+    if edited_text is None or edited_text == original_text:
+        click.echo(f"No changes to cage '{name}'.")
+        return
+
+    # Parse edited content. Any YAML error → reject, preserve original.
+    try:
+        edited_raw = yaml.safe_load(edited_text)
+    except yaml.YAMLError as e:
+        rejected_path.write_text(edited_text)
+        loc = getattr(e, "problem_mark", None)
+        where = f" at line {loc.line + 1}, column {loc.column + 1}" if loc else ""
+        problem = getattr(e, "problem", None) or str(e)
+        click.echo(f"error: edited config is not valid YAML{where}: {problem}",
+                   err=True)
+        click.echo(f"  Rejected edits saved to {rejected_path}", err=True)
+        click.echo(f"  Original config at {config_path} is unchanged.", err=True)
+        sys.exit(1)
+
+    if not isinstance(edited_raw, dict):
+        rejected_path.write_text(edited_text)
+        click.echo("error: edited config must be a YAML mapping at the top level",
+                   err=True)
+        click.echo(f"  Rejected edits saved to {rejected_path}", err=True)
+        click.echo(f"  Original config at {config_path} is unchanged.", err=True)
+        sys.exit(1)
+
+    # Don't allow renaming a cage via `cage edit` — that requires state
+    # directory moves, podman secret renames, quadlet rewrites, and is
+    # outside this command's contract.
+    orig_name = original_raw.get("name")
+    new_name = edited_raw.get("name")
+    if orig_name != new_name:
+        rejected_path.write_text(edited_text)
+        click.echo(
+            f"error: renaming a cage via 'cage edit' is not supported "
+            f"(cage.yaml 'name' changed from '{orig_name}' to '{new_name}')",
+            err=True)
+        click.echo(f"  Rejected edits saved to {rejected_path}", err=True)
+        click.echo(f"  Original config at {config_path} is unchanged.", err=True)
+        sys.exit(1)
+
+    # Re-render so we can validate via the real loader (writes to a tempfile
+    # because load_config takes a path, not a dict).
+    rendered = _yaml_dump(edited_raw)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, dir=str(state_dir)
+    ) as tf:
+        tmp_validate_path = Path(tf.name)
+        tf.write(rendered)
+    try:
+        try:
+            cfg = load_config(str(tmp_validate_path))
+            warnings = validate_config(cfg)
+        except ValueError as e:
+            rejected_path.write_text(edited_text)
+            click.echo(f"error: edited config failed validation: {e}", err=True)
+            click.echo(f"  Rejected edits saved to {rejected_path}", err=True)
+            click.echo(f"  Original config at {config_path} is unchanged.",
+                       err=True)
+            sys.exit(1)
+    finally:
+        tmp_validate_path.unlink(missing_ok=True)
+
+    for w in warnings:
+        click.echo(f"warning: {w}", err=True)
+
+    # Show a unified diff of the change before writing.
+    diff = "".join(difflib.unified_diff(
+        original_text.splitlines(keepends=True),
+        rendered.splitlines(keepends=True),
+        fromfile=f"{name}/cage.yaml (before)",
+        tofile=f"{name}/cage.yaml (after)",
+    ))
+    if diff:
+        click.echo(diff, nl=False)
+
+    # Clear any stale rejected file from a prior failed edit — we now have
+    # a good edit superseding it.
+    rejected_path.unlink(missing_ok=True)
+
+    # Atomic write: temp + fsync + rename. Backup the previous good file
+    # first so a crash between rename and "all done" still leaves the
+    # operator able to recover.
+    shutil.copy2(config_path, backup_path)
+    fd, tmp_name = tempfile.mkstemp(dir=str(state_dir), prefix=".cage.yaml.",
+                                    suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(rendered)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, config_path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    # Persist the proxy-side subset (always — even if nothing in
+    # _PROXY_KEYS changed, this is cheap and keeps proxy-config.yaml in
+    # lockstep with cage.yaml).
+    state.save_proxy_config(name)
+
+    live, restart_keys, rebuild_keys = _classify_changes(original_raw, edited_raw)
+
+    if "domains" in live:
+        _update_dns_quadlet(cfg)
+
+    # Tell the operator what just happened and what (if anything) they
+    # still need to do. Be specific about which fields fall into which
+    # bucket so the next command is obvious.
+    click.echo(f"Updated cage '{name}'. Backup at {backup_path}.")
+    if live:
+        applied = sorted(live)
+        click.echo(f"  Live-applied: {', '.join(applied)}")
+    if restart_keys:
+        keys = sorted(restart_keys)
+        click.echo(f"  Needs restart ({', '.join(keys)}): "
+                   f"agentcage cage restart {name}")
+    if rebuild_keys:
+        keys = sorted(rebuild_keys)
+        click.echo(f"  Needs rebuild ({', '.join(keys)}): "
+                   f"agentcage cage update {name} (or destroy + create)")
 
 
 @cage.command("stop")

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -866,6 +866,239 @@ class TestCageRestart:
         mock_ensure_dns.assert_called_once_with(cfg)
 
 
+class TestCageEdit:
+    """`cage edit` opens the stored cage.yaml in $EDITOR, validates the
+    result, writes atomically with a backup, and surfaces what just
+    changed. These tests exercise the rationale that justifies the
+    command's existence over a bare `$EDITOR <path>` shell call."""
+
+    @staticmethod
+    def _setup_cage(tmp_path, yaml_text):
+        """Lay down a fake state dir with a cage.yaml and wire state mocks."""
+        cage_dir = tmp_path / "cages" / "test"
+        cage_dir.mkdir(parents=True)
+        (cage_dir / "cage.yaml").write_text(yaml_text)
+        return cage_dir
+
+    _GOOD_YAML = (
+        "name: test\n"
+        "container:\n"
+        "  image: node:22-slim\n"
+        "  command: [node, /app/agent.js]\n"
+        "domains:\n"
+        "  allow:\n"
+        "  - anthropic.com\n"
+        "  - github.com\n"
+    )
+
+    @patch("agentcage.cli.state")
+    def test_edit_nonexistent_cage(self, mock_state):
+        mock_state.deployment_exists.return_value = False
+        result = _runner().invoke(main, ["cage", "edit", "nope"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_no_changes_returns_none(self, mock_state, mock_click_edit, tmp_path):
+        """click.edit returns None when the user exits without saving."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        mock_state.load_raw_config.return_value = {"name": "test"}
+        mock_click_edit.return_value = None
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code == 0
+        assert "No changes" in result.output
+        # Nothing should have been written.
+        assert not (cage_dir / "cage.yaml.bak").exists()
+        mock_state.save_proxy_config.assert_not_called()
+
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_no_changes_identical_text(self, mock_state, mock_click_edit, tmp_path):
+        """click.edit returns same text — still a no-op, no backup written."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        mock_state.load_raw_config.return_value = {"name": "test"}
+        mock_click_edit.return_value = self._GOOD_YAML
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code == 0
+        assert "No changes" in result.output
+        assert not (cage_dir / "cage.yaml.bak").exists()
+        mock_state.save_proxy_config.assert_not_called()
+
+    @patch("agentcage.cli._update_dns_quadlet")
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_domain_change_live_reloads_dnsmasq(self, mock_state,
+                                                     mock_click_edit,
+                                                     mock_update_dns, tmp_path):
+        """Adding a domain triggers _update_dns_quadlet — no cage restart."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        # Pre-edit raw config (the in-memory before-image)
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        edited = self._GOOD_YAML.replace(
+            "  - github.com\n",
+            "  - github.com\n  - httpbin.org\n",
+        )
+        mock_click_edit.return_value = edited
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code == 0, result.output
+        assert "Live-applied" in result.output
+        assert "domains" in result.output
+        mock_update_dns.assert_called_once()
+        # save_proxy_config is always called on a real edit so proxy and
+        # cage.yaml stay in lockstep.
+        mock_state.save_proxy_config.assert_called_once_with("test")
+        # Backup written.
+        assert (cage_dir / "cage.yaml.bak").exists()
+        # The new on-disk cage.yaml contains the added domain.
+        written = (cage_dir / "cage.yaml").read_text()
+        assert "httpbin.org" in written
+        # Backup preserves the prior contents (no httpbin.org yet).
+        backup = (cage_dir / "cage.yaml.bak").read_text()
+        assert "httpbin.org" not in backup
+
+    @patch("agentcage.cli._update_dns_quadlet")
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_non_domain_change_prints_restart_hint(self, mock_state,
+                                                       mock_click_edit,
+                                                       mock_update_dns, tmp_path):
+        """Editing container.image needs `cage restart` — no DNS reload."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        edited = self._GOOD_YAML.replace("node:22-slim", "node:24-slim")
+        mock_click_edit.return_value = edited
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code == 0, result.output
+        assert "cage restart test" in result.output
+        mock_update_dns.assert_not_called()
+        mock_state.save_proxy_config.assert_called_once_with("test")
+
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_invalid_yaml_writes_rejected(self, mock_state, mock_click_edit,
+                                               tmp_path):
+        """Bad YAML lands in cage.yaml.rejected; the original is untouched."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        # Unterminated string — yaml.safe_load raises.
+        mock_click_edit.return_value = self._GOOD_YAML + "broken: 'unterminated\n"
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code != 0
+        assert "not valid YAML" in result.output
+        assert "cage.yaml.rejected" in result.output
+        # Rejected file was created with the bad edits.
+        assert (cage_dir / "cage.yaml.rejected").exists()
+        # The original cage.yaml on disk is byte-for-byte unchanged.
+        assert (cage_dir / "cage.yaml").read_text() == self._GOOD_YAML
+        # No backup since we never wrote a new good config.
+        assert not (cage_dir / "cage.yaml.bak").exists()
+        mock_state.save_proxy_config.assert_not_called()
+
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_validation_failure_writes_rejected(self, mock_state,
+                                                     mock_click_edit, tmp_path):
+        """load_config raising ValueError → reject, preserve original."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        # The edited YAML is parseable but semantically rejected by the real
+        # loader. Patch load_config so the test doesn't depend on the real
+        # schema rules (which can drift).
+        with patch("agentcage.cli.load_config",
+                   side_effect=ValueError("inspector 'nope' not found")):
+            edited = self._GOOD_YAML.replace(
+                "domains:\n", "inspectors:\n  - nope\ndomains:\n"
+            )
+            mock_click_edit.return_value = edited
+            result = _runner().invoke(main, ["cage", "edit", "test"])
+
+        assert result.exit_code != 0
+        assert "failed validation" in result.output
+        assert "inspector 'nope' not found" in result.output
+        assert (cage_dir / "cage.yaml.rejected").exists()
+        # Original untouched.
+        assert (cage_dir / "cage.yaml").read_text() == self._GOOD_YAML
+        assert not (cage_dir / "cage.yaml.bak").exists()
+
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_rename_attempt_rejected(self, mock_state, mock_click_edit,
+                                          tmp_path):
+        """Changing top-level `name:` is outside this command's contract."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        mock_click_edit.return_value = self._GOOD_YAML.replace(
+            "name: test\n", "name: renamed\n"
+        )
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code != 0
+        assert "renaming a cage" in result.output
+        assert (cage_dir / "cage.yaml.rejected").exists()
+        assert (cage_dir / "cage.yaml").read_text() == self._GOOD_YAML
+
+    @patch("agentcage.cli._update_dns_quadlet")
+    @patch("click.edit")
+    @patch("agentcage.cli.state")
+    def test_edit_shows_unified_diff(self, mock_state, mock_click_edit,
+                                     _mock_update_dns, tmp_path):
+        """The diff of the change is printed before the success line."""
+        cage_dir = self._setup_cage(tmp_path, self._GOOD_YAML)
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = cage_dir
+        import yaml as _yaml
+        mock_state.load_raw_config.return_value = _yaml.safe_load(self._GOOD_YAML)
+
+        edited = self._GOOD_YAML.replace(
+            "  - github.com\n", "  - github.com\n  - httpbin.org\n"
+        )
+        mock_click_edit.return_value = edited
+
+        result = _runner().invoke(main, ["cage", "edit", "test"])
+        assert result.exit_code == 0, result.output
+        # Unified-diff signature: ---/+++ headers and the added domain on
+        # a +-prefixed line.
+        assert "--- " in result.output
+        assert "+++ " in result.output
+        assert "+" in result.output and "httpbin.org" in result.output
+        # The unified-diff block precedes the "Updated cage" summary.
+        assert result.output.index("---") < result.output.index("Updated cage")
+
+    def test_edit_alias_config_routes_to_edit(self):
+        """`cage config` is an alias for `cage edit` (registered on AliasGroup)."""
+        from agentcage.cli import cage as cage_group
+        assert cage_group.get_command(None, "config").name == "edit"
+
+
 class TestCageStart:
     @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.secret_resolver.resolve_and_populate")


### PR DESCRIPTION
## Why restore it now?

PR #74 removed \`agentcage cage edit\` on the grounds it was a "trivial \`click.edit\` wrapper" — the replacement workflow was \`\$EDITOR ~/.config/agentcage/cages/NAME/cage.yaml && agentcage cage update NAME\`. That was a fair call at the time: the original implementation round-tripped raw YAML through \`click.edit\` and added almost nothing over a bare shell invocation.

This PR brings the command back, but earns its place by doing things the bare-shell approach can't:

1. **Validation before save.** Parses the edited YAML and runs the same \`validate_config\` checks \`cage create\` runs. Failed edits are written to \`cage.yaml.rejected\` (so they aren't lost) and the original \`cage.yaml\` is left byte-for-byte unchanged. The bare-shell approach silently breaks the cage at the next \`cage start\` / \`cage update\`.
2. **Atomic write.** Tempfile + \`fsync\` + \`rename\` — a crash mid-edit cannot corrupt cage state. \`\$EDITOR\` writing directly to \`cage.yaml\` has no such guarantee.
3. **Backup.** The previous good config is copied to \`cage.yaml.bak\` before the new write lands. Operator can \`mv cage.yaml{.bak,}\` to undo.
4. **Unified diff.** Shows exactly what changed before writing.
5. **Auto-reload on domain change.** Calls \`_update_dns_quadlet(cfg)\` if \`domains\` changed — this is live-reload on the container backend per #187 (\`pkill -HUP dnsmasq\` inside the dns sidecar, mitmproxy addon hot-reloads via mtime polling). Any interactive session inside the cage survives. The bare-shell approach forces \`cage update\` (rebuild + restart).
6. **Specific next-step hints.** Tells the operator exactly which command picks up other changes: \`cage restart\` for \`container.*\` / \`secrets\`, \`cage update\` for \`isolation\` / \`vm.*\`.
7. **Rejects renames.** Changing top-level \`name:\` is outside this command's contract (needs quadlet rewrites + secret moves) — \`cage.yaml.rejected\` is written and the operator gets a clear error.

Also adds \`cage config\` as an alias since it's a common muscle-memory verb for this operation.

## What changed

- \`src/agentcage/cli.py\`: \`cage_edit\` command + \`_classify_changes\` helper + \`_PROXY_HOT_RELOAD_KEYS\` / \`_REBUILD_KEYS\` constants. \`config\` alias on the \`cage\` AliasGroup.
- \`tests/test_cage_cli.py\`: new \`TestCageEdit\` class — 10 tests covering nonexistent cage, no-change paths, domain-change live-reload, non-domain restart hint, invalid YAML, validation failure, rename rejection, diff output, alias routing.
- \`docs/cli.md\`: \`cage edit\` row in the cage-group table, \`config → edit\` alias note, dedicated \`## cage edit\` section.
- \`CHANGELOG.md\`: entry under \`[Unreleased]\` / \`Added\`, citing #74 for the prior removal.

No changes to \`cage create\` / \`cage update\` / \`cage restart\` semantics, no changes to \`_update_dns_quadlet\` itself (just calls it), no version bump.

## Test plan

- [x] \`uv run python -m pytest\` — 1596 tests pass (1586 baseline + 10 new)
- [x] \`agentcage cage --help\` shows \`edit\` and \`config → edit\` alias
- [x] \`agentcage cage edit nonexistent-cage\` exits 1 with friendly error
- [ ] Reviewer: smoke-test against a live cage — edit, add a domain, save, confirm \`pkill -HUP dnsmasq\` ran (cage container PID unchanged, dnsmasq picks up the new entry)
- [ ] Reviewer: smoke-test the rejection path — edit, introduce invalid YAML, confirm \`cage.yaml.rejected\` was written and \`cage.yaml\` is intact

## Notes

- Builds on #187's live-reload path — domain changes via \`cage edit\` benefit from the same no-restart behavior as \`domain add\` / \`domain rm\`.
- A parallel branch (\`fix/vm-domain-live-reload\`) is extending \`_update_dns_quadlet\` for VM cages; that's an orthogonal change to the same function I call here. Should merge cleanly — this PR touches the cage subcommands section (\`cli.py\` ~1340), the VM work touches \`_update_dns_quadlet\` (\`cli.py\` ~3030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)