### PR TITLE
fix(apple-container): wrap cage exec in setpriv to drop caps + NNP (CTF F3, subsumes F2)

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1166,35 +1166,68 @@ class AppleContainerBackend:
                 "https://github.com/apple/container/releases"
             )
         flags = ["-it"] if interactive else []
-        spec = "0:0" if as_root else "1000:1000"
 
-        # F2 from the CTF: ``--as-root`` previously gave the operator
-        # CapEff including NET_ADMIN (Apple's runtime reconstructs the
-        # cap set from the container's --cap-add CAP_NET_ADMIN on every
-        # exec). One ``ip route replace default via <apple-gw>`` then
-        # disabled the egress filter entirely. The cage VM is started
-        # with NET_ADMIN because ``cage-init.sh`` stage B needs it for
-        # the default-route bootstrap — but every subsequent exec
-        # session should run WITHOUT NET_ADMIN.
+        # F3 from the CTF: every previous ``cage exec`` session arrived
+        # at the cage workload with NoNewPrivs=0 and CapBnd=0xa80435fb
+        # (the container's full --cap-add set, including NET_ADMIN,
+        # SETUID, SETGID, SYS_CHROOT). cage-init.sh stage D capsh-drops
+        # all of that for the WORKLOAD's PID 1, but each ``container
+        # exec`` enters via Apple's runtime as a fresh process whose
+        # caps are derived directly from the container's --cap-add set
+        # — no inheritance from the capsh-dropped PID 1. The result was
+        # that a uid-1000 process inside the cage could exploit any
+        # setuid-root binary in the base image (ubuntu:24.04 ships
+        # /usr/bin/su, /usr/bin/mount, /usr/bin/passwd, etc. as
+        # mode-4755) to regrant CapEff = CapBnd, then F2's
+        # NET_ADMIN-route-bypass chain works without --as-root.
         #
-        # ``setpriv --bounding-set=-net_admin --inh-caps=-net_admin``
-        # drops NET_ADMIN from the bounding + inheritable sets before
-        # exec'ing the operator's command. CapEff is recomputed from
-        # CapBnd on execve, so the operator's shell starts without
-        # NET_ADMIN — ``ip route replace`` returns EPERM. The rest of
-        # the cap set is preserved (CHOWN/FOWNER/SETUID/SETGID/etc.)
-        # so debug sessions can still apt-install or chown files.
-        # ``setpriv`` is part of util-linux and ships in every distro
-        # we wrap.
-        wrap = []
-        if as_root and service in ("cage", ""):
-            wrap = [
-                "setpriv",
-                "--bounding-set=-net_admin",
-                "--inh-caps=-net_admin",
-                "--",
-            ]
-        return [binary, "exec", "-u", spec, *flags, target, *wrap, *cmd]
+        # Wrap the exec via setpriv, running initially as the image's
+        # default USER (root, set in Containerfile.wrapper.j2). setpriv
+        # uses CAP_SETPCAP to clear the bounding + inheritable sets,
+        # sets PR_SET_NO_NEW_PRIVS, then setresuid/setresgid to
+        # 1000:1000. Once uid changes from 0 the kernel zeroes CapEff/
+        # CapPrm, leaving the exec'd cmd with empty caps + NNP=1 —
+        # matching the workload PID 1's posture exactly.
+        #
+        # ``--as-root`` keeps the previous setpriv shape but only drops
+        # NET_ADMIN (so the operator still has CHOWN/SETUID/etc. for
+        # debug ops like apt-get install). The egress service is left
+        # untouched — egress operations may legitimately need NET_ADMIN
+        # for iptables debugging.
+        wrap: list[str] = []
+        if service in ("cage", ""):
+            if as_root:
+                # uid 0:0 + NET_ADMIN-only drop (F2).
+                spec = "0:0"
+                wrap = [
+                    "setpriv",
+                    "--bounding-set=-net_admin",
+                    "--inh-caps=-net_admin",
+                    "--",
+                ]
+            else:
+                # No -u flag — enter as image USER (root), let setpriv
+                # do the uid drop + cap clear in one step. ``--reuid``
+                # and ``--regid`` are numeric so we don't need to look
+                # up the cage user's name (varies: ubuntu / node /
+                # claude / cage).
+                spec = None
+                wrap = [
+                    "setpriv",
+                    "--reuid=1000",
+                    "--regid=1000",
+                    "--clear-groups",
+                    "--no-new-privs",
+                    "--bounding-set=-all",
+                    "--inh-caps=-all",
+                    "--",
+                ]
+        else:
+            spec = "0:0" if as_root else "1000:1000"
+
+        if spec is not None:
+            return [binary, "exec", "-u", spec, *flags, target, *wrap, *cmd]
+        return [binary, "exec", *flags, target, *wrap, *cmd]
 
     def logs_argv(
         self,

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1167,7 +1167,34 @@ class AppleContainerBackend:
             )
         flags = ["-it"] if interactive else []
         spec = "0:0" if as_root else "1000:1000"
