### PR TITLE
v0.22.7 fix(config): suppress apple-container scaffold-default parity warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.7] - 2026-05-28
+
+### Changed
+
+- **apple-container scaffold-default warnings are no longer noisy.**
+  Pre-0.22.7 every `agentcage run` on apple-container emitted three
+  warnings about `container.tmpfs`, `container.userns`, and
+  `container.read_only` — all triggered by the scaffold's standard
+  defaults, not by operator intent. Predicates tightened:
+  - `read_only`: warn only when explicitly set to `true` (real
+    conflict — apple-container's rootfs is always RW). The default
+    `false` matches backend behavior; no warning.
+  - `userns`: warn only when set to something other than `"keep-id"`.
+    The scaffold ships `keep-id` for the container backend's rootless-
+    podman UID mapping; on apple-container the supervisor's drop-to-
+    uid-1000 already achieves the same outcome.
+  - `tmpfs`: warn only when the operator has multiple entries or a
+    non-`/tmp` target. A single `/tmp:...` entry is the scaffold
+    default; the cage's `/tmp` lives in the RW rootfs and is
+    functionally writable for the workload.
+  Explicit operator overrides still surface — only the defaulted
+  noise is suppressed.
+
 ## [0.22.6] - 2026-05-28
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.6"
+version = "0.22.7"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -950,6 +950,19 @@ def validate_config(config: Config) -> list[str]:
 
     warnings = []
 
+    def _is_scaffold_default_tmpfs(entries: list[str]) -> bool:
+        """A single entry whose target is /tmp matches the stock scaffold
+        default (``tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]``). On
+        apple-container the cage's /tmp lives in the RW rootfs, so the
+        functional outcome (writable /tmp for the workload) is the same;
+        the noexec/nosuid hardening flags aren't enforced but no scaffold
+        relies on them. Multiple entries OR a non-``/tmp`` target IS
+        operator intent that this backend can't honor — keep warning."""
+        if len(entries) != 1:
+            return False
+        target = entries[0].split(":", 1)[0]
+        return target == "/tmp"
+
     # Apple-container backend: surface config knobs that the backend doesn't
     # respect today (silently dropped pre-this-warning). Tracked as the full
     # parity work in #120. Plain `validate_config` warnings so the user sees
@@ -972,7 +985,20 @@ def validate_config(config: Config) -> list[str]:
             # `_user_volume_argv`.
             ("container.named_volumes", bool(config.container.named_volumes),
              "podman named volumes (no equivalent on apple-container)"),
-            ("container.tmpfs", bool(config.container.tmpfs),
+            # Stock scaffold ships `tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]`
+            # as defense-in-depth for the container backend. On apple-
+            # container the cage's /tmp lives in the RW rootfs — the
+            # workload functionally gets a writable /tmp, and the noexec
+            # /nosuid hardening flags aren't enforced. A single /tmp
+            # entry is the documented scaffold default; treating it as
+            # "compatible enough" silences the noisiest warning on every
+            # default cage. Anything else (multiple entries, non-/tmp
+            # targets like /run, /var/cache) still warns because those
+            # do represent operator intent that this backend can't honor.
+            ("container.tmpfs",
+             bool(config.container.tmpfs) and not _is_scaffold_default_tmpfs(
+                 config.container.tmpfs
+             ),
              "tmpfs mounts (apple-container's rootfs is RW; explicit tmpfs entries "
              "are not wired)"),
             ("container.podman_secrets", bool(config.container.podman_secrets),
@@ -981,7 +1007,15 @@ def validate_config(config: Config) -> list[str]:
             ("container.nested_containers", bool(config.container.nested_containers),
              "nested container runtime (no podman-in-podman shim available in "
              "the Apple microVM)"),
-            ("container.userns", bool(config.container.userns),
+            # Scaffold default `userns: "keep-id"` exists for the container
+            # backend's rootless-podman uid mapping. On apple-container,
+            # the supervisor's drop-to-uid-1000 already achieves the
+            # "workload isn't root" goal, so keep-id is functionally a
+            # no-op rather than a missing feature. Anything else (e.g.
+            # an explicit remap config) is operator intent that doesn't
+            # apply here — keep warning on those.
+            ("container.userns",
+             bool(config.container.userns) and config.container.userns != "keep-id",
              "user namespace remap (the supervisor drops to a fixed uid 1000 — "
              "no remap layer)"),
             ("container.add_capabilities", bool(config.container.add_capabilities),
@@ -992,10 +1026,17 @@ def validate_config(config: Config) -> list[str]:
              list(config.container.drop_capabilities) != ["ALL"],
              "custom drop list — the supervisor unconditionally drops ALL caps; "
              "your selective drop list has no effect"),
-            ("container.read_only", config.container.read_only is False,
-             "writable rootfs — apple-container's rootfs is always RW; "
-             "the False here matches behavior but is silently not enforced "
-             "as a config-driven choice"),
+            # Only warn when the operator EXPLICITLY wants a read-only
+            # rootfs and apple-container can't deliver. The False default
+            # matches the backend's actual behavior — it's not a conflict,
+            # just config-vs-runtime parity. Pre-0.22.7 the predicate was
+            # `is False` which fired on every default cage (the scaffold
+            # ships read_only: false for coding agents that write to the
+            # FS), making this the single noisiest warning on every
+            # `agentcage run`.
+            ("container.read_only", config.container.read_only is True,
+             "read-only rootfs — apple-container's rootfs is always RW, "
+             "so `read_only: true` cannot be enforced"),
             ("container.security_label_disable",
              config.container.security_label_disable is False,
              "SELinux label control — apple-container's microVM has no SELinux"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1779,7 +1779,9 @@ class TestAppleContainerSilentDrops:
         _, warnings = self._validate_under_apple(str(p))
         assert any("container.named_volumes" in w for w in warnings), warnings
 
-    def test_tmpfs_warns(self, tmp_path):
+    def test_tmpfs_non_default_warns(self, tmp_path):
+        """Multi-entry tmpfs or non-/tmp target → operator intent that
+        apple-container can't honor → warn."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -1788,9 +1790,31 @@ class TestAppleContainerSilentDrops:
               image: localhost/test:latest
               tmpfs:
                 - "/tmp:rw,size=64M"
+                - "/run:rw,size=16M"
         """))
         _, warnings = self._validate_under_apple(str(p))
         assert any("container.tmpfs" in w for w in warnings), warnings
+
+    def test_tmpfs_single_tmp_entry_does_not_warn(self, tmp_path):
+        """Scaffold default ``tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]``
+        is the single-most-common cage.yaml shape across built-in scaffolds.
+        On apple-container the cage's /tmp lives in the RW rootfs — the
+        workload still gets a writable /tmp — so the noisiest warning on
+        every default cage was pure cosmetic friction. 0.22.7+ suppresses
+        it when the only tmpfs entry targets /tmp."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: ac-demo
+            isolation: apple-container
+            container:
+              image: localhost/test:latest
+              tmpfs:
+                - "/tmp:rw,noexec,nosuid,size=256M"
+        """))
+        _, warnings = self._validate_under_apple(str(p))
+        assert not any(
+            "container.tmpfs" in w for w in warnings
+        ), warnings
 
     def test_podman_secrets_warns(self, tmp_path):
         p = tmp_path / "config.yaml"
@@ -1817,17 +1841,38 @@ class TestAppleContainerSilentDrops:
         _, warnings = self._validate_under_apple(str(p))
         assert any("container.nested_containers" in w for w in warnings), warnings
 
-    def test_userns_warns(self, tmp_path):
+    def test_userns_custom_warns(self, tmp_path):
+        """Non-``keep-id`` userns is operator intent (explicit remap
+        config) that this backend can't honor → warn."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
             isolation: apple-container
             container:
               image: localhost/test:latest
-              userns: keep-id
+              userns: "auto:uidmapping=0:200000:65536"
         """))
         _, warnings = self._validate_under_apple(str(p))
         assert any("container.userns" in w for w in warnings), warnings
