### PR TITLE
fix(vm): live-reload dnsmasq on domain add/rm (VM half of #187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`fix(cli)`: `domain add` / `domain rm` are now live-reload on the
+  VM (Lima) backend too — closes the VM half of #187.** Container cages
+  shipped live-reload in #187, but the VM path still hit a hard wall:
+  Lima's reverse-sshfs mount of `~/.config/agentcage` caches host writes,
+  so a host-side rewrite of `proxy-config.yaml` / `dns-allowlist.conf`
+  was invisible to processes inside the VM and dnsmasq SIGHUP would
+  re-read the same stale cached bytes. (The legacy restart-all path had
+  the same root cause and was also silently broken on VM — operators
+  worked around it by destroying and recreating the cage.) Fix: the
+  proxy and dns quadlets now bind-mount a VM-local copy of those files
+  at `~/.config/agentcage-vm/cages/<name>/...` (outside any Lima mount).
+  `cage create` / `start` / `restart` / `domain add` / `domain rm` all
+  push the latest host bytes into the VM-local path via `inst.exec`
+  (base64 over the limactl ssh channel — no sshfs in the loop), then
+  SIGHUP dnsmasq the same way the container backend does. Mitmproxy's
+  mtime poll picks up the proxy-config rewrite on the next request. Net
+  effect: VM domain changes are roughly instant and any interactive
+  session inside the cage survives the edit. Pre-upgrade cages whose
+  on-disk quadlet still bind-mounts the cached host path are migrated
+  automatically by `_ensure_dns_quadlet_current` on the first edit (one
+  `daemon-reload` + `systemctl --user restart <name>-dns.service` — every
+  subsequent edit on that cage takes the SIGHUP fast path). The
+  authoritative state still lives at the host path, so `cage backup` and
+  audit tooling are unchanged. The apple-container path is unchanged
+  (tracked in #120).
 - **`fix(cli)`: `domain add` / `domain rm` no longer restart the cage on
   the container backend.** They now write the updated allowlist files
   and `pkill -HUP dnsmasq` inside the dns sidecar — the mitmproxy addon
@@ -60,10 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. `agentcage run`) survives the update. Why `pkill` instead of
   `podman kill --signal HUP`: PID 1 in the dns container is the
   `dns-audit.sh` wrapper, not dnsmasq itself, so the signal would be
-  eaten by the wrapper. The VM and apple-container paths are unchanged
-  (Lima reverse-sshfs caches host file content past the SIGHUP, and the
-  apple-container allowlist is baked into the wrapper image — both still
-  require the restart cycle to pick up changes).
+  eaten by the wrapper. The apple-container path is unchanged (the
+  allowlist is baked into the wrapper image at build time — needs the
+  larger #120 change to add a bind-mounted allowlist).
 
 ## [0.21.15] - 2026-05-26
 

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -17,7 +17,50 @@ from agentcage.config import Config
 from agentcage.lima import prerequisites as lima_prerequisites
 from agentcage.lima.instance import LimaInstance
 from agentcage.lima.provisioning import generate_lima_config
-from agentcage.quadlets import generate_quadlets
+from agentcage.quadlets import (
+    generate_quadlets,
+    vm_local_config_dir,
+    vm_local_dns_allowlist_path,
+    vm_local_proxy_config_path,
+)
+
+
+def push_config_files(name: str, inst: LimaInstance) -> None:
+    """Mirror the host's proxy-config.yaml + dns-allowlist.conf into the VM.
+
+    The proxy and dns sidecar containers bind-mount these files. On the VM
+    backend the source can't be the host path under
+    ``~/.config/agentcage/cages/<name>/`` because Lima's reverse-sshfs mount
+    caches host writes — dnsmasq SIGHUP and the mitmproxy mtime-poll would
+    re-read the same stale bytes forever. So we keep the host file as the
+    authoritative state (preserved for ``cage backup``, audit tooling, etc.)
+    and additionally push a copy to a VM-local path that the quadlets
+    actually mount.
+
+    Idempotent. Safe to call on every deploy / start / restart / domain
+    edit; the cost is two ``inst.exec`` round-trips per file.
+    """
+    from agentcage import state
+    vm_dir = vm_local_config_dir(name)
+    inst.exec(["bash", "-c", f"mkdir -p {shlex.quote(vm_dir)}"])
+
+    proxy_cfg = state.deployment_dir(name) / "proxy-config.yaml"
+    if proxy_cfg.is_file():
+        encoded = base64.b64encode(proxy_cfg.read_bytes()).decode()
+        inst.exec([
+            "bash", "-c",
+            f"echo '{encoded}' | base64 -d > "
+            f"{shlex.quote(vm_local_proxy_config_path(name))}",
+        ])
+
+    dns_allow = state.dns_allowlist_path(name)
+    if dns_allow.is_file():
+        encoded = base64.b64encode(dns_allow.read_bytes()).decode()
+        inst.exec([
+            "bash", "-c",
+            f"echo '{encoded}' | base64 -d > "
+            f"{shlex.quote(vm_local_dns_allowlist_path(name))}",
+        ])
 
 
 VM_SERVICE_STARTUP_DELAY_S = 5
@@ -334,6 +377,14 @@ class VmBackend:
                         "bash", "-c",
                         f"echo '{encoded}' | base64 -d > {shlex.quote(vm_quadlet_dir)}/{shlex.quote(qfile.name)}",
                     ])
