### PR TITLE
v0.22.5 fix(egress): secret_injector reads from /home/acproxy/secrets/ on apple-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.5] - 2026-05-28
+
+### Fixed
+
+- **Egress secret-injection now works on the apple-container backend.**
+  The mitmproxy `SecretInjector` only read real secret values from
+  `os.environ[<env_name>]`. The container/podman backend wires that
+  via Quadlet `Secret=type=env,target=<KEY>`, but apple-container
+  deliberately doesn't pass cleartext via `-e KEY=VAL` (would leak
+  through `container inspect` and process listings) — instead it
+  bind-mounts the secret values as 0600 files at
+  `/home/acproxy/secrets/<env-name>` on the egress sibling. The
+  injector was unaware of those files, so on apple-container every
+  outbound request sent the literal `{{PLACEHOLDER}}` upstream and got
+  401'd. Add a file-delivery fallback: when env lookup misses, read
+  from `$AGENTCAGE_SECRETS_DIR/<env-name>` (defaults to
+  `/home/acproxy/secrets`). Env still takes precedence so the
+  container backend's behavior is unchanged.
+
 ## [0.22.4] - 2026-05-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.4"
+version = "0.22.5"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 from mitmproxy import http
@@ -18,6 +19,19 @@ from mitmproxy import http
 from inspectors.base import InspectionResult
 
 log = logging.getLogger("agentcage.secret_injector")
+
+# File-delivery fallback for backends that don't inject secrets as env vars.
+# The container/podman backend uses Quadlet `Secret=type=env,target=KEY` so
+# secrets land in os.environ. The apple-container backend can't — apple's
+# `container` CLI has no quadlet-style env-secret primitive and we
+# deliberately don't pass cleartext via `-e KEY=VAL` (would show in
+# `container inspect` and process listings). Instead the backend bind-mounts
+# a 0600 secrets dir into the egress sibling at /home/acproxy/secrets.
+# This module reads from there when env lookup misses. Path is overridable
+# via AGENTCAGE_SECRETS_DIR so tests don't need to write to /home.
+_SECRETS_DIR = Path(
+    os.environ.get("AGENTCAGE_SECRETS_DIR", "/home/acproxy/secrets")
+)
 
 
 @dataclass
@@ -65,6 +79,23 @@ class SecretInjector:
             inject_to = [d.lower() for d in entry.get("inject_to", [])]
 
             real_value = os.environ.get(env_name, "")
