### PR TITLE
v0.22.6 security(apple-container): cage no longer sees the egress CA private key (CTF F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.6] - 2026-05-28
+
+### Security
+
+- **apple-container cage no longer sees the egress's CA private key.**
+  Headline finding from the CTF re-run on 0.22.5 (`F1`): the cage
+  bound `certs_dir` (mitmproxy's full `~/.mitmproxy/` dir) at `/certs`
+  so claude-code could install the public CA cert into its trust
+  store. That dir also holds `mitmproxy-ca.pem` and `mitmproxy-ca.p12`
+  (the CA *private* key + PKCS#12), mode 0600 but identity-mapped to
+  uid 1000 via virtiofs — so a uid-1000 cage workload could read the
+  key and sign a forged cert for any allowlisted host (the CTF
+  generated a `forged-anthropic.crt` that verified cleanly against the
+  cage's trust store). Regression introduced by #205 (the 0.22.3 CA
+  env-var fix). Split the bind: cage now mounts a new
+  `public_certs_dir` containing only `mitmproxy-ca-cert.pem`, populated
+  by `supervisor-egress.sh` Step E (`install -m 0644 "$CA_PATH"
+  /home/acproxy/public-certs/mitmproxy-ca-cert.pem`). The full
+  `~/.mitmproxy/` dir stays egress-only.
+
 ## [0.22.5] - 2026-05-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.5"
+version = "0.22.6"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -147,15 +147,33 @@ class AppleContainerBackend:
         return self._state_dir(name) / "egress-config"
 
     def certs_dir(self, name: str) -> Path:
-        """Per-cage CA-cert exchange dir, bind-mounted into BOTH microVMs.
+        """Per-cage CA-cert dir, bind-mounted ONLY into the egress microVM.
 
-        Egress writes mitmproxy-ca-cert.pem here at startup; cage-init.sh
-        reads it to install into the cage's trust store. Same host path
-        for both --volume flags so the two VMs see byte-identical contents
-        (avoids the apple-container directory-COPY 0-byte bug entirely
-        since there's no COPY involved).
+        This is mitmproxy's full ``~/.mitmproxy/`` working dir on the host
+        — it contains the egress's CA *private* key
+        (``mitmproxy-ca.pem``, ``mitmproxy-ca.p12``) which mitmproxy needs
+        to mint per-host certs for transparent MITM. The private key MUST
+        NEVER be exposed to the cage workload — a uid-1000 process that
+        can read it can mint a trusted certificate for any allowlisted
+        host and bypass the trust-store guard from cage-init.sh stage C.
+
+        Pre-0.22.6: this dir was bind-mounted on the cage at /certs (for
+        the public cert install), which silently exposed the private key
+        too — caught by the CTF re-run on 0.22.5 as the headline finding.
+        The cage now mounts ``public_certs_dir`` instead; the egress is
+        still the only VM that sees the full mitmproxy dir.
         """
         return self._state_dir(name) / "certs"
+
+    def public_certs_dir(self, name: str) -> Path:
+        """Per-cage *public-only* cert dir, bind-mounted into BOTH microVMs.
+
+        Egress's supervisor copies just ``mitmproxy-ca-cert.pem`` here
+        after generation; cage-init.sh stage C reads it to install into
+        the cage's trust store. Private key material stays in
+        ``certs_dir`` which is egress-only.
+        """
+        return self._state_dir(name) / "public-certs"
 
     def secrets_dir(self, name: str) -> Path:
         """Per-cage secrets dir on the host, bind-mounted ONLY into the
@@ -689,6 +707,15 @@ class AppleContainerBackend:
         certs_dir.mkdir(parents=True, exist_ok=True)
         os.chmod(certs_dir, 0o1777)
 
+        # Separate cage-visible cert dir — holds ONLY the public cert.
+        # Egress's supervisor-egress.sh Step E copies
+        # mitmproxy-ca-cert.pem here after generation; the cage mounts
+        # THIS dir at /certs, not the full certs_dir which holds the
+        # private key. See public_certs_dir() docstring for context.
+        public_certs_dir = self.public_certs_dir(name)
+        public_certs_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(public_certs_dir, 0o1777)
+
         egress_cfg_dir = self.egress_config_dir(name)
         if not egress_cfg_dir.is_dir():
             raise RuntimeError(
@@ -755,6 +782,11 @@ class AppleContainerBackend:
             "--network", network_name,
             "--volume", f"{logs_dir}:/var/log/agentcage",
             "--volume", f"{certs_dir}:/home/acproxy/.mitmproxy",
+            # Egress writes the public-only cert here so the cage can
+            # bind-mount JUST this dir, not certs_dir (which holds the
+            # CA private key — see public_certs_dir() docstring + the
+            # CTF F1 finding on 0.22.5).
+            "--volume", f"{public_certs_dir}:/home/acproxy/public-certs",
             "--volume", f"{egress_cfg_dir}/proxy-config.yaml:/etc/agentcage/config.yaml:ro",
             "--volume", f"{egress_cfg_dir}/dnsmasq.conf:/etc/agentcage/dnsmasq.conf:ro",
             "--volume", f"{egress_cfg_dir}/dns-allowlist.conf:/etc/agentcage/dns-allowlist.conf:ro",
@@ -817,7 +849,13 @@ class AppleContainerBackend:
             "run", "-d", "--name", name,
             "--cap-add", "CAP_NET_ADMIN",
             "--network", network_name,
-            "--volume", f"{certs_dir}:/certs",
+            # CTF F1 (0.22.5): pre-0.22.6 this bound certs_dir, which
+            # holds mitmproxy-ca.pem (the CA *private* key). A uid-1000
+            # cage workload could read it and mint a trusted forged
+            # cert for any allowlisted host. Bind public_certs_dir
+            # instead — egress's Step E copies only the public cert
+            # there. The full mitmproxy dir is now egress-only.
+            "--volume", f"{public_certs_dir}:/certs",
             "-e", f"AGENTCAGE_EGRESS_IP={egress_ip}",
             # Point HTTPS clients at the proxy CA immediately, without
             # waiting for cage-init.sh stage C to finish copying it into

--- a/src/agentcage/data/containers/supervisor-egress.sh
+++ b/src/agentcage/data/containers/supervisor-egress.sh
@@ -362,6 +362,20 @@ ss -lnt 2>/dev/null | grep -q ':8443 ' \
   || die "mitmproxy listener never came up on :8443 within 30s" 52
 log "step E: mitmproxy ready (CA at $CA_PATH, listening on :8443)"
 
+# Publish just the public cert to /home/acproxy/public-certs, which the
+# apple-container backend bind-mounts to the cage at /certs. The cage
+# must NOT see the full ~/.mitmproxy/ dir because it also contains
+# mitmproxy-ca.pem (the CA private key) — exposed to uid 1000 in 0.22.0
+# through 0.22.5, caught as F1 by the CTF re-run on 0.22.5.
+# install(1) handles atomic-rename + permissions in one call; -m 0644
+# matches mitmproxy-ca-cert.pem's default mode. The directory is
+# created by the host backend before the egress is started, so this
+# never runs on a missing mount point.
+if [ -d /home/acproxy/public-certs ]; then
+  install -m 0644 "$CA_PATH" /home/acproxy/public-certs/mitmproxy-ca-cert.pem
+  log "step E: published public cert to /home/acproxy/public-certs/"
+fi
+
 #-- Step F. Readiness marker -----------------------------------------------
 # Backends (PR 2) poll for this file to declare the cage ready. Must be
 # the LAST thing the supervisor does before entering the monitor loop —

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -755,6 +755,7 @@ def _setup_start_test(tmp_path, monkeypatch, *, unit_meta):
     (egress_cfg / "dnsmasq.conf").write_text("# stub\n")
     (egress_cfg / "dns-allowlist.conf").write_text("\n")
     certs_dir = tmp_path / "certs"
+    public_certs_dir = tmp_path / "public-certs"
 
     captured: list[list[str]] = []
 
@@ -767,6 +768,9 @@ def _setup_start_test(tmp_path, monkeypatch, *, unit_meta):
     monkeypatch.setattr(backend, "secrets_dir", lambda _n: secrets_dir)
     monkeypatch.setattr(backend, "egress_config_dir", lambda _n: egress_cfg)
     monkeypatch.setattr(backend, "certs_dir", lambda _n: certs_dir)
+    monkeypatch.setattr(
+        backend, "public_certs_dir", lambda _n: public_certs_dir,
+    )
     monkeypatch.setattr(
         ac_cli, "image_inspect", lambda _img: {"config": {}},
     )
@@ -891,6 +895,48 @@ def test_start_argv_injects_proxy_ca_env_vars(tmp_path, monkeypatch):
     cage_argv = _cage_run_argv(captured)
     assert "SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem" in cage_argv
     assert "NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem" in cage_argv
+
+
+def test_start_cage_bind_excludes_ca_private_key(tmp_path, monkeypatch):
+    """CTF F1 (0.22.5): the cage's /certs bind-mount MUST come from
+    ``public_certs_dir``, not ``certs_dir``. ``certs_dir`` is mitmproxy's
+    full ~/.mitmproxy/ — it contains ``mitmproxy-ca.pem`` (the CA
+    *private* key) which a uid-1000 cage workload could read and use to
+    mint a forged trusted cert for any allowlisted host, defeating the
+    egress's trust-store guard. 0.22.6 regression guard.
+    """
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x",
+            "cpus": "", "memory": "", "lifecycle": "interactive",
+        },
+    )
+
+    backend.start("demo", quiet=True)
+
+    cage_argv = _cage_run_argv(captured)
+    egress_argv = _egress_run_argv(captured)
+    certs_dir = str(tmp_path / "certs")
+    public_certs_dir = str(tmp_path / "public-certs")
+
+    # Cage's /certs MUST come from public_certs_dir.
+    assert f"{public_certs_dir}:/certs" in cage_argv
+    # Cage MUST NOT mount certs_dir anywhere (any guest path) — that
+    # would re-introduce the CA-private-key leak. Anchor on the host
+    # path so an empty certs_dir name (unlikely tmp_path collision)
+    # doesn't false-match.
+    for a in cage_argv:
+        assert not (
+            a.startswith(certs_dir + ":") and not a.startswith(public_certs_dir + ":")
+        ), f"cage argv leaks certs_dir mount: {a!r}"
+
+    # Egress still gets the full mitmproxy dir (needs the private key
+    # to mint per-host certs).
+    assert f"{certs_dir}:/home/acproxy/.mitmproxy" in egress_argv
+    # Egress also gets the public-cert dir so supervisor-egress.sh's
+    # Step E can copy the cert there for the cage to pick up.
+    assert f"{public_certs_dir}:/home/acproxy/public-certs" in egress_argv
 
 
 def test_start_secrets_bind_only_to_egress(tmp_path, monkeypatch):

--- a/tests/test_egress_image.py
+++ b/tests/test_egress_image.py
@@ -377,3 +377,43 @@ def test_mitmproxy_uid_and_capbnd(egress_container: str) -> None:
             f"no mitmdump pid had uid=200 + CapBnd=0.\n"
             f"last checked: {last_report}\nall pids: {pids}\nlogs:\n{logs}"
         )
+
+
+def test_supervisor_publishes_public_cert_only():
+    """CTF F1 (0.22.5): supervisor-egress.sh must publish the *public*
+    cert to /home/acproxy/public-certs/ after Step E, so the
+    apple-container backend can mount a dir that DOES NOT contain
+    mitmproxy-ca.pem (the CA private key) on the cage. Static check on
+    the script content — running the cage would be the strongest
+    assertion but the script content is the load-bearing piece.
+    """
+    from pathlib import Path
+    repo_root = Path(__file__).resolve().parent.parent
+    script = (
+        repo_root / "src/agentcage/data/containers/supervisor-egress.sh"
+    ).read_text()
+    # The install line publishes ONLY the public cert. Asserting on
+    # the exact target path keeps a future "let's also copy the .p12"
+    # edit from re-leaking the private key.
+    assert (
+        'install -m 0644 "$CA_PATH" /home/acproxy/public-certs/mitmproxy-ca-cert.pem'
+        in script
+    ), "supervisor-egress.sh missing the public-cert publish step"
+    # Defense-in-depth: no line in the script should copy the CA
+    # private key (.p12 or mitmproxy-ca.pem without the -cert suffix)
+    # to the public-certs dir.
+    for line in script.splitlines():
+        if "/home/acproxy/public-certs" not in line:
+            continue
+        # mitmproxy-ca.pem is the private key; mitmproxy-ca-cert.pem is
+        # the public cert. The former must never appear here without
+        # the latter substring being the actual target.
+        if "mitmproxy-ca.pem" in line and "mitmproxy-ca-cert.pem" not in line:
+            raise AssertionError(
+                f"supervisor-egress.sh copies the CA *private* key "
+                f"into public-certs: {line!r}"
+            )
+        assert "mitmproxy-ca.p12" not in line, (
+            f"supervisor-egress.sh copies CA .p12 into public-certs: "
+            f"{line!r}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.4"
+version = "0.22.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Headline finding from the CTF re-run on 0.22.5 (`F1`). Severity: HIGH (defeats every egress filter for the in-cage workload).

The cage's `/certs` bind mounted `certs_dir` — mitmproxy's full `~/.mitmproxy/` host dir — so claude-code could install the public CA cert into its trust store at `cage-init.sh` stage C. That dir also holds `mitmproxy-ca.pem` and `mitmproxy-ca.p12` (the CA *private* key + PKCS#12), mode 0600 but identity-mapped to uid 1000 via virtiofs. A uid-1000 cage workload could read the private key and mint a forged trusted cert for any allowlisted host. The CTF demonstrated this by generating a `forged-anthropic.crt` that verified cleanly against the cage's system trust store.

The regression was introduced by #205 (the 0.22.3 CA env-var fix), which added `--volume {certs_dir}:/certs` to make the cage's HTTPS clients trust the proxy MITM. The intent was correct; the implementation was too broad — the whole mitmproxy state dir got shared instead of just the public cert.

## Fix

- New `public_certs_dir(name)` returns `<state>/public-certs`
- Egress gets BOTH binds:
  - `certs_dir:/home/acproxy/.mitmproxy` (RW, full mitmproxy dir incl. private key)
  - `public_certs_dir:/home/acproxy/public-certs` (RW, for the public-cert publish)
- Cage now mounts ONLY `public_certs_dir:/certs` — no private key
- `supervisor-egress.sh` Step E (after CA cert is ready) does:
  ```
  install -m 0644 "$CA_PATH" /home/acproxy/public-certs/mitmproxy-ca-cert.pem
  ```

## Verified live on m1 (62.210.193.28)

```
Before (0.22.5): /certs/ contained mitmproxy-ca.pem (0600, owned by node)
                  → cage uid 1000 could read it
After  (0.22.6): /certs/ contains ONLY mitmproxy-ca-cert.pem (0644)
                  curl https://api.anthropic.com → RC=404 (trust store still
                  has the CA via public-cert install)
```

## Test plan

- [x] New `test_start_cage_bind_excludes_ca_private_key` — asserts cage `--volume` is `public_certs_dir:/certs` AND `certs_dir` does NOT appear in cage argv anywhere; egress still gets both binds
- [x] New `test_supervisor_publishes_public_cert_only` — asserts `supervisor-egress.sh` contains the `install -m 0644` to `/home/acproxy/public-certs/` and ONLY copies the public cert (no `.pem` private key, no `.p12`) into that dir
- [x] Full suite: 1580 passed
- [x] Live verification on Mac

## Closes

This is the headline finding (F1) from the 0.22.5 CTF re-run report — findings file pulled to `~/luca/github/agentcage-ctf/findings-apple-0.22.5.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)