### PR TITLE
v0.22.8 security(apple-container): block cage→host-gateway TCP + non-DNS UDP (CTF F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.8] - 2026-05-28
+
+### Security
+
+- **apple-container cage→host-gateway TCP and non-DNS UDP are now
+  blocked at cage-init.** Headline finding F1 from the CTF re-run on
+  0.22.6: Apple's container runtime puts the macOS host on the cage's
+  vmnet subnet as the `.1` address, and the host's loopback services
+  (sshd on `:22`, Apple Remote Desktop on `:5900`) were reachable
+  directly via that gateway — completely OUTSIDE the egress proxy at
+  `192.168.65.2:8080`, which only handles `:80`/`:443` via the
+  REDIRECT rule. claude demonstrated banner-grabbing OpenSSH 10.2 and
+  RFB 003.889 from inside the cage. Wrapper Containerfile now installs
+  `iptables`; cage-init.sh stage B' (new) derives the host-gateway IP
+  as `<subnet>.1` from the cage's own eth0 address and installs
+  `iptables -A OUTPUT -d <gw> -p tcp -j DROP` plus
+  `-p udp ! --dport 53 -j DROP`. UDP `:53` is kept open as a temporary
+  exception because the cage's `/etc/resolv.conf` still points at the
+  apple gateway in this commit (closed in a follow-up PR for F2).
+
 ## [0.22.7] - 2026-05-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.7"
+version = "0.22.8"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/data/apple-container/Containerfile.wrapper.j2
+++ b/src/agentcage/data/apple-container/Containerfile.wrapper.j2
@@ -50,10 +50,10 @@ USER root
 RUN if command -v apt-get >/dev/null 2>&1; then \
         apt-get update -qq \
         && apt-get install -y --no-install-recommends \
-            iproute2 libcap2-bin iputils-ping ca-certificates \
+            iproute2 libcap2-bin iputils-ping ca-certificates iptables \
         && rm -rf /var/lib/apt/lists/* ; \
     elif command -v apk >/dev/null 2>&1; then \
-        apk add --no-cache iproute2 libcap iputils ca-certificates ; \
+        apk add --no-cache iproute2 libcap iputils ca-certificates iptables ; \
     fi
 
 # Ensure a uid-1000 user exists for the cage workload. Bases like

--- a/src/agentcage/data/apple-container/cage-init.sh
+++ b/src/agentcage/data/apple-container/cage-init.sh
@@ -67,6 +67,39 @@ log "stage B: setting default route via ${AGENTCAGE_EGRESS_IP}"
 ip route replace default via "${AGENTCAGE_EGRESS_IP}" \
   || die "failed to set default route via ${AGENTCAGE_EGRESS_IP} — CAP_NET_ADMIN missing?" 2
 
+#-- Stage B'. Block cage→apple-host-gateway TCP + non-DNS UDP --------------
+# CTF F1 (0.22.6): Apple's container runtime puts the macOS host on the
+# same vmnet subnet as the cage as the .1 address. The host's loopback
+# services (sshd on :22, Apple Remote Desktop on :5900) are reachable
+# from the cage directly via that gateway IP — OUTSIDE the egress proxy
+# (which sees only :80/:443 via the REDIRECT). The cage doesn't have any
+# legitimate reason to talk to the host gateway: HTTPS goes through the
+# egress sibling at AGENTCAGE_EGRESS_IP, and DNS *should* too (F2 — the
+# resolv.conf still points at the apple gateway in this commit, fixed
+# in a separate PR). Until F2 lands we keep UDP :53 open as a temporary
+# exception so name resolution doesn't break; F1 still closes the
+# heaviest abuse channel (TCP :22 / :5900 / arbitrary ports).
+#
+# Derive the apple-vmnet host IP as <subnet>.1 — apple-container always
+# assigns the host the first usable address on the bridge subnet, and
+# our default route via the egress sibling sits at <subnet>.2 (or
+# elsewhere on the same /24). Anchoring on the cage's own eth0 IP makes
+# this robust to apple changing the default subnet allocation in a
+# future runtime release.
+_local_ip=$(ip -o -4 addr show eth0 2>/dev/null \
+  | awk '/inet / {sub(/\/.*/,"",$4); print $4; exit}')
+_apple_host_gw=$(printf '%s\n' "${_local_ip}" \
+  | awk -F. 'NF==4 {print $1"."$2"."$3".1"}')
+if [ -n "${_apple_host_gw}" ] && command -v iptables >/dev/null 2>&1; then
+  log "stage B': blocking cage→host-gateway ${_apple_host_gw} (TCP all; UDP except :53)"
+  iptables -A OUTPUT -d "${_apple_host_gw}" -p tcp -j DROP \
+    || log "warn: iptables TCP DROP rule for ${_apple_host_gw} failed (cage→host SSH/ARD remains reachable)"
+  iptables -A OUTPUT -d "${_apple_host_gw}" -p udp ! --dport 53 -j DROP \
+    || log "warn: iptables UDP-non-53 DROP rule for ${_apple_host_gw} failed"
+else
+  log "warn: cannot derive apple-vmnet gateway IP or iptables missing — F1 mitigation skipped"
+fi
+
 #-- Stage C. Install proxy CA into the cage's trust store -----------------
 # The egress sibling writes mitmproxy-ca-cert.pem into the shared /certs
 # bind-mount on its first startup. Cage and egress mount the same host

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -227,6 +227,16 @@ def test_stage_build_context_writes_cage_init(tmp_path):
     assert 'export USER="${CAGE_USER}"' in cage_init
     assert 'export LOGNAME="${CAGE_USER}"' in cage_init
     assert 'CAGE_HOME=$(getent passwd 1000 | cut -d: -f6)' in cage_init