+            if not real_value:
+                # Fallback: read from the bind-mounted secrets dir. Used by
+                # the apple-container backend, which stages secrets as 0600
+                # files at /home/acproxy/secrets/<env-name> rather than
+                # injecting them as env vars on the egress process.
+                # Without this fallback the addon silently no-ops and every
+                # outbound request sends the literal {{PLACEHOLDER}}
+                # upstream, getting 401'd.
+                secret_file = _SECRETS_DIR / env_name
+                try:
+                    if secret_file.is_file():
+                        real_value = secret_file.read_text().rstrip("\n")
+                except OSError as e:
+                    log.warning(
+                        "secret_injection: failed reading %s: %s",
+                        secret_file, e,
+                    )
             if not real_value:
                 log.warning(
                     "secret_injection: env var %s not set, skipping rule", env_name

--- a/tests/test_secret_injector.py
+++ b/tests/test_secret_injector.py
@@ -306,6 +306,69 @@ class TestConfigure:
         inj.configure([])
         assert len(inj.rules) == 0
 
+    def test_falls_back_to_file_when_env_missing(self, monkeypatch, tmp_path):
+        """Apple-container backend stages secrets to a bind-mounted file
+        dir rather than injecting them as env vars on the egress (no
+        cleartext on `container inspect` / process listings). The
+        injector must read from that file when the env var is empty,
+        otherwise the addon silently no-ops and every outbound request
+        sends the literal `{{PLACEHOLDER}}` upstream → 401. Regression
+        guard against the 0.22.0 file-delivery refactor (PR #196).
+        """
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        (secrets_dir / "ANTHROPIC_API_KEY").write_text("sk-ant-real-1234\n")
+        monkeypatch.setenv("AGENTCAGE_SECRETS_DIR", str(secrets_dir))
+        # Module reads AGENTCAGE_SECRETS_DIR once at import time, so
+        # reload it to pick up the test override.
+        import importlib, secret_injector
+        importlib.reload(secret_injector)
+        inj = secret_injector.SecretInjector()
+        inj.configure([
+            {"env": "ANTHROPIC_API_KEY",
+             "placeholder": "{{ANTHROPIC_API_KEY}}",
+             "inject_to": ["anthropic.com"]},
+        ])
+        assert len(inj.rules) == 1
+        # Trailing newline must be stripped — file delivery writes with
+        # \n at the end on apple-container, and the on-wire header would
+        # include the \n verbatim otherwise (breaks HTTP framing).
+        assert inj.rules[0].real_value == "sk-ant-real-1234"
+
+    def test_file_fallback_missing_file_still_skips(self, monkeypatch, tmp_path):
+        """Env var missing AND no fallback file → rule is skipped (the
+        original behavior). The fallback only fires when the file exists.
+        """
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        monkeypatch.setenv("AGENTCAGE_SECRETS_DIR", str(tmp_path))
+        import importlib, secret_injector
+        importlib.reload(secret_injector)
+        inj = secret_injector.SecretInjector()
+        inj.configure([
+            {"env": "MISSING_KEY", "placeholder": "{{MISSING_KEY}}"},
+        ])
+        assert len(inj.rules) == 0
+
+    def test_env_takes_precedence_over_file(self, monkeypatch, tmp_path):
+        """When BOTH env and file are present, env wins. This matches the
+        container/podman backend's behavior (Quadlet `Secret=type=env`
+        sets the env var; the file path is the fallback for backends
+        that can't do env-based secret injection)."""
+        monkeypatch.setenv("DUAL_KEY", "from-env")
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+        (secrets_dir / "DUAL_KEY").write_text("from-file\n")
+        monkeypatch.setenv("AGENTCAGE_SECRETS_DIR", str(secrets_dir))
+        import importlib, secret_injector
+        importlib.reload(secret_injector)
+        inj = secret_injector.SecretInjector()
+        inj.configure([
+            {"env": "DUAL_KEY", "placeholder": "{{DUAL_KEY}}"},
+        ])
+        assert len(inj.rules) == 1
+        assert inj.rules[0].real_value == "from-env"
+
 
 # ── Domain matching ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Third and final in-cage regression fix from the apple-container CTF re-run, after #205 (CA env) and #206 (HOME env).

The mitmproxy `SecretInjector.configure()` only read real secret values from `os.environ[<env_name>]`. The container/podman backend wires that via Quadlet `Secret=type=env,target=<KEY>` — but apple-container deliberately doesn't pass cleartext via `-e KEY=VAL` (would leak via `container inspect` and process listings). Instead the backend bind-mounts a 0600 secrets dir at `/home/acproxy/secrets/<env-name>` on the egress sibling. The injector was unaware of those files, so on apple-container every outbound request sent the literal `{{PLACEHOLDER}}` upstream and got 401'd.

## Fix

`src/agentcage/data/proxy/secret_injector.py:67-89` — when `os.environ[env_name]` is empty, read from `$AGENTCAGE_SECRETS_DIR/<env_name>` (defaults to `/home/acproxy/secrets`). Env takes precedence so the container backend's behavior is unchanged. Trailing newline is stripped so file-delivered values don't break HTTP framing when used as a header value.

## Verified live on m1 (62.210.193.28)

```
Before (0.22.4):
  curl -H "x-api-key: {{ANTHROPIC_API_KEY}}" ...   → 401 invalid x-api-key
  claude -p PONG                                    → "Invalid API key" RC=1

After  (0.22.5):
  curl -H "x-api-key: {{ANTHROPIC_API_KEY}}" ...   → real Haiku response, "PONG"
  claude -p PONG                                    → "PONG" RC=0
```

## Test plan

- [x] Three new tests in `test_secret_injector.py`:
  - `test_falls_back_to_file_when_env_missing` — primary path
  - `test_file_fallback_missing_file_still_skips` — no false-positive
  - `test_env_takes_precedence_over_file` — container backend unaffected
- [x] Full suite: 1578 passed
- [x] Live verification on Mac (apple-container backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)