### PR TITLE
v0.21.18 fix(vm): use %h not ~ in quadlet Volume= so podman bind-mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.18] - 2026-05-27
+
+### Fixed
+
+- VM cages still couldn't start after v0.21.17: the proxy + dns quadlets
+  emitted `Volume=~/.config/agentcage-vm/cages/<name>/...` and
+  podman-quadlet doesn't expand `~`. Podman then treated the path as a
+  named-volume reference, which failed the `[a-zA-Z0-9_.-]*` name
+  validator with `creating named volume "~/...": names must match ...:
+  invalid argument`. Switched `vm_local_config_dir()` to the systemd
+  specifier `%h`, which systemd-quadlet expands to the user's home
+  before podman parses the unit. Updated the shell-context substitution
+  in `push_config_files` to swap `%h` for the real `$HOME` (bash does
+  not expand systemd specifiers). New `test_quadlets_do_not_emit_unexpanded_tilde_volume`
+  regression scans every generated quadlet for `Volume=~` so this can't
+  recur.
+- End-to-end validated: `agentcage run ubuntu --isolation vm` builds and
+  starts the cage cleanly, `domain add` / `domain rm` live-reload
+  dnsmasq via SIGHUP without restarting the container, and
+  `getent hosts example.com` from inside the cage resolves through the
+  updated allowlist.
+
 ## [0.21.17] - 2026-05-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.21.17"
+version = "0.21.18"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -41,13 +41,15 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
     edit; the cost is two ``inst.exec`` round-trips per file.
     """
     from agentcage import state
-    # vm_local_*() return ``~/...`` paths; the ~ is meant to be expanded
-    # by the guest shell, but ``shlex.quote`` below would suppress that.
-    # Resolve $HOME in the guest once and rewrite to absolute form.
+    # vm_local_*() return ``%h/...`` paths so podman-quadlet can bind-mount
+    # them (systemd expands ``%h`` to the user's home before podman parses
+    # the unit). Bash does NOT expand systemd specifiers, so for shell-
+    # context use here we must resolve ``$HOME`` in the guest ourselves
+    # and substitute before invocation.
     home = inst.exec(["bash", "-c", "echo ~"]).stdout.strip()
 
     def _abs(p: str) -> str:
-        return home + p[1:] if p.startswith("~") else p
+        return home + p[2:] if p.startswith("%h") else p
 
     vm_dir = _abs(vm_local_config_dir(name))
     inst.exec(["mkdir", "-p", vm_dir])

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -209,16 +209,21 @@ def vm_local_config_dir(name: str) -> str:
     — so a host-side rewrite of ``proxy-config.yaml`` or
     ``dns-allowlist.conf`` is invisible to processes running inside the VM
     until the mount itself is reset. We sidestep that by writing a VM-local
-    copy of those two files into a parallel directory tree
-    (``~/.config/agentcage-vm/...``) that is *not* a Lima mount, and
-    bind-mounting the VM-local copy into the proxy/dns containers.
+    copy of those two files into a parallel directory tree under the user's
+    home that is *not* a Lima mount, and bind-mounting the VM-local copy
+    into the proxy/dns containers.
 
-    Returned as a POSIX-style string (``~/.config/agentcage-vm/cages/<name>``)
-    suitable for use both as a quadlet ``Volume=`` source and as a shell
-    argument inside the VM (``~`` is expanded by the guest's shell, not by
-    Python).
+    Returned with the systemd ``%h`` home-directory specifier instead of
+    ``~``: systemd-quadlet expands ``%h`` to the user's absolute home before
+    podman parses the unit, so ``Volume=%h/...`` works as a bind mount.
+    Using ``~`` would NOT work — podman-quadlet treats unprefixed paths as
+    named volumes, and the resulting "name" fails podman's
+    ``[a-zA-Z0-9_.-]*`` validator. Shell-context callers (e.g. ``mkdir`` /
+    ``base64`` in :func:`agentcage.backends.vm.push_config_files`) must
+    substitute ``%h`` with the actual ``$HOME`` before invocation; bash
+    does not expand systemd specifiers.
     """