+    # CTF F1 (0.22.6): stage B' must install iptables rules that DROP
+    # cage→apple-host-gateway TCP and non-DNS UDP. Without this the cage
+    # can reach the macOS host's sshd (:22) and Apple Remote Desktop
+    # (:5900) directly via the vmnet gateway, OUTSIDE the egress proxy.
+    assert "_apple_host_gw=" in cage_init
+    assert 'iptables -A OUTPUT -d "${_apple_host_gw}" -p tcp -j DROP' in cage_init
+    assert (
+        'iptables -A OUTPUT -d "${_apple_host_gw}" -p udp ! --dport 53 -j DROP'
+        in cage_init
+    )
     # Legacy files must NOT be staged.
     assert not (tmp_path / "supervisor.sh").exists()
     assert not (tmp_path / "allowlist_addon.py").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.6"
+version = "0.22.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Headline finding F1 from the [CTF re-run on 0.22.6](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.6.md). HIGH severity (general TCP egress channel that bypasses the egress audit proxy).

Apple's container runtime puts the macOS host on the cage's vmnet subnet as the `.1` address. The host's loopback services were reachable from inside the cage **directly via that gateway IP** — OUTSIDE the egress proxy at `192.168.65.2:8080` which only handles `:80`/`:443` via the REDIRECT rule:

```
$ python3 -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('192.168.65.1',22)); print(s.recv(200))"
b'SSH-2.0-OpenSSH_10.2\r\n'
$ python3 -c "import socket; s=socket.socket(); s.settimeout(2); s.connect(('192.168.65.1',5900)); print(s.recv(200))"
b'RFB 003.889\n'        # Apple Remote Desktop / Screen Sharing protocol
```

Impact: SSH brute-force / fingerprinting surface against the macOS host, Screen Sharing reachable from inside the cage, and a general TCP egress channel that nothing in `cage audit` / `cage har` would surface.

## Fix

- `Containerfile.wrapper.j2:50-57` — wrapper image now installs `iptables` (both apt and apk branches).
- `cage-init.sh` adds stage B' (after Stage B route-replace, before Stage C trust-store install) which derives the host-gateway IP as `<subnet>.1` from the cage's own eth0 address and installs:
  ```
  iptables -A OUTPUT -d <gw> -p tcp -j DROP
  iptables -A OUTPUT -d <gw> -p udp ! --dport 53 -j DROP
  ```
- UDP `:53` is kept open as a temporary exception because the cage's `/etc/resolv.conf` still points at the apple gateway in this commit. The companion F2 PR repoints resolv.conf at the egress sibling; after that lands the F1 rule can be tightened to DROP `:53` too.
- Anchoring on `<subnet>.1` (derived from our own IP) instead of a hard-coded `192.168.65.1` makes the rule robust to apple changing the default subnet allocation in a future runtime release.

## Verified live on m1 (apple-container backend, agentcage 0.22.8)

```
Before (0.22.7):
  cage→.1:22   → b'SSH-2.0-OpenSSH_10.2\r\n'
  cage→.1:5900 → b'RFB 003.889\n'

After  (0.22.8):
  cage→.1:22   → TimeoutError
  cage→.1:5900 → TimeoutError
  cage→.1:53   → DNS bytes: 61      (kept open as temp exception)
  cage→api.anthropic.com → RC=404   (egress proxy still works end-to-end)
```

## Test plan

- [x] New asserts in `test_stage_build_context_emits_cage_init_in_build_dir` — `_apple_host_gw=`, both `iptables -A OUTPUT -d "${_apple_host_gw}"` lines present
- [x] Full suite: 1583 passed
- [x] Live verification on Mac

## Related

- Part 1 of 3 from the [0.22.6 CTF findings](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.6.md): **F1 (this PR)**, F2 (DNS-tunnel exfil — follow-up PR), F3 (SNI/Host mismatch — follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)