### PR TITLE
v0.22.4 fix(apple-container): export HOME/USER/LOGNAME for dropped-priv workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4] - 2026-05-28
+
+### Fixed
+
+- **apple-container cage workload now sees `HOME=/home/<user>`, not
+  `HOME=/root`** (companion fix to 0.22.3). cage-init.sh stage D's
+  capsh-drop and the F3 `cage exec` setpriv wrapper both change uid
+  but leave env vars alone, so the dropped-priv workload inherited
+  root's `HOME=/root` — which is mode 0700 and unreadable to uid
+  1000. claude-code 2.1.x reads/writes `~/.claude/` on startup and,
+  on EACCES there, silently exits 0 from `claude -p` (no error
+  message, no stderr). Same surface hits npm (`~/.npm`),
+  pip (`~/.cache/pip`), and anything else touching XDG_* paths.
+  Stage D now exports `HOME`/`USER`/`LOGNAME` derived from
+  `getent passwd 1000` before exec'ing capsh; the `cage exec`
+  wrapper does the same via a small `sh -c` shim around setpriv.
+
 ## [0.22.3] - 2026-05-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.3"
+version = "0.22.4"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1222,16 +1222,28 @@ class AppleContainerBackend:
                 # and ``--regid`` are numeric so we don't need to look
                 # up the cage user's name (varies: ubuntu / node /
                 # claude / cage).
+                #
+                # setpriv changes uid but does NOT update HOME/USER/
+                # LOGNAME — the exec target inherits root's HOME=/root,
+                # which is 0700 and unreadable to uid 1000. claude-
+                # code 2.1.x reads/writes ~/.claude/ on startup and
+                # silently exits 0 from `claude -p` on EACCES (no error
+                # message, no stderr). Same EACCES surface bites npm
+                # (~/.npm), pip (~/.cache/pip), and any tool that
+                # touches XDG_*. Wrap setpriv in a small sh -c that
+                # reads /etc/passwd for uid 1000 and re-exports HOME/
+                # USER/LOGNAME before exec'ing setpriv. Matches cage-
+                # init.sh stage D's behavior for the workload PID 1.
                 spec = None
                 wrap = [
-                    "setpriv",
-                    "--reuid=1000",
-                    "--regid=1000",
-                    "--clear-groups",
-                    "--no-new-privs",
-                    "--bounding-set=-all",
-                    "--inh-caps=-all",
-                    "--",
+                    "sh", "-c",
+                    'CU=$(getent passwd 1000 | cut -d: -f1) && '
+                    'CH=$(getent passwd 1000 | cut -d: -f6) && '
+                    'exec env HOME="$CH" USER="$CU" LOGNAME="$CU" '
+                    'setpriv --reuid=1000 --regid=1000 --clear-groups '
+                    '--no-new-privs --bounding-set=-all --inh-caps=-all '
+                    '-- "$@"',
+                    "agentcage-exec-wrap",
                 ]
         else:
             spec = "0:0" if as_root else "1000:1000"

--- a/src/agentcage/data/apple-container/cage-init.sh
+++ b/src/agentcage/data/apple-container/cage-init.sh
@@ -105,8 +105,23 @@ fi
 CAGE_USER=$(getent passwd 1000 | cut -d: -f1)
 [ -n "${CAGE_USER}" ] \
   || die "no uid-1000 user in cage image — wrapper Containerfile should have created one" 3
+CAGE_HOME=$(getent passwd 1000 | cut -d: -f6)
+[ -n "${CAGE_HOME}" ] \
+  || die "no home directory for uid 1000 — wrapper Containerfile useradd should have set one" 3
 
 log "stage D: dropping caps, switching to '${CAGE_USER}' (uid 1000), exec'ing cage CMD"
+
+# capsh changes uid/caps but does NOT update env vars. cage-init runs
+# as root with HOME=/root inherited from the entrypoint; without these
+# exports the dropped-priv workload would see HOME=/root, which is
+# 0700 root-owned, so any tool that touches its config dir (claude-
+# code's ~/.claude/, npm's ~/.npm/, pip's ~/.cache/) fails EACCES and
+# in claude-code 2.1.x specifically that means a silent exit-0 from
+# `claude -p`. Set HOME/USER/LOGNAME explicitly; capsh passes env
+# through to the exec target.
+export HOME="${CAGE_HOME}"
+export USER="${CAGE_USER}"
+export LOGNAME="${CAGE_USER}"
 
 # capsh chain (order matters):
 #   --no-new-privs  — prctl(PR_SET_NO_NEW_PRIVS). Sticks across exec.

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -217,6 +217,16 @@ def test_stage_build_context_writes_cage_init(tmp_path):
     assert "AGENTCAGE_EGRESS_IP" in cage_init
     assert "ip route replace default via" in cage_init
     assert "capsh" in cage_init
