### PR TITLE
warn(apple-container): flag rw host bind mounts at cage create (CTF F4)

### DIFF
--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -66,6 +66,35 @@ def _is_apple_container(cfg) -> bool:
     return getattr(cfg, "isolation", None) == "apple-container"
 
 
+def _is_rw_host_bind(volume_spec: str) -> bool:
+    """True if *volume_spec* describes an rw host bind mount.
+
+    Distinguishes from RO bind mounts (`:ro` suffix) and from named
+    volumes (no `/` or `~` in the source). Used by the cage create
+    warning for CTF F4 (apple-container identity uid_map).
+
+    >>> _is_rw_host_bind("/Users/m1/proj:/workspace")
+    True
+    >>> _is_rw_host_bind("/Users/m1/proj:/workspace:ro")
+    False
+    >>> _is_rw_host_bind("/Users/m1/proj:/workspace:rw")
+    True
+    >>> _is_rw_host_bind("agentcage-cache:/cache")
+    False
+    """
+    parts = volume_spec.split(":")
+    if len(parts) < 2:
+        return False
+    source = parts[0]
+    # Named volume: no host path. Only `/`-rooted or `~`-rooted strings
+    # are bind mounts; everything else is a podman named volume reference.
+    if not source.startswith(("/", "~")):
+        return False
+    # Mode suffix: anything other than 'ro' (e.g. 'rw', 'Z', or none).
+    mode = parts[-1] if len(parts) >= 3 else ""
+    return "ro" not in mode.split(",")
+
+
 def _exit_apple_container_unsupported(command: str) -> None:
     """Exit cleanly when a subcommand isn't implemented on apple-container.
 
@@ -466,6 +495,34 @@ def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool,
         sys.exit(1)
     for w in warnings:
         click.echo(f"warning: {w}", err=True)
+
+    # CTF F4: apple-container has identity uid_map (0 0 4294967295 — no
+    # user-namespace shift). Any host bind mount mounted RW into the cage
+    # means uid-1000-inside-the-cage maps to uid-1000-on-the-mac-host (the
+    # ``m1`` user), so the cage workload can write to anything readable by
+    # the m1 user via the virtiofs lower layer. RO mounts close the path.
+    # Container/VM backends shift uids via rootless podman's user namespace
+    # so this isn't an issue there.
+    if cfg.isolation == "apple-container" and cfg.container.volumes:
+        rw_host_mounts = [
+            v for v in cfg.container.volumes
+            if _is_rw_host_bind(v)
+        ]
+        if rw_host_mounts:
+            click.echo(
+                "warning: apple-container has identity uid_map; "
+                "rw host bind mounts grant the cage write access to the "
+                "host filesystem at uid 1000. Affected mounts:",
+                err=True,
+            )
+            for v in rw_host_mounts:
+                click.echo(f"  {v}", err=True)
+            click.echo(
+                "  Add ``:ro`` to make these mounts read-only, or run on "
+                "the ``container`` / ``vm`` backend where rootless podman "
+                "user-namespace shift isolates the host uid range.",
+                err=True,
+            )
 
     name = cfg.name
 

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -55,6 +55,70 @@ class TestCageCreate:
         result = _runner().invoke(main, ["cage", "create"])
         assert result.exit_code != 0
 
+    @patch("agentcage.config.platform.machine", return_value="arm64")
+    @patch("agentcage.config.platform.system", return_value="Darwin")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_apple_container_rw_host_bind_warning(
+        self, mock_state, MockPodman, mock_systemd, _ms, _mm, tmp_path,
+    ):
+        """CTF F4: warn when an apple-container cage has rw host bind
+        mounts. Apple's runtime uses identity uid_map so rw mounts
+        grant the cage workload host-uid-1000 write access to anything
+        readable by the macOS user.
+
+        Test still expects cage create to FAIL on a later step (we
+        don't mock the full backend); the assertion is just that the
+        F4 warning is emitted to stderr.
+        """
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: testaa
+            isolation: apple-container
+            container:
+              image: test:latest
+              volumes:
+                - "/Users/op/project:/workspace"
+                - "/Users/op/cache:/cache:ro"
+                - "agentcage-named:/data"
+        """))
+        mock_state.deployment_exists.return_value = False
+
+        result = _runner().invoke(main, ["cage", "create", "-c", str(p)])
+        assert "apple-container has identity uid_map" in result.output
+        # The rw mount is flagged.
+        assert "/Users/op/project:/workspace" in result.output
+        # The :ro mount is NOT flagged.
+        assert "/Users/op/cache" not in result.output
+        # The named volume is NOT flagged.
+        assert "agentcage-named" not in result.output
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_container_backend_no_apple_warning(
+        self, mock_state, MockPodman, mock_systemd, tmp_path,
+    ):
+        """Container backend has user-namespace shift via rootless
+        podman, so rw host bind mounts don't grant identity host-uid
+        access. The F4 warning should NOT fire."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: testbb
+            container:
+              image: test:latest
+              volumes:
+                - "/home/u/project:/workspace"
+        """))
+        mock_state.deployment_exists.return_value = False
+        podman = MockPodman.return_value
+        podman.secret_exists.return_value = True
+
+        result = _runner().invoke(main, ["cage", "create", "-c", str(p)])
+        # No F4 warning on the container backend.
+        assert "apple-container has identity uid_map" not in result.output
+
 
 class TestCageUpdate:
     @patch("agentcage.cli.systemd")


### PR DESCRIPTION
## Summary

Closes CTF F4: apple-container uses Apple's identity uid_map (``0 0 4294967295`` — no user-namespace shift). Any rw host bind mount gives the cage workload host-uid-1000 write access to anything readable by the m1 user via the virtiofs lower layer.

Container/VM backends shift uids via rootless podman's user namespace so they don't have this property.

Emit a one-time warning at cage create when an apple-container cage has rw host bind mounts. Named volumes and ``:ro`` bind mounts are exempted. Doc-only — doesn't block create.

## Verification (Mac)

```
$ agentcage cage create -c /tmp/f4-yaml.yaml
...
warning: apple-container has identity uid_map; rw host bind mounts grant
the cage write access to the host filesystem at uid 1000. Affected
mounts:
  /Users/m1/agentcage:/workspace/src
  Add ``:ro`` to make these mounts read-only, or run on the ``container``
  / ``vm`` backend where rootless podman user-namespace shift isolates
  the host uid range.
```

- ``/Users/m1/ctf-PROMPT.md:/workspace/PROMPT.md:ro`` is NOT flagged (ro mode).
- ``/Users/m1/agentcage:/workspace/src`` IS flagged (no mode → rw default).
- Named volumes (no ``/`` or ``~`` prefix) are also exempted.

## Test plan

- [x] Unit tests for ``_is_rw_host_bind`` helper (mode parsing).
- [x] ``test_apple_container_rw_host_bind_warning`` — warning fires for rw bind, not for ro bind, not for named volume.
- [x] ``test_container_backend_no_apple_warning`` — warning does NOT fire on the container backend (rootless podman shifts uids).
- [x] Mac manual: warning emitted at cage create, cage still starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)