-    return f"~/.config/agentcage-vm/cages/{name}"
+    return f"%h/.config/agentcage-vm/cages/{name}"
 
 
 def vm_local_dns_allowlist_path(name: str) -> str:

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -403,7 +403,38 @@ class TestVmLocalConfigPaths:
     """VM backend: proxy + dns quadlets must bind-mount a VM-local copy
     of proxy-config.yaml and dns-allowlist.conf — NOT the host path
     under ``~/.config/agentcage`` that Lima's reverse-sshfs caches past
-    the point where dnsmasq SIGHUP / proxy mtime-poll would re-read it."""
+    the point where dnsmasq SIGHUP / proxy mtime-poll would re-read it.
+
+    The bind source uses the systemd ``%h`` home-directory specifier so
+    podman-quadlet expands it to an absolute path. A bare ``~/...`` would
+    be treated as a named volume by podman and rejected as an invalid
+    name."""
+
+    def test_quadlets_do_not_emit_unexpanded_tilde_volume(self, tmp_path):
+        """Regression: ``Volume=~/...`` reaches podman-quadlet as a
+        named-volume reference, not a bind mount, and fails the
+        ``[a-zA-Z0-9_.-]*`` name validator at service start time. Every
+        quadlet ``Volume=`` source must be either an absolute path,
+        ``%h/...`` (resolved by systemd), or a real named volume."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+        for fname, content in files.items():
+            for line in content.splitlines():
+                if line.startswith("Volume=~"):
+                    raise AssertionError(
+                        f"{fname} emits an unexpanded ~ Volume= source: "
+                        f"{line!r}"
+                    )
 
     def test_dns_quadlet_uses_vm_local_allowlist_path(self, tmp_path):
         p = tmp_path / "config.yaml"
@@ -421,7 +452,7 @@ class TestVmLocalConfigPaths:
         content = files["test-dns.container"]
         # VM-local path is the bind source — NOT the host
         # ~/.config/agentcage cache path.
-        assert "~/.config/agentcage-vm/cages/test/dns-allowlist.conf" in content
+        assert "%h/.config/agentcage-vm/cages/test/dns-allowlist.conf" in content
         assert "~/.config/agentcage/cages/test/dns-allowlist.conf" not in content
 
     def test_proxy_quadlet_uses_vm_local_config_path(self, tmp_path):
@@ -437,7 +468,7 @@ class TestVmLocalConfigPaths:
         content = files["test-proxy.container"]
         # The proxy config bind source is VM-local; the host path passed
         # to generate_quadlets is ignored for the volume mount.
-        assert "~/.config/agentcage-vm/cages/test/proxy-config.yaml:/etc/agentcage/config.yaml" in content
+        assert "%h/.config/agentcage-vm/cages/test/proxy-config.yaml:/etc/agentcage/config.yaml" in content
         assert "/host/c.yaml:/etc/agentcage/config.yaml" not in content
 
     def test_container_backend_still_uses_host_path(self, tmp_path):
