### PR TITLE
v0.21.17 fix(vm): resolve $HOME so tilde paths don't reach shlex.quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.17] - 2026-05-27
+
+### Fixed
+
+- `agentcage run --isolation vm` failed with `mkdir: cannot create directory
+  '~': Permission denied` after the v0.21.16 dnsmasq live-reload changes.
+  `push_config_files` wrapped tilde-prefixed paths in `shlex.quote()`, which
+  suppressed shell expansion so `~` reached the guest as a literal directory
+  name. Fix resolves `$HOME` in the guest once and rewrites the paths to
+  absolute form before quoting. New regression test scans every shell argv
+  for unexpanded tildes so the next time this slips in, it gets caught at
+  unit-test time instead of at the user's first VM cage launch.
+
 ## [0.21.16] - 2026-05-26
 
 A torture session against v0.21.15's `agentcage run -i` exposed that the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.21.16"
+version = "0.21.17"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -41,8 +41,16 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
     edit; the cost is two ``inst.exec`` round-trips per file.
     """
     from agentcage import state
-    vm_dir = vm_local_config_dir(name)
-    inst.exec(["bash", "-c", f"mkdir -p {shlex.quote(vm_dir)}"])
+    # vm_local_*() return ``~/...`` paths; the ~ is meant to be expanded
+    # by the guest shell, but ``shlex.quote`` below would suppress that.
+    # Resolve $HOME in the guest once and rewrite to absolute form.
+    home = inst.exec(["bash", "-c", "echo ~"]).stdout.strip()
+
+    def _abs(p: str) -> str:
+        return home + p[1:] if p.startswith("~") else p
+
+    vm_dir = _abs(vm_local_config_dir(name))
+    inst.exec(["mkdir", "-p", vm_dir])
 
     proxy_cfg = state.deployment_dir(name) / "proxy-config.yaml"
     if proxy_cfg.is_file():
@@ -50,7 +58,7 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
         inst.exec([
             "bash", "-c",
             f"echo '{encoded}' | base64 -d > "
-            f"{shlex.quote(vm_local_proxy_config_path(name))}",
+            f"{shlex.quote(_abs(vm_local_proxy_config_path(name)))}",
         ])
 
     dns_allow = state.dns_allowlist_path(name)
@@ -59,7 +67,7 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
         inst.exec([
             "bash", "-c",
             f"echo '{encoded}' | base64 -d > "
-            f"{shlex.quote(vm_local_dns_allowlist_path(name))}",
+            f"{shlex.quote(_abs(vm_local_dns_allowlist_path(name)))}",
         ])
 
 

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -654,6 +654,18 @@ class TestPushConfigFiles:
     reverse-sshfs cache). Called from ``_deploy_cage`` on every start /
     restart / deploy AND from ``_update_dns_quadlet`` on every domain edit."""
 
+    @staticmethod
+    def _mock_inst(home: str = "/home/lima") -> MagicMock:
+        """Build a MagicMock LimaInstance that returns *home* for ``echo ~``.
+
+        ``push_config_files`` resolves ``$HOME`` once in the guest before
+        building any further shell commands; the mock must answer that
+        probe so the later calls receive a real absolute path.
+        """
+        inst = MagicMock()
+        inst.exec.return_value = MagicMock(stdout=f"{home}\n")
+        return inst
+
     def test_creates_vm_local_directory(self, tmp_path, monkeypatch):
         # state._DEPLOYMENTS_DIR is computed at import time from env, so
         # monkeypatching the env var doesn't move the path — patch the
@@ -669,14 +681,17 @@ class TestPushConfigFiles:
         )
 
         from agentcage.backends.vm import push_config_files
-        inst = MagicMock()
+        inst = self._mock_inst(home="/home/lima")
         push_config_files("demo", inst)
 
-        # First call must `mkdir -p` the VM-local config dir.
-        first = inst.exec.call_args_list[0]
-        assert first.args[0][0:2] == ["bash", "-c"]
-        assert "mkdir -p" in first.args[0][2]
-        assert "~/.config/agentcage-vm/cages/demo" in first.args[0][2]
+        calls = inst.exec.call_args_list
+        # First call resolves $HOME in the guest.
+        assert calls[0].args[0] == ["bash", "-c", "echo ~"]
+        # Second call must `mkdir -p` the VM-local config dir as an
+        # absolute path — no `~` left for the shell to expand.
+        assert calls[1].args[0] == [
+            "mkdir", "-p", "/home/lima/.config/agentcage-vm/cages/demo",
+        ]
 
     def test_pushes_both_files_when_present(self, tmp_path, monkeypatch):
         d = tmp_path / "cages" / "demo"
@@ -692,22 +707,50 @@ class TestPushConfigFiles:
         )
 
         from agentcage.backends.vm import push_config_files
-        inst = MagicMock()
+        inst = self._mock_inst(home="/home/lima")
         push_config_files("demo", inst)
 