+
+        # Mirror proxy-config.yaml + dns-allowlist.conf into a VM-local
+        # path. Quadlets bind-mount this VM-local copy (NOT the host path
+        # under ~/.config/agentcage) so SIGHUP / mtime-poll live-reload
+        # actually sees ``domain add``/``domain rm`` rewrites — see
+        # ``push_config_files`` and ``cli._update_dns_quadlet``.
+        with Phase("deploy.vm_local_config", cage=name):
+            push_config_files(name, inst)
 
         # Bridge secrets from host Podman into VM's Podman
         with Phase("deploy.bridge_secrets", cage=name):

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -3236,18 +3236,28 @@ def _update_dns_quadlet(cfg) -> None:
         session inside it (e.g. ``agentcage run``) survives a domain
         add/rm.
 
-    VM backend (Lima):
-      - Lima's reverse-sshfs mount (the default on Linux+QEMU) caches host
-        file content aggressively — a host-side rewrite of the allowlist
-        files is NOT visible inside the VM until the Lima mount itself is
-        reset. SIGHUP'ing dnsmasq inside the VM would just have it re-read
-        the same stale data. The legacy restart-all behavior had the same
-        underlying limitation (the bind mount source is the same cached
-        sshfs path), so we leave it in place rather than silently doing
-        nothing. Users wanting to reliably apply a VM domain change today
-        must restart the cage (``agentcage cage restart NAME``). Tracking
-        the proper fix (write into a VM-local path via ``inst.exec``) as
-        follow-up.
+    VM backend (Lima, live-reload, no cage restart):
+      - Lima's reverse-sshfs mount of ``~/.config/agentcage`` caches host
+        writes — a host-side rewrite of ``proxy-config.yaml`` /
+        ``dns-allowlist.conf`` is invisible to processes inside the VM
+        until the mount itself is reset. We sidestep that entirely: the
+        proxy / dns quadlets bind-mount a *VM-local* copy of those files
+        (``~/.config/agentcage-vm/cages/<name>/...`` — outside any Lima
+        mount). On a domain edit we push the new file bytes into that
+        VM-local path via ``inst.exec`` (base64 over the limactl ssh
+        channel, no sshfs in the loop), then SIGHUP dnsmasq the same way
+        the container backend does — ``podman exec <name>-dns pkill -HUP
+        dnsmasq``. The mitmproxy addon's mtime poll picks up the
+        proxy-config rewrite on the next request.
+      - For cages created before this change the on-disk quadlet still
+        bind-mounts the cached host path; ``_ensure_dns_quadlet_current``
+        regenerates the unit (and ``daemon-reload``s) the first time a
+        domain edit runs against an upgraded install. The running dns
+        sidecar is still mounting the old path, so on this one-shot
+        migration we restart it (``systemctl --user restart``) instead
+        of SIGHUP — the new container picks up the new bind mount on the
+        way up, and every subsequent edit on this cage takes the SIGHUP
+        fast path.
 
     Apple-container backend:
       - Allowlist is baked into the wrapper image at build time, so a