@@ -478,7 +509,7 @@ class TestVmLocalConfigPaths:
         """))
         cfg = load_config(str(p))
         rendered = render_dns_quadlet(cfg)
-        assert "~/.config/agentcage-vm/cages/test/dns-allowlist.conf" in rendered
+        assert "%h/.config/agentcage-vm/cages/test/dns-allowlist.conf" in rendered
 
 
 class TestProxyQuadlet:

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -688,7 +688,7 @@ class TestPushConfigFiles:
         # First call resolves $HOME in the guest.
         assert calls[0].args[0] == ["bash", "-c", "echo ~"]
         # Second call must `mkdir -p` the VM-local config dir as an
-        # absolute path — no `~` left for the shell to expand.
+        # absolute path — no `%h` (or `~`) left for the shell.
         assert calls[1].args[0] == [
             "mkdir", "-p", "/home/lima/.config/agentcage-vm/cages/demo",
         ]
@@ -723,12 +723,16 @@ class TestPushConfigFiles:
             in s for s in scripts
         )
 
-    def test_no_unexpanded_tilde_in_shell_args(self, tmp_path, monkeypatch):
-        """Regression: ``vm_local_*`` returns ``~/...`` strings; if they
-        reach ``shlex.quote`` (or any single-quoted shell context) the
-        ``~`` becomes a literal directory name and ``mkdir`` fails with
-        ``cannot create directory '~'``. Assert every shell argument is
-        free of unexpanded tildes."""
+    def test_no_unexpanded_home_marker_in_shell_args(
+        self, tmp_path, monkeypatch,
+    ):
+        """Regression: ``vm_local_*`` paths use ``%h`` (the systemd
+        home-directory specifier) so quadlet ``Volume=`` lines work.
+        Bash does NOT expand ``%h``, and ``shlex.quote`` would suppress
+        ``~`` expansion too — so every shell argument we hand to the
+        guest must already be absolute. Assert no ``%h`` or ``~`` leaks
+        through. Without this, ``mkdir`` (or ``podman volume create``)
+        sees a literal marker and fails."""
         d = tmp_path / "cages" / "demo"
         d.mkdir(parents=True, exist_ok=True)
         (d / "proxy-config.yaml").write_text("x")
@@ -743,10 +747,14 @@ class TestPushConfigFiles:
         inst = self._mock_inst(home="/home/lima")
         push_config_files("demo", inst)
 
-        # Skip the first call (``echo ~`` — the one legitimate tilde).
+        # Skip the first call (``echo ~`` — the legitimate home probe).
         for call in inst.exec.call_args_list[1:]:
             argv = call.args[0]
             for arg in argv:
+                assert "%h" not in arg, (
+                    f"unexpanded %h leaked into shell argument: {arg!r} "
+                    f"(full argv: {argv!r})"
+                )
                 assert "~" not in arg, (
                     f"unexpanded ~ leaked into shell argument: {arg!r} "
                     f"(full argv: {argv!r})"


### PR DESCRIPTION
## Summary

Sibling bug to v0.21.17 (PR #193) — same `~` in `vm_local_config_dir()`, different downstream consumer.

After v0.21.17 cleared the `mkdir '~'` failure, VM cages still couldn't start. The proxy + dns quadlets emitted:

```
Volume=~/.config/agentcage-vm/cages/<name>/dns-allowlist.conf:/etc/dnsmasq-allow.conf:ro,Z
```

podman-quadlet doesn't expand `~`, so podman treated the path as a *named volume* reference, which failed podman's `[a-zA-Z0-9_.-]*` name validator:

```
Error: creating named volume "~/.config/agentcage-vm/cages/<name>/dns-allowlist.conf":
running volume create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
```

`validate-vm-fix-dns.service` then loop-failed, the proxy's `Requires=` dependency was never satisfied, and the cage timed out at the 30s `systemd.wait_proxy` mark.

**Fix:** swap `~` for the systemd specifier `%h`. systemd-quadlet expands `%h` to the user's absolute home *before* podman parses the unit, so `Volume=%h/...` becomes a proper bind mount. Bash doesn't expand systemd specifiers, so `_abs()` in `push_config_files` now substitutes `%h` instead of `~` for the shell-context callers.

## Why two PRs

`vm_local_config_dir()` returned `~/...`. PR #193 fixed the **shell-context** consumers (`mkdir` and the base64-pipe in `push_config_files`). The **quadlet-context** consumers (`Volume=` lines in the generated `.container` units) were a separate failure mode I didn't catch until the live verification surfaced it. Same root, different layer.

## Test Coverage

All three changed paths in `push_config_files` and all quadlet emitters are covered:

- `test_no_unexpanded_home_marker_in_shell_args` *(updated)* — scans every argv after the `echo ~` probe for `%h` AND `~`
- `test_quadlets_do_not_emit_unexpanded_tilde_volume` *(new)* — scans every generated quadlet for `Volume=~`
- `test_dns_quadlet_uses_vm_local_allowlist_path` *(updated)* — asserts `%h/...` shape
- `test_proxy_quadlet_uses_vm_local_config_path` *(updated)* — asserts `%h/...` shape
- `test_render_dns_quadlet_vm_uses_vm_local_path` *(updated)* — asserts `%h/...` in the migration entry point

## Validation (end-to-end, real Lima VM)

```
$ agentcage run ubuntu --isolation vm --name validate-vm-fix3 --time
[timing] deploy.quadlets:        785ms
[timing] deploy.vm_local_config: 159ms
[timing] build.proxy:          18816ms
[timing] build.dns:             4885ms
[timing] build.cage:           11428ms
[timing] systemd.start:         1901ms
[timing] systemd.wait_proxy:      41ms   ← was hanging at 30000ms before
[timing] systemd.start_cage:     687ms
```

Then exercised the live-reload promise of PR #192:

| Action | Result |
|---|---|
| `agentcage domain add validate-vm-fix3 example.com` | `Added 'example.com' to cage 'validate-vm-fix3'. DNS and proxy updated.` |
| `getent hosts example.com` inside cage | `2606:4700:10::6814:179a example.com` (Cloudflare IPs) |
| `agentcage domain rm validate-vm-fix3 example.com` | `Removed 'example.com' from cage 'validate-vm-fix3'. DNS and proxy updated.` |
| Re-add + resolve | Resolves again |
| `systemctl --user show validate-vm-fix3-dns --property=MainPID` | `MainPID=1570` — **same process across all three modifications**, dnsmasq SIGHUP'd, never restarted |

## Test plan

- [x] `python -m pytest` — 1578 passed
- [x] `agentcage run ubuntu --isolation vm` builds and starts cleanly (no `mkdir '~'`, no `named volume "~/..."` errors)
- [x] `agentcage domain add/rm` live-reloads dnsmasq via SIGHUP (MainPID stable)
- [x] Inside-cage DNS resolution returns the right IPs after `domain add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)