### PR TITLE
fix(apple-container): drop NET_ADMIN from cage exec --as-root via setpriv (CTF F2)

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1167,7 +1167,34 @@ class AppleContainerBackend:
             )
         flags = ["-it"] if interactive else []
         spec = "0:0" if as_root else "1000:1000"
-        return [binary, "exec", "-u", spec, *flags, target, *cmd]
+
+        # F2 from the CTF: ``--as-root`` previously gave the operator
+        # CapEff including NET_ADMIN (Apple's runtime reconstructs the
+        # cap set from the container's --cap-add CAP_NET_ADMIN on every
+        # exec). One ``ip route replace default via <apple-gw>`` then
+        # disabled the egress filter entirely. The cage VM is started
+        # with NET_ADMIN because ``cage-init.sh`` stage B needs it for
+        # the default-route bootstrap — but every subsequent exec
+        # session should run WITHOUT NET_ADMIN.
+        #
+        # ``setpriv --bounding-set=-net_admin --inh-caps=-net_admin``
+        # drops NET_ADMIN from the bounding + inheritable sets before
+        # exec'ing the operator's command. CapEff is recomputed from
+        # CapBnd on execve, so the operator's shell starts without
+        # NET_ADMIN — ``ip route replace`` returns EPERM. The rest of
+        # the cap set is preserved (CHOWN/FOWNER/SETUID/SETGID/etc.)
+        # so debug sessions can still apt-install or chown files.
+        # ``setpriv`` is part of util-linux and ships in every distro
+        # we wrap.
+        wrap = []
+        if as_root and service in ("cage", ""):
+            wrap = [
+                "setpriv",
+                "--bounding-set=-net_admin",
+                "--inh-caps=-net_admin",
+                "--",
+            ]
+        return [binary, "exec", "-u", spec, *flags, target, *wrap, *cmd]
 
     def logs_argv(
         self,

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -75,12 +75,29 @@ class TestCageExecAppleContainer:
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_as_root_skips_capsh_wrap(
+    def test_exec_as_root_drops_net_admin_via_setpriv(
         self, mock_state, mock_execvp, mock_binary, _mock_inspect,
     ):
-        """`--as-root` bypasses capsh entirely — operator gets a root
-        shell with the container's full cap set + NoNewPrivs=0.
-        Necessary for `apt-get install` and similar one-off ops."""
+        """``--as-root`` gets a uid-0 shell with NET_ADMIN DROPPED from
+        the bounding set, so ``ip route replace`` returns EPERM and the
+        operator cannot bypass the egress filter. CTF F2 (v0.22.1).
+
+        The cage VM is started with ``--cap-add CAP_NET_ADMIN`` because
+        ``cage-init.sh`` stage B needs it to set the default route via
+        the egress sibling. Apple's runtime reconstructs that cap in
+        CapEff on every ``container exec --user 0``, so before this fix
+        an operator could ``ip route replace default via
+        <apple-gateway>`` and reach the internet without mitmproxy
+        interposition — full egress bypass via the operator-debug door.
+
+        ``setpriv --bounding-set=-net_admin
+        --inh-caps=-net_admin`` runs as uid 0 (no setuid happens),
+        drops NET_ADMIN from the bounding + inheritable sets, then
+        execve's the operator's cmd. execve recomputes CapEff/CapPrm
+        from CapBnd, so the new process starts with NET_ADMIN cleared.
+        Other caps (CHOWN, SETUID, SETGID, etc.) survive — ``apt-get
+        install`` and similar debug ops continue to work.
+        """
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
@@ -90,12 +107,13 @@ class TestCageExecAppleContainer:
         )
 
         argv = mock_execvp.call_args.args[1]
-        # No capsh = full root with the container's caps.
-        assert "capsh" not in argv
-        assert "--no-new-privs" not in argv
-        assert "--drop=all" not in argv
-        # And no `-u 1000` either; image USER (root on wrapper) applies.
-        assert "1000" not in argv
+        # Setpriv wrap drops NET_ADMIN before exec'ing the operator's cmd.
+        assert "setpriv" in argv
+        assert "--bounding-set=-net_admin" in argv
+        assert "--inh-caps=-net_admin" in argv
+        # Still --as-root → uid 0:0 (operator's debug intent).
+        assert "0:0" in argv
+        # The operator's actual cmd still reaches the executable.
         assert "iptables" in argv
 
     @patch("agentcage.backends.apple_container.ac_cli.inspect",


### PR DESCRIPTION
## Summary

Closes the CTF F2 bypass from v0.22.1: operator with ``--as-root`` could ``ip route replace default via <apple-gw>`` and curl the open internet, fully bypassing the egress filter.

The cage VM has ``--cap-add CAP_NET_ADMIN`` because ``cage-init.sh`` stage B needs it for the default-route bootstrap. Apple's runtime reconstructs that cap in CapEff on every ``container exec --user 0``, so the operator's debug shell starts with NET_ADMIN even though the cage workload itself (capsh-dropped) doesn't have it.

Wrap the ``--as-root`` exec in ``setpriv --bounding-set=-net_admin --inh-caps=-net_admin`` — drops NET_ADMIN from the bounding set before exec'ing the operator's cmd. Kernel recomputes CapEff/CapPrm from CapBnd on execve, so the new process starts without NET_ADMIN. Other caps (CHOWN/SETUID/SETGID/etc.) preserved so ``apt-get install`` still works.

## Verification on Mac

```
$ agentcage cage exec ctf --as-root -- grep -E '^Cap' /proc/self/status
CapBnd: 0000000000a80425fb         ← NET_ADMIN (bit 12 = 0x1000) cleared

$ agentcage cage exec ctf --as-root -- ip route replace default via 192.168.65.1
RTNETLINK answers: Operation not permitted
exit=2
```

Before fix: CapBnd = ``0x00000000a80435fb`` (NET_ADMIN set), route replace works, full bypass.

## Test plan

- [x] Unit tests pass (``test_exec_as_root_drops_net_admin_via_setpriv`` updated to assert the setpriv wrap).
- [x] Manual on Mac: route replace returns EPERM, ``apt-get install`` still works (CHOWN/SETUID preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)