@@ -3261,23 +3271,39 @@ def _update_dns_quadlet(cfg) -> None:
     pre-upgrade install.
     """
     state.save_dns_allowlist(cfg.name)
-    _ensure_dns_quadlet_current(cfg)
+    quadlet_changed = _ensure_dns_quadlet_current(cfg)
 
     backend = get_backend(cfg)
     name = cfg.name
 
     if cfg.isolation == "vm":
-        # See docstring — Lima reverse-sshfs caching makes live-reload
-        # unreliable; keep the legacy restart-all path until the bind
-        # source moves to a VM-local file.
+        # Push the rewritten host-side files into the VM-local path the
+        # proxy/dns containers actually bind-mount, then SIGHUP dnsmasq.
+        # The mitmproxy addon's mtime-poll hot-reload handles the
+        # proxy-config side on its own.
+        inst = LimaInstance(name)
+        if not inst.is_running():
+            return
+        from agentcage.backends.vm import push_config_files
+        push_config_files(name, inst)
         if backend.is_running(name, "dns"):
-            inst = LimaInstance(name)
-            services = backend.service_names(name)
-            for svc in services:
-                inst.exec(["systemctl", "--user", "stop", f"{name}-{svc}.service"],
-                          check=False)
-            for svc in reversed(services):
-                inst.exec(["systemctl", "--user", "start", f"{name}-{svc}.service"])
+            if quadlet_changed:
+                # One-shot migration: the on-disk quadlet was just rewritten
+                # to point its bind-mount at the new VM-local path, but the
+                # running dnsmasq container is still mounting the old host
+                # (sshfs-cached) path. SIGHUP would re-read the stale cache;
+                # restart the dns sidecar so it picks up the new mount.
+                inst.exec(
+                    ["systemctl", "--user", "restart",
+                     f"{name}-dns.service"],
+                    check=False,
+                )
+            else:
+                inst.exec(
+                    ["podman", "exec", f"{name}-dns",
+                     "pkill", "-HUP", "dnsmasq"],
+                    check=False,
+                )
     elif _is_apple_container(cfg):
         was_running = backend.is_running(name, "cage")
         if was_running:

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -201,6 +201,36 @@ def _make_env() -> SandboxedEnvironment:
     return env
 
 
+def vm_local_config_dir(name: str) -> str:
+    """VM-local path where the cage's proxy + DNS config files live.
+
+    The host's ``~/.config/agentcage/cages/<name>/`` is exposed inside the
+    Lima VM as a reverse-sshfs mount that caches file contents aggressively
+    — so a host-side rewrite of ``proxy-config.yaml`` or
+    ``dns-allowlist.conf`` is invisible to processes running inside the VM
+    until the mount itself is reset. We sidestep that by writing a VM-local
+    copy of those two files into a parallel directory tree
+    (``~/.config/agentcage-vm/...``) that is *not* a Lima mount, and
+    bind-mounting the VM-local copy into the proxy/dns containers.
+
+    Returned as a POSIX-style string (``~/.config/agentcage-vm/cages/<name>``)
+    suitable for use both as a quadlet ``Volume=`` source and as a shell
+    argument inside the VM (``~`` is expanded by the guest's shell, not by
+    Python).
+    """
+    return f"~/.config/agentcage-vm/cages/{name}"
+
+
+def vm_local_dns_allowlist_path(name: str) -> str:
+    """VM-local path of the dnsmasq allowlist file. See ``vm_local_config_dir``."""
+    return f"{vm_local_config_dir(name)}/dns-allowlist.conf"
+
+
+def vm_local_proxy_config_path(name: str) -> str:
+    """VM-local path of the proxy config file. See ``vm_local_config_dir``."""
+    return f"{vm_local_config_dir(name)}/proxy-config.yaml"
+
+
 def render_dns_quadlet(
     config: Config,
     used_octets: set[int] | None = None,
@@ -215,20 +245,29 @@ def render_dns_quadlet(
     from that octet, bypassing the hash-based allocation (and the
     *used_octets* parameter is ignored).  This is the correct path for
     updates to an already-deployed cage whose subnet must not change.
+
+    VM backend: the bind-mount source points at a VM-local path (see
+    ``vm_local_dns_allowlist_path``) rather than the host-side allowlist
+    file, because Lima's reverse-sshfs mount caches host writes past the
+    point where dnsmasq would re-read them.
     """
     env = _make_env()
     name = config.name
     addrs = cage_network_addrs(
         name, used_octets=used_octets, network_octet=network_octet,
     )