-        # Three calls: mkdir, push proxy-config, push dns-allowlist.
         scripts = [
             c.args[0][2] for c in inst.exec.call_args_list
             if c.args[0][:2] == ["bash", "-c"]
         ]
         assert any(
-            "~/.config/agentcage-vm/cages/demo/proxy-config.yaml" in s
-            for s in scripts
+            "/home/lima/.config/agentcage-vm/cages/demo/proxy-config.yaml"
+            in s for s in scripts
         )
         assert any(
-            "~/.config/agentcage-vm/cages/demo/dns-allowlist.conf" in s
-            for s in scripts
+            "/home/lima/.config/agentcage-vm/cages/demo/dns-allowlist.conf"
+            in s for s in scripts
         )
+
+    def test_no_unexpanded_tilde_in_shell_args(self, tmp_path, monkeypatch):
+        """Regression: ``vm_local_*`` returns ``~/...`` strings; if they
+        reach ``shlex.quote`` (or any single-quoted shell context) the
+        ``~`` becomes a literal directory name and ``mkdir`` fails with
+        ``cannot create directory '~'``. Assert every shell argument is
+        free of unexpanded tildes."""
+        d = tmp_path / "cages" / "demo"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "proxy-config.yaml").write_text("x")
+        (d / "dns-allowlist.conf").write_text("y")
+        monkeypatch.setattr("agentcage.state.deployment_dir", lambda _n: d)
+        monkeypatch.setattr(
+            "agentcage.state.dns_allowlist_path",
+            lambda _n: d / "dns-allowlist.conf",
+        )
+
+        from agentcage.backends.vm import push_config_files
+        inst = self._mock_inst(home="/home/lima")
+        push_config_files("demo", inst)
+
+        # Skip the first call (``echo ~`` — the one legitimate tilde).
+        for call in inst.exec.call_args_list[1:]:
+            argv = call.args[0]
+            for arg in argv:
+                assert "~" not in arg, (
+                    f"unexpanded ~ leaked into shell argument: {arg!r} "
+                    f"(full argv: {argv!r})"
+                )
 
     def test_skips_missing_files(self, tmp_path, monkeypatch):
         """A cage in blocklist mode may have an empty/missing allowlist
@@ -724,11 +767,11 @@ class TestPushConfigFiles:
         )
 
         from agentcage.backends.vm import push_config_files
-        inst = MagicMock()
+        inst = self._mock_inst(home="/home/lima")
         push_config_files("demo", inst)
 
-        # Only the mkdir runs.
-        assert inst.exec.call_count == 1
+        # Two calls: resolve $HOME, then the mkdir. No file pushes.
+        assert inst.exec.call_count == 2
 
 
 class TestGetBackend:


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced in v0.21.16 (PR #192). `agentcage run --isolation vm` failed at the cage-deploy step with:

```
mkdir: cannot create directory '~': Permission denied
```

`push_config_files` was passing tilde-prefixed paths (`~/.config/agentcage-vm/cages/<name>`) straight into `shlex.quote()`, which wraps them in single quotes and suppresses shell tilde expansion. `~` then reached `mkdir` as a literal directory name.

**Fix:** resolve `$HOME` in the guest once via `bash -c "echo ~"`, rewrite the paths to absolute form, then `shlex.quote()` them. Three call sites updated, one local helper added.

## Test Coverage

All three changed paths in `push_config_files` are covered:

- `test_creates_vm_local_directory` — `$HOME` probe + absolute mkdir
- `test_pushes_both_files_when_present` — both file-push paths
- `test_skips_missing_files` — no-files-to-push path
- `test_no_unexpanded_tilde_in_shell_args` *(new)* — regression test: iterates every shell argv (skipping the legitimate `echo ~` probe) and fails if a literal `~` ever appears

The new regression test catches the original bug. The old `test_creates_vm_local_directory` did not — it asserted `"~/.config/agentcage-vm/cages/demo" in bash_command_str`, which matched both broken (`'~/.config/...'` after `shlex.quote`) and fixed shapes.

## Why E2E Missed This

- Phase 7 (`tests/e2e/phase7_vm.sh`) exercises the live path but is gated on `/dev/kvm` and only runs manually. `.github/workflows/e2e.yml` only runs phase 8 (container/openclaw).
- The unit test used `MagicMock` and substring-matched the bash command, which masked the quoting bug.

The new regression assertion closes both gaps at unit-test time.

## Validation

- Full test suite: **1577 passed**
- End-to-end check against a live Lima VM (the one that failed in the original repro): `push_config_files` writes both `proxy-config.yaml` and `dns-allowlist.conf` to `/home/luca.guest/.config/agentcage-vm/cages/<name>/`, no errors.

## Test plan

- [x] `python -m pytest` — 1577 passed
- [x] `python -m pytest tests/test_vm_backend.py::TestPushConfigFiles -v` — 4 passed
- [x] Live VM check: `push_config_files('reprotest', LimaInstance('ubuntu-wild-mew'))` writes the expected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)