-        return [binary, "exec", "-u", spec, *flags, target, *cmd]
+
+        # F2 from the CTF: ``--as-root`` previously gave the operator
+        # CapEff including NET_ADMIN (Apple's runtime reconstructs the
+        # cap set from the container's --cap-add CAP_NET_ADMIN on every
+        # exec). One ``ip route replace default via <apple-gw>`` then
+        # disabled the egress filter entirely. The cage VM is started
+        # with NET_ADMIN because ``cage-init.sh`` stage B needs it for
+        # the default-route bootstrap — but every subsequent exec
+        # session should run WITHOUT NET_ADMIN.
+        #
+        # ``setpriv --bounding-set=-net_admin --inh-caps=-net_admin``
+        # drops NET_ADMIN from the bounding + inheritable sets before
+        # exec'ing the operator's command. CapEff is recomputed from
+        # CapBnd on execve, so the operator's shell starts without
+        # NET_ADMIN — ``ip route replace`` returns EPERM. The rest of
+        # the cap set is preserved (CHOWN/FOWNER/SETUID/SETGID/etc.)
+        # so debug sessions can still apt-install or chown files.
+        # ``setpriv`` is part of util-linux and ships in every distro
+        # we wrap.
+        wrap = []
+        if as_root and service in ("cage", ""):
+            wrap = [
+                "setpriv",
+                "--bounding-set=-net_admin",
+                "--inh-caps=-net_admin",
+                "--",
+            ]
+        return [binary, "exec", "-u", spec, *flags, target, *wrap, *cmd]
 
     def logs_argv(
         self,

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -75,12 +75,29 @@ class TestCageExecAppleContainer:
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_as_root_skips_capsh_wrap(
+    def test_exec_as_root_drops_net_admin_via_setpriv(
         self, mock_state, mock_execvp, mock_binary, _mock_inspect,
     ):
-        """`--as-root` bypasses capsh entirely — operator gets a root
-        shell with the container's full cap set + NoNewPrivs=0.
-        Necessary for `apt-get install` and similar one-off ops."""
+        """``--as-root`` gets a uid-0 shell with NET_ADMIN DROPPED from
+        the bounding set, so ``ip route replace`` returns EPERM and the
+        operator cannot bypass the egress filter. CTF F2 (v0.22.1).
+
+        The cage VM is started with ``--cap-add CAP_NET_ADMIN`` because
+        ``cage-init.sh`` stage B needs it to set the default route via
+        the egress sibling. Apple's runtime reconstructs that cap in
+        CapEff on every ``container exec --user 0``, so before this fix
+        an operator could ``ip route replace default via
+        <apple-gateway>`` and reach the internet without mitmproxy
+        interposition — full egress bypass via the operator-debug door.
+
+        ``setpriv --bounding-set=-net_admin
+        --inh-caps=-net_admin`` runs as uid 0 (no setuid happens),
+        drops NET_ADMIN from the bounding + inheritable sets, then
+        execve's the operator's cmd. execve recomputes CapEff/CapPrm
+        from CapBnd, so the new process starts with NET_ADMIN cleared.
+        Other caps (CHOWN, SETUID, SETGID, etc.) survive — ``apt-get
+        install`` and similar debug ops continue to work.
+        """
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
@@ -90,12 +107,13 @@ class TestCageExecAppleContainer:
         )
 
         argv = mock_execvp.call_args.args[1]
-        # No capsh = full root with the container's caps.
-        assert "capsh" not in argv
-        assert "--no-new-privs" not in argv
-        assert "--drop=all" not in argv
-        # And no `-u 1000` either; image USER (root on wrapper) applies.
-        assert "1000" not in argv
+        # Setpriv wrap drops NET_ADMIN before exec'ing the operator's cmd.
+        assert "setpriv" in argv
+        assert "--bounding-set=-net_admin" in argv
+        assert "--inh-caps=-net_admin" in argv
+        # Still --as-root → uid 0:0 (operator's debug intent).
+        assert "0:0" in argv
+        # The operator's actual cmd still reaches the executable.
         assert "iptables" in argv
 
     @patch("agentcage.backends.apple_container.ac_cli.inspect",

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -44,20 +44,24 @@ class TestCageExecAppleContainer:
     @patch("agentcage.apple_container.cli.container_binary")
     @patch("agentcage.cli.os.execvp")
     @patch("agentcage.cli.state")
-    def test_exec_uses_flat_uid_spec(
+    def test_exec_default_wraps_in_setpriv_with_full_cap_drop(
         self, mock_state, mock_execvp, mock_binary, _mock_inspect,
     ):
-        """PR 3 (2-microVM model): `cage exec` is now a flat
-        ``container exec -u 1000:1000 <cage> <cmd>``. No capsh wrap —
-        the cage VM no longer contains the egress filter, so the
-        legacy setuid-binary-reacquires-caps escape path against
-        iptables doesn't exist anymore (no iptables binary in the
-        slim wrapper). uid 0→1000 in `container exec -u` clears
-        CapEff/CapPrm; CAP_NET_ADMIN remains in CapBnd but uid 1000
-        can't gain it back via setuid-root because the slim wrapper
-        also has no setuid-root binaries that would help (no
-        iptables to flush, no dnsmasq config to rewrite, secrets in
-        a different VM)."""
+        """CTF F3 (v0.22.1): default ``cage exec`` enters via setpriv
+        as the image's USER (root), drops all caps + sets NoNewPrivs,
+        then setresuid/setresgid to 1000:1000 before execve'ing the
+        operator's cmd. Previously this path was a flat ``container
+        exec -u 1000:1000`` which left CapBnd=0xa80435fb intact and
+        NoNewPrivs=0; any setuid-root binary in the base image
+        (ubuntu:24.04 ships /usr/bin/su as 4755) could regrant
+        CapEff = CapBnd and chain to the F2 route-replace bypass
+        without --as-root.
+
+        Wrap shape mirrors cage-init.sh stage D, which is what the
+        WORKLOAD's PID 1 already does — this just closes the gap
+        between PID 1's posture and every subsequent ``container
+        exec`` session.
+        """
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("apple-container")
         mock_binary.return_value = "/usr/local/bin/container"
@@ -66,8 +70,11 @@ class TestCageExecAppleContainer:
 
         mock_execvp.assert_called_once_with(
             "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "-u", "1000:1000",
-             "demo", "ls", "-la"],
+            ["/usr/local/bin/container", "exec", "demo",
+             "setpriv", "--reuid=1000", "--regid=1000",
+             "--clear-groups", "--no-new-privs",
+             "--bounding-set=-all", "--inh-caps=-all", "--",
+             "ls", "-la"],
         )
 
     @patch("agentcage.backends.apple_container.ac_cli.inspect",


### PR DESCRIPTION
## Summary

Closes CTF F2 + F3. The two findings are co-located in ``exec_argv`` so this PR addresses both. **#202 will be auto-closed by this — same code path.**

### F3 (uid 1000 path)

Before: ``container exec -u 1000:1000 <cage> <cmd>``. The cmd arrived with ``NoNewPrivs=0`` and ``CapBnd=0xa80435fb`` (full --cap-add set including NET_ADMIN). A uid-1000 process could exploit any setuid-root binary in the base image (``/usr/bin/su`` is 4755 on ubuntu:24.04) to regrant ``CapEff = CapBnd``, then chain to F2's route bypass without ``--as-root``.

After: wrapped in ``setpriv --reuid=1000 --regid=1000 --clear-groups --no-new-privs --bounding-set=-all --inh-caps=-all -- <cmd>``. Image USER (root) is preserved so setpriv has CAP_SETPCAP to clear the bounding set, then drops to uid 1000 + NNP=1 before execve.

### F2 (--as-root path)

Before: ``container exec -u 0:0`` with full CapEff including NET_ADMIN — operator could ``ip route replace default via <apple-gw>`` and bypass the egress entirely.

After: wrapped in ``setpriv --bounding-set=-net_admin --inh-caps=-net_admin -- <cmd>``. uid stays 0 (operator's debug intent) but NET_ADMIN is cleared from CapBnd, so the next execve produces ``CapEff = 0xa80425fb`` (NET_ADMIN bit 12 stripped). Other caps (CHOWN, FOWNER, SETUID, SETGID, SETPCAP, etc.) survive so ``apt-get install`` and similar debug ops still work.

## Verification (Mac, apple-container 0.12.3)

```
$ agentcage cage exec ctf -- grep -E '^(Uid|Cap|NoNewPrivs)' /proc/self/status
Uid:    1000  1000  1000  1000
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000000000000000   ← F3: empty
NoNewPrivs: 1               ← F3: set

$ agentcage cage exec ctf --as-root -- grep -E '^(Uid|Cap)' /proc/self/status
Uid:    0  0  0  0
CapBnd: 00000000a80425fb   ← F2: NET_ADMIN cleared (was 0xa80435fb)

$ agentcage cage exec ctf --as-root -- ip route replace default via 192.168.65.1
RTNETLINK answers: Operation not permitted
exit=2                      ← F2 bypass closed

$ agentcage cage exec ctf -- ls /tmp        ← legit ops still work
ok
```

## Notes

- ``--reuid=1000``/``--regid=1000`` are numeric so this works across scaffolds that name uid 1000 differently (ubuntu vs node vs claude vs cage).
- ``--service egress`` is untouched: egress debugging may legitimately need NET_ADMIN for iptables inspection.
- Closes #202 (F2-only PR — same code path, this PR has both).

## Test plan

- [x] Unit tests pass (``test_exec_default_wraps_in_setpriv_with_full_cap_drop`` + ``test_exec_as_root_drops_net_admin_via_setpriv``).
- [x] Mac manual: NoNewPrivs=1 + CapBnd=0 on default exec; CapBnd has NET_ADMIN bit cleared on --as-root; ip route replace returns EPERM; legit ops still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)