+
+    def test_userns_keep_id_does_not_warn(self, tmp_path):
+        """Scaffold default ``userns: keep-id`` is for container backend's
+        rootless-podman UID mapping. On apple-container the supervisor's
+        drop-to-uid-1000 already achieves the "workload isn't root" goal,
+        so keep-id is functionally compatible — don't warn on the
+        scaffold default. 0.22.7+ suppresses."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: ac-demo
+            isolation: apple-container
+            container:
+              image: localhost/test:latest
+              userns: "keep-id"
+        """))
+        _, warnings = self._validate_under_apple(str(p))
+        assert not any(
+            "container.userns" in w for w in warnings
+        ), warnings
 
     def test_add_capabilities_warns(self, tmp_path):
         p = tmp_path / "config.yaml"
@@ -1871,7 +1916,28 @@ class TestAppleContainerSilentDrops:
             "container.drop_capabilities" in w for w in warnings
         ), warnings
 
-    def test_read_only_false_warns(self, tmp_path):
+    def test_read_only_true_warns(self, tmp_path):
+        """Operator wants a read-only rootfs but apple-container always
+        runs RW → real conflict, warn so the operator knows their config
+        won't be honored."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: ac-demo
+            isolation: apple-container
+            container:
+              image: localhost/test:latest
+              read_only: true
+        """))
+        _, warnings = self._validate_under_apple(str(p))
+        assert any("container.read_only" in w for w in warnings), warnings
+
+    def test_read_only_false_does_not_warn(self, tmp_path):
+        """Pre-0.22.7 the predicate was ``read_only is False``, firing
+        on every default cage (the scaffolds ship ``read_only: false``
+        for coding agents that write to the FS). The False default
+        matches apple-container's actual behavior — no conflict, no
+        need to warn. This was the single loudest warning on every
+        ``agentcage run``."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -1881,7 +1947,9 @@ class TestAppleContainerSilentDrops:
               read_only: false
         """))
         _, warnings = self._validate_under_apple(str(p))
