### PR TITLE
v0.22.3 fix(apple-container): inject proxy CA env vars into cage VM (0.22.0 regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3] - 2026-05-28
+
+### Fixed
+
+- **apple-container cage now trusts the egress MITM CA** via env vars,
+  not just the system trust store. The 0.22.0 3→2-service unification
+  (#200) dropped the `SSL_CERT_FILE` + `NODE_EXTRA_CA_CERTS` env vars
+  the old single-VM supervisor.sh used to wire up; the slimmed cage VM
+  was left relying only on cage-init.sh stage C's
+  `update-ca-certificates` dance, which races with workload startup
+  and silently no-ops on non-debian bases. Without these env vars
+  `curl https://api.anthropic.com` inside the cage failed with
+  "unable to get local issuer certificate", and claude-code 2.1.x
+  silently exited 0 from `-p` when its HTTPS call failed — meaning
+  the CTF agent (and every other claude-code workload on
+  apple-container since 0.22.0) was running blind. Wire the two env
+  vars at `container run` time so HTTPS clients trust the proxy CA
+  immediately. Mirrors `cage.container.j2` lines 14-15 on the
+  container backend.
+
 ## [0.22.2] - 2026-05-27
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.2"
+version = "0.22.3"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -819,6 +819,17 @@ class AppleContainerBackend:
             "--network", network_name,
             "--volume", f"{certs_dir}:/certs",
             "-e", f"AGENTCAGE_EGRESS_IP={egress_ip}",
+            # Point HTTPS clients at the proxy CA immediately, without
+            # waiting for cage-init.sh stage C to finish copying it into
+            # /usr/local/share/ca-certificates and running
+            # update-ca-certificates. curl reads SSL_CERT_FILE, Node reads
+            # NODE_EXTRA_CA_CERTS; together they cover the agents we
+            # actually ship (claude-code, codex, the openclaw stack).
+            # Mirrors the container backend's cage.container.j2 (lines
+            # 14–15). Without this, claude-code 2.1.x silently exits 0
+            # from `-p` when its HTTPS call fails verification.
+            "-e", "SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem",
+            "-e", "NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem",
         ]
         # User-defined env from cage.yaml.
         for env_k, env_v in (meta.get("env") or {}).items():

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -859,6 +859,30 @@ def test_start_argv_uses_file_delivery_when_placeholders_known(
     assert oct(secrets_dir.stat().st_mode & 0o777) == "0o700"
 
 
+def test_start_argv_injects_proxy_ca_env_vars(tmp_path, monkeypatch):
+    """Apple-container's cage VM must get SSL_CERT_FILE and NODE_EXTRA_CA_CERTS
+    pointing at /certs/mitmproxy-ca-cert.pem so HTTPS clients trust the
+    egress MITM CA without waiting for cage-init.sh stage C to finish the
+    update-ca-certificates dance. Mirrors cage.container.j2 lines 14-15
+    on the container backend. Regression guard: the 0.22.0 3→2-service
+    unification dropped these env vars and claude-code 2.1.x silently
+    exited 0 from `-p` when its HTTPS calls failed cert verification.
+    """
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x",
+            "cpus": "", "memory": "", "lifecycle": "interactive",
+        },
+    )
+
+    backend.start("demo", quiet=True)
+
+    cage_argv = _cage_run_argv(captured)
+    assert "SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem" in cage_argv
+    assert "NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem" in cage_argv
+
+
 def test_start_secrets_bind_only_to_egress(tmp_path, monkeypatch):
     """Threat-model invariant for PR 3: the secrets bind-mount appears
     on the egress sibling's argv and NEVER on the cage VM's argv. This


### PR DESCRIPTION
## Summary

The 0.22.0 3→2-service unification (#200) silently dropped CA env-var injection into the cage VM. Wire `SSL_CERT_FILE` + `NODE_EXTRA_CA_CERTS` at `container run` time, mirroring `cage.container.j2:14-15` on the container backend.

## Why it matters

Inside an apple-container cage on 0.22.x:
- `curl https://api.anthropic.com` returned `SSL certificate problem: unable to get local issuer certificate`
- `claude-code 2.1.x` with `-p` silently exited 0 when its HTTPS call failed cert verification

That means every claude-code workload on apple-container since 0.22.0 has been running blind to its own auth failures — the CTF re-run on 0.22.2 returned an empty report for exactly this reason.

## What changed

`src/agentcage/backends/apple_container.py:816-836` — two `-e` flags appended to `cage_argv` pointing at `/certs/mitmproxy-ca-cert.pem` (already mounted, already populated by the egress sibling).

## Test plan

- [x] `tests/test_apple_container.py::test_start_argv_injects_proxy_ca_env_vars` — new regression test
- [x] Full suite: `uv run pytest tests/` → 1575 passed
- [x] Live verification on m1 (apple-container backend, 0.22.3 wheel):

```
--- env (cert) ---
NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem
SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem
--- HTTPS verify api.anthropic.com ---  → RC=404 (real upstream, no cert error)
--- HTTPS verify example.com ---        → RC=403 (real upstream, no cert error)
--- node TLS api.anthropic.com ---       → 404   (real upstream, no cert error)
```

## Risk

Very low. Two `-e` flags in the cage VM's `container run` argv; identical pattern is shipped and battle-tested on the container backend (`cage.container.j2:14-15`). No behavior change for the container or vm backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)