+    # Stage D must export HOME/USER/LOGNAME for the dropped-uid workload
+    # before exec'ing capsh. capsh switches uid but does NOT update env,
+    # so without these the workload inherits root's HOME=/root and any
+    # tool that touches ~/.config or ~/.cache fails EACCES — claude-code
+    # 2.1.x silently exits 0 from `claude -p` on that path. 0.22.4
+    # regression guard.
+    assert 'export HOME="${CAGE_HOME}"' in cage_init
+    assert 'export USER="${CAGE_USER}"' in cage_init
+    assert 'export LOGNAME="${CAGE_USER}"' in cage_init
+    assert 'CAGE_HOME=$(getent passwd 1000 | cut -d: -f6)' in cage_init
     # Legacy files must NOT be staged.
     assert not (tmp_path / "supervisor.sh").exists()
     assert not (tmp_path / "allowlist_addon.py").exists()

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -68,14 +68,37 @@ class TestCageExecAppleContainer:
 
         _runner().invoke(main, ["cage", "exec", "demo", "--", "ls", "-la"])
 
-        mock_execvp.assert_called_once_with(
-            "/usr/local/bin/container",
-            ["/usr/local/bin/container", "exec", "demo",
-             "setpriv", "--reuid=1000", "--regid=1000",
-             "--clear-groups", "--no-new-privs",
-             "--bounding-set=-all", "--inh-caps=-all", "--",
-             "ls", "-la"],
-        )
+        argv = mock_execvp.call_args.args[1]
+        # Outer shape: `container exec demo sh -c <script> <$0> ls -la`.
+        # The sh -c wrapper exists to re-export HOME/USER/LOGNAME for the
+        # dropped-uid workload (setpriv itself does NOT touch env). See
+        # the `else` branch in apple_container.py exec_argv for why.
+        assert argv[:4] == ["/usr/local/bin/container", "exec", "demo", "sh"]
+        assert argv[4] == "-c"
+        script = argv[5]
+        # $0 placeholder must come after the script; the operator's cmd
+        # tail must come after that and be reachable via "$@" inside
+        # the script.
+        assert argv[6] == "agentcage-exec-wrap"
+        assert argv[-2:] == ["ls", "-la"]
+        # The script reads /etc/passwd for uid 1000 and exports the
+        # right HOME/USER/LOGNAME before exec'ing setpriv. This is the
+        # load-bearing change vs. the pre-0.22.4 flat-setpriv shape that
+        # left HOME=/root for the cage workload and broke claude-code
+        # 2.1.x in `-p` mode (silent exit-0 on EACCES at ~/.claude/).
+        assert "getent passwd 1000" in script
+        assert 'HOME="$CH"' in script
+        assert 'USER="$CU"' in script
+        assert 'LOGNAME="$CU"' in script
+        # All of the F3 setpriv guards are still present in the script,
+        # so the cap-drop posture is unchanged.
+        assert "setpriv" in script
+        assert "--reuid=1000" in script
+        assert "--regid=1000" in script
+        assert "--clear-groups" in script
+        assert "--no-new-privs" in script
+        assert "--bounding-set=-all" in script
+        assert "--inh-caps=-all" in script
 
     @patch("agentcage.backends.apple_container.ac_cli.inspect",
            return_value={"status": "running"})

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.2"
+version = "0.22.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Companion fix to v0.22.3 (#205). The capsh drop in `cage-init.sh` stage D and the F3 setpriv wrapper on `cage exec` both change uid but don't touch env vars. The dropped-priv workload inherited root's `HOME=/root`, mode 0700, unreadable to uid 1000.

## Symptom

claude-code 2.1.x reads/writes `~/.claude/` on startup. On EACCES there, `claude -p` silently exits 0 — no error message, no stderr. The 0.22.3 CTF re-run produced an empty report for exactly this reason. Same surface hits `~/.npm`, `~/.cache/pip`, and anything XDG_*.

## Fix

- `cage-init.sh:106-126` — derive `CAGE_HOME` from `getent passwd 1000` and `export HOME/USER/LOGNAME` before `exec capsh`. capsh passes env through.
- `apple_container.py:1219-1245` — wrap setpriv in a small `sh -c` shim that does the same lookup; setpriv passes env through.

## Verified live on m1 (62.210.193.28)

```
Before (0.22.3): uid=1000 HOME=/root  → ls Permission denied
                                       → claude -p PONG: RC=0, empty
After  (0.22.4): uid=1000 HOME=/home/node USER=node
                                       → ls lists files
                                       → claude -p PONG: RC=1 "Invalid API key"
                                         (real error surfaced — see Caveat)
```

## Caveat: CTF still blocked

The `claude -p` error `Invalid API key · Fix external API key` after this fix lands surfaces a SEPARATE regression — the egress proxy is not substituting the `{{ANTHROPIC_API_KEY}}` placeholder. Filed as a follow-up; this PR does not address it.

## Test plan

- [x] New test `test_exec_default_wraps_in_setpriv_with_full_cap_drop` — asserts sh -c shim shape + getent lookup + HOME/USER/LOGNAME exports + all F3 setpriv guards intact
- [x] New asserts in `test_stage_build_context_emits_cage_init_in_build_dir` — cage-init stage D exports the three env vars
- [x] Full suite: 1575 passed
- [x] Live verification on Mac (apple-container backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)