-        assert any("container.read_only" in w for w in warnings), warnings
+        assert not any(
+            "container.read_only" in w for w in warnings
+        ), warnings
 
     def test_security_label_disable_false_warns(self, tmp_path):
         p = tmp_path / "config.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.5"
+version = "0.22.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Pre-0.22.7, every `agentcage run` on apple-container emitted three "silently has no effect" warnings on every default cage — all triggered by the scaffold's standard defaults, not by operator intent. They were technically accurate but cosmetically noisy on every default run.

## What changed

Three predicates in `config.py:963-1014` tightened so they fire only on *real* operator overrides:

| Field | Pre-0.22.7 predicate | New predicate | Why |
|---|---|---|---|
| `container.read_only` | `is False` (fires on default) | `is True` (real conflict) | False matches apple-container's actual behavior — RW rootfs. The scaffold ships `false` for coding agents that write to FS. |
| `container.userns` | `bool(value)` (fires on `keep-id`) | `bool(value) and != "keep-id"` | `keep-id` is the scaffold default for container-backend rootless-podman UID mapping; on apple-container, supervisor's drop-to-uid-1000 already covers "not root". |
| `container.tmpfs` | `bool(entries)` (fires on `/tmp:...`) | non-default targets or multi-entry | Single `/tmp:rw,noexec,nosuid,size=256M` is scaffold default. Cage's /tmp lives in RW rootfs — workload still gets writable /tmp; noexec/nosuid aren't enforced but no scaffold relies on them. |

Explicit operator overrides still surface — only the defaulted noise is suppressed.

## Test plan

- [x] 3 new positive tests (`test_*_does_not_warn`) — assert scaffold-default values don't trigger warnings
- [x] 2 reworked tests — rename + repurpose to cover the "real conflict" branch (`test_read_only_true_warns`, `test_userns_custom_warns`); new `test_tmpfs_non_default_warns` for multi-entry case
- [x] Full suite: 1583 passed (up from 1580)
- [x] Local validate against the claude-code scaffold's cage.yaml.j2 default output produces zero parity warnings

## Out of scope

`container.security_label_disable` follows the same `is False` pattern and has the same nature (no SELinux in apple-container). Not touched in this PR — wasn't called out, and the field is rarely set by scaffolds. Easy follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)