-    from agentcage.state import dns_allowlist_path
+    if config.isolation == "vm":
+        allowlist_path = vm_local_dns_allowlist_path(name)
+    else:
+        from agentcage.state import dns_allowlist_path
+        allowlist_path = str(dns_allowlist_path(name))
     return env.get_template("dns.container.j2").render(
         name=name,
         **addrs,
         dns_servers=config.dns_servers,
         log_dns_queries=config.logging.dns_queries,
         dns_allowlist_enabled=(config.domains.mode == "allowlist"),
-        dns_allowlist_host_path=str(dns_allowlist_path(name)),
+        dns_allowlist_host_path=allowlist_path,
     )
 
 
@@ -418,13 +457,24 @@ def generate_quadlets(
     # DNS container — allowlist comes from a sidecar file mounted in
     # (state.dns_allowlist_path). The quadlet only encodes whether allowlist
     # mode is on; the contents change without touching the systemd unit.
-    from agentcage.state import dns_allowlist_path
+    #
+    # VM backend: the bind mount source is a VM-local path, NOT the host
+    # path under ~/.config/agentcage. Lima's reverse-sshfs mount caches
+    # host writes, so a host-side rewrite of dns-allowlist.conf would not
+    # propagate into the dnsmasq container; the VM-local copy is rewritten
+    # by ``_update_dns_quadlet`` via ``inst.exec`` and dnsmasq SIGHUPs to
+    # pick it up.
+    if config.isolation == "vm":
+        dns_allowlist_path_str = vm_local_dns_allowlist_path(deploy_name or name)
+    else:
+        from agentcage.state import dns_allowlist_path
+        dns_allowlist_path_str = str(dns_allowlist_path(deploy_name or name))
     files[f"{name}-dns.container"] = env.get_template("dns.container.j2").render(
         **common,
         dns_servers=config.dns_servers,
         log_dns_queries=config.logging.dns_queries,
         dns_allowlist_enabled=(config.domains.mode == "allowlist"),
-        dns_allowlist_host_path=str(dns_allowlist_path(deploy_name or name)),
+        dns_allowlist_host_path=dns_allowlist_path_str,
     )
 
     # Capture volume — host path for capture JSONL
@@ -457,9 +507,18 @@ def generate_quadlets(
         if _scope == "user":
             creds_scope_flag = "--user "
 
+    # VM backend: rewrite proxy-config.yaml mount source to a VM-local
+    # path for the same reason as dns-allowlist.conf above — Lima's
+    # reverse-sshfs caching would otherwise hide host-side rewrites from
+    # mitmproxy's mtime-poll hot-reload.
+    if config.isolation == "vm":
+        proxy_config_path = vm_local_proxy_config_path(deploy_name or name)
+    else:
+        proxy_config_path = config_host_path
+
     files[f"{name}-proxy.container"] = env.get_template("proxy.container.j2").render(
         **common,
-        config_host_path=config_host_path,
+        config_host_path=proxy_config_path,
         proxy_secrets=proxy_secrets,
         deploy_name=deploy_name,
         creds_secrets=creds_secrets,

--- a/tests/test_dns_live_reload.py
+++ b/tests/test_dns_live_reload.py
@@ -116,21 +116,21 @@ class TestContainerBackendLiveReload:
         mock_state.save_dns_allowlist.assert_called_once_with("demo")
 
 
-class TestVmBackendKeepsLegacyRestart:
-    """On VM (Lima), live-reload via SIGHUP would not actually take effect:
-    Lima's reverse-sshfs mount caches host file contents, so dnsmasq inside
-    the VM would re-read the same stale bytes regardless of signal. The
-    legacy restart-all behavior had the same limitation but is documented
-    and what existing users expect, so we keep it. Regression guard: a
-    domain add on a running VM cage still issues a stop/start cycle of
-    all infra services."""
+class TestVmBackendLiveReload:
+    """On VM (Lima), live-reload works the same way as container backend:
+    SIGHUP dnsmasq, let mtime-poll handle proxy hot-reload, never touch
+    the cage container. The historical Lima reverse-sshfs caching problem
+    is sidestepped by writing the config files to a VM-local path (NOT
+    under the cached ``~/.config/agentcage`` mount) via ``inst.exec``."""
 
+    @patch("agentcage.backends.vm.push_config_files")
     @patch("agentcage.cli.LimaInstance")
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=False)
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
-    def test_vm_restarts_all_services(
+    def test_vm_signals_dnsmasq_via_pkill(
         self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
     ):
         from agentcage.cli import _update_dns_quadlet
         cfg = _mock_cfg("vm")
@@ -139,37 +139,192 @@ class TestVmBackendKeepsLegacyRestart:
         backend.service_names.return_value = ["cage", "proxy", "dns"]
         mock_get_backend.return_value = backend
         inst = mock_lima_cls.return_value
+        inst.is_running.return_value = True
 
         _update_dns_quadlet(cfg)
 
-        # Stops cage, proxy, dns (in that order); starts dns, proxy, cage.
-        argv_list = [c.args[0] for c in inst.exec.call_args_list]
-        stops = [a for a in argv_list if "stop" in a]
-        starts = [a for a in argv_list if "start" in a]
-        assert ["systemctl", "--user", "stop", "demo-cage.service"] in stops
-        assert ["systemctl", "--user", "stop", "demo-proxy.service"] in stops
-        assert ["systemctl", "--user", "stop", "demo-dns.service"] in stops
-        assert ["systemctl", "--user", "start", "demo-dns.service"] in starts
-        assert ["systemctl", "--user", "start", "demo-proxy.service"] in starts
-        assert ["systemctl", "--user", "start", "demo-cage.service"] in starts
+        # Exactly one podman-exec pkill call to the dns sidecar.
+        pkill_calls = [
+            c for c in inst.exec.call_args_list
+            if len(c.args) > 0
+            and isinstance(c.args[0], list)
+            and c.args[0][:2] == ["podman", "exec"]
+            and "pkill" in c.args[0]
+        ]
+        assert len(pkill_calls) == 1
+        assert pkill_calls[0].args[0] == [
+            "podman", "exec", "demo-dns", "pkill", "-HUP", "dnsmasq",
+        ]
 
+    @patch("agentcage.backends.vm.push_config_files")
     @patch("agentcage.cli.LimaInstance")
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=False)
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
-    def test_vm_skips_restart_when_dns_not_running(
+    def test_vm_does_not_stop_or_start_any_unit(
         self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
     ):
+        """Cage interactive sessions inside the VM must survive a domain
+        add — i.e. NO ``systemctl stop/start`` of any cage service."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+        inst.is_running.return_value = True
+
+        _update_dns_quadlet(cfg)
+
+        for call in inst.exec.call_args_list:
+            argv = call.args[0] if call.args else []
+            if not isinstance(argv, list):
+                continue
+            # No systemctl stop / start anywhere in the live-reload path.
+            assert not (argv[:1] == ["systemctl"] and "stop" in argv), (
+                f"unexpected systemctl stop call: {argv}"
+            )
+            assert not (argv[:1] == ["systemctl"] and "start" in argv), (
+                f"unexpected systemctl start call: {argv}"
+            )
+
+    @patch("agentcage.backends.vm.push_config_files")
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=False)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_pushes_files_to_vm_local_path(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
+    ):
+        """Domain edit must write the rewritten host files into the VM-local
+        path the proxy/dns containers actually bind-mount, bypassing the
+        Lima reverse-sshfs cache."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+        inst.is_running.return_value = True
+
+        _update_dns_quadlet(cfg)
+
+        # Allowlist file rewritten host-side AND pushed VM-local.
+        mock_state.save_dns_allowlist.assert_called_once_with("demo")
+        mock_push.assert_called_once_with("demo", inst)
+
+    @patch("agentcage.backends.vm.push_config_files")
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=False)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_skips_signal_when_dns_not_running(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
+    ):
+        """VM running but dns service stopped: still push files (so the
+        next start picks them up) but skip the SIGHUP."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = False  # dns not running
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+        inst.is_running.return_value = True
+
+        _update_dns_quadlet(cfg)
+
+        # File push happened
+        mock_push.assert_called_once_with("demo", inst)
+        # No pkill — dnsmasq isn't running
+        pkill_calls = [
+            c for c in inst.exec.call_args_list
+            if len(c.args) > 0
+            and isinstance(c.args[0], list)
+            and "pkill" in c.args[0]
+        ]
+        assert pkill_calls == []
+
+    @patch("agentcage.backends.vm.push_config_files")
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=False)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_skips_everything_when_vm_not_running(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
+    ):
+        """VM stopped entirely: host file rewrite is enough — ``cage
+        start`` will push and mount on next boot. Don't try to ``inst.exec``
+        into a non-running VM."""
         from agentcage.cli import _update_dns_quadlet
         cfg = _mock_cfg("vm")
         backend = MagicMock()
         backend.is_running.return_value = False
         mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+        inst.is_running.return_value = False
 
         _update_dns_quadlet(cfg)
 
-        mock_lima_cls.assert_not_called()
+        # Allowlist file IS rewritten host-side
         mock_state.save_dns_allowlist.assert_called_once_with("demo")
+        # But no VM operations
+        mock_push.assert_not_called()
+        inst.exec.assert_not_called()
+
+    @patch("agentcage.backends.vm.push_config_files")
+    @patch("agentcage.cli.LimaInstance")
+    @patch("agentcage.cli._ensure_dns_quadlet_current", return_value=True)
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.state")
+    def test_vm_migration_restarts_dns_when_quadlet_rewritten(
+        self, mock_state, mock_get_backend, _mock_ensure, mock_lima_cls,
+        mock_push,
+    ):
+        """One-shot migration: on a pre-upgrade VM cage the on-disk
+        quadlet still bind-mounts the cached host path. After
+        ``_ensure_dns_quadlet_current`` rewrites the unit to the new
+        VM-local shape, the *running* dnsmasq container is still mounting
+        the old path — SIGHUP would re-read the stale cache. Restart the
+        dns sidecar so it picks up the new mount; every subsequent edit
+        on this cage takes the fast SIGHUP path."""
+        from agentcage.cli import _update_dns_quadlet
+        cfg = _mock_cfg("vm")
+        backend = MagicMock()
+        backend.is_running.return_value = True
+        backend.service_names.return_value = ["cage", "proxy", "dns"]
+        mock_get_backend.return_value = backend
+        inst = mock_lima_cls.return_value
+        inst.is_running.return_value = True
+
+        _update_dns_quadlet(cfg)
+
+        # systemctl restart of ONLY the dns service — not proxy, not cage.
+        restart_calls = [
+            c for c in inst.exec.call_args_list
+            if len(c.args) > 0
+            and isinstance(c.args[0], list)
+            and c.args[0][:3] == ["systemctl", "--user", "restart"]
+        ]
+        assert len(restart_calls) == 1
+        assert restart_calls[0].args[0] == [
+            "systemctl", "--user", "restart", "demo-dns.service",
+        ]
+        # And no SIGHUP — the restart supersedes it on the migration
+        # path (the new container picks up the new mount on the way up).
+        pkill_calls = [
+            c for c in inst.exec.call_args_list
+            if len(c.args) > 0
+            and isinstance(c.args[0], list)
+            and "pkill" in c.args[0]
+        ]
+        assert pkill_calls == []
 
 
 class TestAppleContainerBackendStillRebuilds:

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -399,6 +399,88 @@ class TestDnsQuadlet:
         assert "--address=/#/198.51.100.1" not in content
 
 
+class TestVmLocalConfigPaths:
+    """VM backend: proxy + dns quadlets must bind-mount a VM-local copy
+    of proxy-config.yaml and dns-allowlist.conf — NOT the host path
+    under ``~/.config/agentcage`` that Lima's reverse-sshfs caches past
+    the point where dnsmasq SIGHUP / proxy mtime-poll would re-read it."""
+
+    def test_dns_quadlet_uses_vm_local_allowlist_path(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+        content = files["test-dns.container"]
+        # VM-local path is the bind source — NOT the host
+        # ~/.config/agentcage cache path.
+        assert "~/.config/agentcage-vm/cages/test/dns-allowlist.conf" in content
+        assert "~/.config/agentcage/cages/test/dns-allowlist.conf" not in content
+
+    def test_proxy_quadlet_uses_vm_local_config_path(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+        content = files["test-proxy.container"]
+        # The proxy config bind source is VM-local; the host path passed
+        # to generate_quadlets is ignored for the volume mount.
+        assert "~/.config/agentcage-vm/cages/test/proxy-config.yaml:/etc/agentcage/config.yaml" in content
+        assert "/host/c.yaml:/etc/agentcage/config.yaml" not in content
+
+    def test_container_backend_still_uses_host_path(self, tmp_path):
+        """Regression guard: the container backend (no Lima sshfs) must
+        keep mounting the authoritative host paths directly. We only
+        sidestep the cache for VM cages."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+        # Host paths used directly — NOT the agentcage-vm tree.
+        assert "/host/c.yaml:/etc/agentcage/config.yaml" in files["test-proxy.container"]
+        assert "agentcage-vm" not in files["test-proxy.container"]
+        assert "agentcage-vm" not in files["test-dns.container"]
+
+    def test_render_dns_quadlet_vm_uses_vm_local_path(self, tmp_path):
+        """``render_dns_quadlet`` is the entry point used by
+        ``_ensure_dns_quadlet_current`` — it must also produce the
+        VM-local bind source for vm cages so the migration check
+        rewrites pre-upgrade quadlets to the new shape."""
+        from agentcage.quadlets import render_dns_quadlet
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+        """))
+        cfg = load_config(str(p))
+        rendered = render_dns_quadlet(cfg)
+        assert "~/.config/agentcage-vm/cages/test/dns-allowlist.conf" in rendered
+
+
 class TestProxyQuadlet:
     def test_proxy_basics(self, minimal_yaml):
         cfg = load_config(minimal_yaml)

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -648,6 +648,89 @@ class TestDeployCageStartOrder:
             )
 
 
+class TestPushConfigFiles:
+    """``push_config_files`` mirrors proxy-config.yaml + dns-allowlist.conf
+    into a VM-local path the cage quadlets bind-mount (bypassing the Lima
+    reverse-sshfs cache). Called from ``_deploy_cage`` on every start /
+    restart / deploy AND from ``_update_dns_quadlet`` on every domain edit."""
+
+    def test_creates_vm_local_directory(self, tmp_path, monkeypatch):
+        # state._DEPLOYMENTS_DIR is computed at import time from env, so
+        # monkeypatching the env var doesn't move the path — patch the
+        # state.deployment_dir helper directly.
+        d = tmp_path / "cages" / "demo"
+        d.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(
+            "agentcage.state.deployment_dir", lambda _name: d,
+        )
+        monkeypatch.setattr(
+            "agentcage.state.dns_allowlist_path",
+            lambda _name: d / "dns-allowlist.conf",
+        )
+
+        from agentcage.backends.vm import push_config_files
+        inst = MagicMock()
+        push_config_files("demo", inst)
+
+        # First call must `mkdir -p` the VM-local config dir.
+        first = inst.exec.call_args_list[0]
+        assert first.args[0][0:2] == ["bash", "-c"]
+        assert "mkdir -p" in first.args[0][2]
+        assert "~/.config/agentcage-vm/cages/demo" in first.args[0][2]
+
+    def test_pushes_both_files_when_present(self, tmp_path, monkeypatch):
+        d = tmp_path / "cages" / "demo"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "proxy-config.yaml").write_text("domains: {allow: [example.com]}")
+        (d / "dns-allowlist.conf").write_text("server=/example.com/1.1.1.1\n")
+        monkeypatch.setattr(
+            "agentcage.state.deployment_dir", lambda _name: d,
+        )
+        monkeypatch.setattr(
+            "agentcage.state.dns_allowlist_path",
+            lambda _name: d / "dns-allowlist.conf",
+        )
+
+        from agentcage.backends.vm import push_config_files
+        inst = MagicMock()
+        push_config_files("demo", inst)
+
+        # Three calls: mkdir, push proxy-config, push dns-allowlist.
+        scripts = [
+            c.args[0][2] for c in inst.exec.call_args_list
+            if c.args[0][:2] == ["bash", "-c"]
+        ]
+        assert any(
+            "~/.config/agentcage-vm/cages/demo/proxy-config.yaml" in s
+            for s in scripts
+        )
+        assert any(
+            "~/.config/agentcage-vm/cages/demo/dns-allowlist.conf" in s
+            for s in scripts
+        )
+
+    def test_skips_missing_files(self, tmp_path, monkeypatch):
+        """A cage in blocklist mode may have an empty/missing allowlist
+        file; missing file = skip push, never crash."""
+        d = tmp_path / "cages" / "demo"
+        d.mkdir(parents=True, exist_ok=True)
+        # No proxy-config.yaml, no dns-allowlist.conf
+        monkeypatch.setattr(
+            "agentcage.state.deployment_dir", lambda _name: d,
+        )
+        monkeypatch.setattr(
+            "agentcage.state.dns_allowlist_path",
+            lambda _name: d / "dns-allowlist.conf",
+        )
+
+        from agentcage.backends.vm import push_config_files
+        inst = MagicMock()
+        push_config_files("demo", inst)
+
+        # Only the mkdir runs.
+        assert inst.exec.call_count == 1
+
+
 class TestGetBackend:
     def test_returns_vm_backend_for_vm_isolation(self):
         from agentcage.backends import get_backend


### PR DESCRIPTION
## Summary

- Closes the VM half of #187. Container cages got live-reload there; the VM (Lima) path was silently broken because Lima's reverse-sshfs mount of `~/.config/agentcage` caches host writes — a host-side rewrite of `proxy-config.yaml` / `dns-allowlist.conf` was invisible inside the VM regardless of SIGHUP, and the legacy restart-all path had the same root cause (operators worked around it by destroying + recreating the cage).
- The proxy/dns quadlets now bind-mount a VM-local copy of those files at `~/.config/agentcage-vm/cages/<name>/...` (outside any Lima mount). `cage create` / `start` / `restart` / `domain add` / `domain rm` all push the latest host bytes into the VM-local path via `inst.exec` (base64 over the limactl ssh channel — no sshfs in the loop). Then SIGHUP dnsmasq the same way the container backend does; mitmproxy's mtime poll picks up the proxy-config rewrite on the next request.
- Pre-upgrade cages get migrated automatically on the first domain edit: `_ensure_dns_quadlet_current` rewrites the on-disk unit + daemon-reloads, and the running dns sidecar is restarted once so it picks up the new bind mount (every subsequent edit on that cage takes the SIGHUP fast path).

## Why this shape

- VM-local path bypasses the Lima cache. Keeping the host file as the authoritative state preserves `cage backup` / audit tooling — the VM-local copy is just a mount source that the quadlets see freshly on every reload.
- One-shot migration via dns-only `systemctl restart` (not a full cage restart): SIGHUP wouldn't work on a container that's still mounting the cached host path, but restarting just the dns sidecar lets the cage container (and any interactive session inside it) survive. This is the migration cost for one edit per upgraded cage.
- apple-container path is unchanged (allowlist is baked into the wrapper image; needs the larger #120 change).

## Test plan

- [x] `uv run python -m pytest` — 1597 passed (was 1555 before adding new tests; everything green)
- [x] New tests in `tests/test_dns_live_reload.py::TestVmBackendLiveReload` cover: SIGHUP via `inst.exec(["podman","exec",...,"pkill","-HUP","dnsmasq"])`, no `systemctl stop/start` of any cage service, file-push via `push_config_files`, dns-not-running and vm-not-running branches, and the one-shot migration path (`systemctl restart <name>-dns.service` when the quadlet was just rewritten)
- [x] New `tests/test_quadlets.py::TestVmLocalConfigPaths` covers quadlet bind-mount sources (VM-local vs host) for both proxy and dns containers, and that `render_dns_quadlet` produces the new shape for vm cages
- [x] New `tests/test_vm_backend.py::TestPushConfigFiles` covers mkdir + push both files + skip missing files
- [x] Manual quadlet inspection against the real `pi-ctf-vm` cage: `render_dns_quadlet` and `generate_quadlets` both emit `Volume=~/.config/agentcage-vm/cages/pi-ctf-vm/...` (not the host cache path)
- [ ] Live smoke test on a VM cage (deferred — the only VM cage on this host is mid-CTF and shouldn't be touched; PR author to run before landing): capture cage PID, `agentcage domain add <name> live-test.example`, verify the entry shows up via `limactl shell agentcage-<name> -- podman exec <name>-dns cat /etc/dnsmasq-allow.conf`, verify cage PID unchanged, then `domain rm`