### PR TITLE
security(container,vm): cage no longer mounts the CA private key (CTF F6/F9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **container + vm backends: cage no longer mounts the egress CA private
+  key.** Previously the cage's `/certs:ro` bind exposed the whole
+  `agentcage-certs-<name>` podman volume — including mitmproxy's
+  `mitmproxy-ca.pem` (cert + private key) and the `.p12` bundles. Today
+  the file mode (0600) + uid mismatch (199 vs 1000) blocked reads, but
+  any future uid-map regression, mount-mode flip, or container escape
+  would have promoted "escape this cage" into "mint trusted certs for
+  every allowlisted host." CTF re-run on 0.22.7 flagged this as F6
+  (container) and F9 (vm); both reports recommended the apple-container
+  split done in #208.
+
+  Split the volume mirroring the apple-container fix:
+  - New `<name>-public-certs.volume` quadlet (`agentcage-public-certs-<name>`
+    podman volume) holds the published public cert only.
+  - Egress mounts BOTH: `agentcage-certs-<name>` at `/home/acproxy/.mitmproxy`
+    (RW, for mitmproxy's own use including the private key) AND
+    `agentcage-public-certs-<name>` at `/home/acproxy/public-certs` (RW,
+    target of `supervisor-egress.sh` Step E's `install -m 0644 ...
+    mitmproxy-ca-cert.pem`).
+  - Cage now mounts ONLY `agentcage-public-certs-<name>` at `/certs:ro` —
+    no path to the private key, regardless of uid mapping or file mode.
+
+  Lifecycle wiring (`backends/container.py`, `backends/vm.py`) updated to
+  start, restart, enumerate, and tear down the new volume alongside the
+  existing one. `_QUADLET_FILES` includes the new suffix so `cage destroy`
+  cleans it up.
+
 ## [0.22.9] - 2026-05-28
 
 ### Security

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -22,7 +22,7 @@ def _cage_from_units(units: dict[str, str]) -> str | None:
     for fname in units:
         for suffix in ("-cage.container", "-egress.container",
                        "-proxy.container", "-dns.container",
-                       "-net.network", "-certs.volume"):
+                       "-net.network", "-public-certs.volume", "-certs.volume"):
             if fname.endswith(suffix):
                 return fname[: -len(suffix)]
     return None
@@ -122,6 +122,11 @@ class ContainerBackend:
             except Exception as e:
                 if not quiet:
                     click.echo(f"warning: failed to restart volume service: {e}", err=True)
+            try:
+                systemd.restart_unit(f"{name}-public-certs-volume.service")
+            except Exception as e:
+                if not quiet:
+                    click.echo(f"warning: failed to restart public-certs volume service: {e}", err=True)
             if (self.unit_dir() / f"{name}-podman-storage.volume").exists():
                 try:
                     systemd.restart_unit(f"{name}-podman-storage-volume.service")
@@ -158,6 +163,7 @@ class ContainerBackend:
         "-egress.container",
         "-net.network",
         "-certs.volume",
+        "-public-certs.volume",
         "-podman-storage.volume",
         # legacy v0.21 layout — kept for `cage destroy` cleanup only
         "-proxy.container",
@@ -183,6 +189,8 @@ class ContainerBackend:
             removed.append(f"network:{name}-net")
         if self._podman.volume_remove(f"agentcage-certs-{name}"):
             removed.append(f"volume:agentcage-certs-{name}")
+        if self._podman.volume_remove(f"agentcage-public-certs-{name}"):
+            removed.append(f"volume:agentcage-public-certs-{name}")
         if self._podman.volume_remove(f"agentcage-podman-{name}"):
             removed.append(f"volume:agentcage-podman-{name}")
 

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -417,6 +417,7 @@ class VmBackend:
         infra_services = [
             f"{name}-net-network",
             f"{name}-certs-volume",
+            f"{name}-public-certs-volume",
             f"{name}-egress",
         ]
 

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -422,9 +422,25 @@ def generate_quadlets(
     # Network
     files[f"{name}-net.network"] = env.get_template("network.j2").render(**common)
 
-    # Volume
+    # Volumes
+    #
+    # Two cert volumes, not one:
+    #   * agentcage-certs-<name>        — mitmproxy state dir (private key,
+    #     .p12 bundles, public cert). Mounted RW into the egress only.
+    #   * agentcage-public-certs-<name> — published public cert only.
+    #     Mounted RW into the egress (so supervisor-egress.sh Step E can
+    #     install the cert there) and RO into the cage at /certs.
+    #
+    # The cage MUST NOT see the private-key volume. CTF findings F6 (container)
+    # and F9 (vm) on agentcage 0.22.0 flagged the prior single-volume layout
+    # as a defense-in-depth violation: a uid/perm regression would let the
+    # cage mint trusted certs for any allowlisted host. Mirrors the apple-
+    # container split done in #208 (a1dcb4a).
     files[f"{name}-certs.volume"] = env.get_template("volume.j2").render(
         volume_name=f"agentcage-certs-{name}",
+    )
+    files[f"{name}-public-certs.volume"] = env.get_template("volume.j2").render(
+        volume_name=f"agentcage-public-certs-{name}",
     )
 
     # DNS allowlist sidecar file path — bind-mounted into the egress

--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -14,7 +14,7 @@ Environment="https_proxy=http://{{ ip_egress }}:8080"
 Environment="NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem"
 Environment="SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem"
 Environment="AGENTCAGE_VERSION={{ agentcage_version }}"
-Volume={{ name }}-certs.volume:/certs:ro,Z
+Volume={{ name }}-public-certs.volume:/certs:ro,Z
 {# NOTE: do NOT reintroduce a broad `Volume={{ patches_host_dir }}:/agentcage`
    bind here. That mount used to expose every sibling cage's resolv-<name>.conf
    inside this cage (cage name + DNS sidecar IP — any cage could `ls /agentcage/`

--- a/src/agentcage/templates/egress.container.j2
+++ b/src/agentcage/templates/egress.container.j2
@@ -15,6 +15,11 @@ Volume={{ dns_allowlist_host_path }}:/etc/agentcage/dns-allowlist.conf:ro,Z
 {% endif %}
 Environment="PYTHONUNBUFFERED=1"
 Volume={{ name }}-certs.volume:/home/acproxy/.mitmproxy:Z
+# Public-only cert publish dir — see quadlets.py for why this is a
+# separate volume. supervisor-egress.sh Step E installs the public
+# CA cert here after mitmproxy generates it; the cage's /certs:ro
+# bind reads from this volume (NOT the private-key volume above).
+Volume={{ name }}-public-certs.volume:/home/acproxy/public-certs:Z
 {% if capture_enabled %}
 Volume={{ capture_host_dir }}:/var/log/agentcage/capture:Z
 Environment="AGENTCAGE_CAPTURE=/var/log/agentcage/capture/capture.jsonl"
@@ -115,6 +120,7 @@ Secret={{ secret }},type=env
 ExecStartPre=/bin/bash -o pipefail -c 'podman secret rm "{{ deploy_name }}.{{ cred }}" 2>/dev/null || true; systemd-creds {{ creds_scope_flag }}decrypt --name "{{ cred }}" "{{ creds_dir }}/{{ cred }}.cred" - | podman secret create "{{ deploy_name }}.{{ cred }}" -'
 {% endfor %}
 ExecStartPre=/bin/bash -c 'mp=$(podman volume inspect agentcage-certs-{{ name }} --format "{{"{{"}}.Mountpoint{{"}}"}}") && {% if rootless %}podman unshare chown{% else %}chown{% endif %} 200:200 "$mp"'
+ExecStartPre=/bin/bash -c 'mp=$(podman volume inspect agentcage-public-certs-{{ name }} --format "{{"{{"}}.Mountpoint{{"}}"}}") && {% if rootless %}podman unshare chown{% else %}chown{% endif %} 200:200 "$mp"'
 {% if capture_enabled %}
 ExecStartPre=/bin/bash -c '{% if rootless %}podman unshare chown 200:200 "{{ capture_host_dir }}" 2>/dev/null || chmod 1777 "{{ capture_host_dir }}"{% else %}chown 200:200 "{{ capture_host_dir }}"{% endif %}'
 {% endif %}

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -151,6 +151,7 @@ class TestStart:
 
         mock_sd.restart_unit.assert_any_call("myapp-net-network.service")
         mock_sd.restart_unit.assert_any_call("myapp-certs-volume.service")
+        mock_sd.restart_unit.assert_any_call("myapp-public-certs-volume.service")
 
 
 class TestStop:
@@ -261,6 +262,11 @@ class TestDestroyResources:
         mock_net.assert_called_once_with("myapp-net")
         assert "network:myapp-net" in removed
         assert "volume:agentcage-certs-myapp" in removed
+        # The public-certs volume is a separate podman volume — leaving it
+        # behind across destroy would leave stale published certs that the
+        # next cage with the same name would silently inherit.
+        assert "volume:agentcage-public-certs-myapp" in removed
+        mock_vol.assert_any_call("agentcage-public-certs-myapp")
 
     def test_removes_secrets_by_default(self, tmp_path):
         backend = ContainerBackend()

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -97,13 +97,13 @@ class TestNestedQuadletGeneration:
         content = files["test-podman-storage.volume"]
         assert "VolumeName=agentcage-podman-test" in content
 
-    def test_five_files_generated_with_nested(self, nested_yaml):
+    def test_six_files_generated_with_nested(self, nested_yaml):
         cfg = load_config(nested_yaml)
         files = generate_quadlets(cfg, "/c.yaml", "/patches")
-        # v0.22: net + certs + cage + egress + podman-storage = 5
-        # (was 6 with the legacy proxy + dns pair, now collapsed to
-        # a single egress quadlet).
-        assert len(files) == 5
+        # net + certs + public-certs + cage + egress + podman-storage = 6
+        # (public-certs split off from certs in the CTF F6/F9 fix so the
+        # cage no longer mounts the volume that holds the CA private key).
+        assert len(files) == 6
 
     def test_capabilities_overridden(self, nested_yaml):
         cfg = load_config(nested_yaml)
@@ -165,12 +165,12 @@ class TestNestedQuadletGeneration:
 
 
 class TestNestedDisabledDefault:
-    def test_four_files_when_disabled(self, minimal_yaml):
+    def test_five_files_when_disabled(self, minimal_yaml):
         cfg = load_config(minimal_yaml)
         files = generate_quadlets(cfg, "/c.yaml", "/patches")
-        # v0.22: net + certs + cage + egress = 4 (was 5; proxy + dns
-        # merged into the single egress quadlet).
-        assert len(files) == 4
+        # net + certs + public-certs + cage + egress = 5
+        # (public-certs split off from certs in the CTF F6/F9 fix).
+        assert len(files) == 5
         assert "test-podman-storage.volume" not in files
 
     def test_no_fuse_device_when_disabled(self, minimal_yaml):

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -10,12 +10,14 @@ from agentcage.quadlets import generate_quadlets, _systemd_exec_join, cage_netwo
 
 
 class TestQuadletFileNames:
-    def test_generates_four_files(self, minimal_yaml):
+    def test_generates_five_files(self, minimal_yaml):
         cfg = load_config(minimal_yaml)
         files = generate_quadlets(cfg, "/path/to/config.yaml", "/path/to/patches")
-        # v0.22 2-service shape: net.network + certs.volume + cage + egress
-        # (was 5 files in the legacy 3-service shape; proxy + dns merged).
-        assert len(files) == 4
+        # v0.22 shape: net.network + certs.volume (private, egress-only) +
+        # public-certs.volume (cage-visible) + cage + egress. The split
+        # between certs.volume and public-certs.volume closes CTF F6/F9 —
+        # the cage MUST NOT see mitmproxy's private key.
+        assert len(files) == 5
 
     def test_file_names(self, minimal_yaml):
         cfg = load_config(minimal_yaml)
@@ -23,6 +25,7 @@ class TestQuadletFileNames:
         assert set(files.keys()) == {
             "test-net.network",
             "test-certs.volume",
+            "test-public-certs.volume",
             "test-egress.container",
             "test-cage.container",
         }
@@ -45,6 +48,15 @@ class TestVolumeQuadlet:
         files = generate_quadlets(cfg, "/c.yaml", "/patches")
         content = files["test-certs.volume"]
         assert "VolumeName=agentcage-certs-test" in content
+
+    def test_public_certs_volume_content(self, minimal_yaml):
+        """Public-cert-only volume that the cage mounts at /certs:ro.
+        Lives separately from agentcage-certs-<name> so the cage cannot
+        see mitmproxy's private key + .p12 bundles (CTF F6 + F9)."""
+        cfg = load_config(minimal_yaml)
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-public-certs.volume"]
+        assert "VolumeName=agentcage-public-certs-test" in content
 
 
 class TestEgressQuadlet:
@@ -178,6 +190,21 @@ class TestEgressQuadlet:
         files = generate_quadlets(cfg, "/c.yaml", "/patches")
         content = files["test-egress.container"]
         assert "Volume=test-certs.volume:/home/acproxy/.mitmproxy:Z" in content
+
+    def test_egress_public_certs_volume(self, minimal_yaml):
+        """Egress also mounts the public-certs volume RW so
+        supervisor-egress.sh Step E can publish mitmproxy-ca-cert.pem
+        there. Cage will mount the SAME volume read-only at /certs."""
+        cfg = load_config(minimal_yaml)
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-egress.container"]
+        assert "Volume=test-public-certs.volume:/home/acproxy/public-certs:Z" in content
+        # Chown ExecStartPre for the public-certs mountpoint mirrors the
+        # private-certs one — uid 200 = acproxy inside the egress image.
+        assert (
+            "podman volume inspect agentcage-public-certs-test" in content
+            and "200:200" in content
+        )
 
     def test_egress_config_bind(self, minimal_yaml):
         """The proxy-config bind source is the host path passed to
@@ -536,7 +563,13 @@ class TestCageQuadlet:
         assert 'Environment="SSL_CERT_FILE=/certs/mitmproxy-ca-cert.pem"' in content
         assert 'NODE_OPTIONS' not in content
         assert 'Environment="AGENTCAGE_VERSION=' in content
-        assert "Volume=test-certs.volume:/certs:ro,Z" in content
+        # The cage MUST mount the public-certs volume (public cert only),
+        # NOT the certs volume (which holds mitmproxy's private key,
+        # .p12 bundles, etc.). CTF F6/F9 — agentcage 0.22.0 leaked the
+        # full keypair into /certs and only file mode + uid mismatch
+        # blocked reads.
+        assert "Volume=test-public-certs.volume:/certs:ro,Z" in content
+        assert "Volume=test-certs.volume:/certs:ro,Z" not in content
         # The broad `<patches_host_dir>:/agentcage` bind was removed — it
         # leaked every sibling cage's resolv-<name>.conf to this cage.
         assert "Volume=/home/patches:/agentcage:ro,Z" not in content

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -692,7 +692,7 @@ class TestDeployCageStartOrder:
         if "foo-cage.service" in unit_seq:
             cage_idx = unit_seq.index("foo-cage.service")
             infra = {"foo-net-network.service", "foo-certs-volume.service",
-                     "foo-egress.service"}
+                     "foo-public-certs-volume.service", "foo-egress.service"}
             earlier = set(unit_seq[:cage_idx])
             # Every infra service that ran must have run before cage.
             assert infra.intersection(unit_seq).issubset(earlier), (

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.7"
+version = "0.22.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

CTF re-run on agentcage 0.22.7 (local Arch host, container + vm backends) flagged that the cage's `/certs:ro` bind mounts the whole `agentcage-certs-<name>` podman volume, which holds mitmproxy's `mitmproxy-ca.pem` (cert + **private key**) and the `.p12` bundles alongside the public cert. File mode 0600 + uid mismatch (199 vs 1000) blocks reads today, but any future uid-map regression, mode flip, or container-side escape would promote "escape this cage" into "mint trusted certs for every allowlisted host."

Mirrors the apple-container split done in #208 (a1dcb4a) for the container and vm backends.

## Findings cited

- `findings-container-0.22.0.md` F6 — *"MITM CA private key unreadable from cage"*: the volume mount exposes `/certs/mitmproxy-ca.pem` (mode 0600 uid 199) — blocked today, but the keypair has no in-cage consumer.
- `findings-vm-0.22.0.md` F9 — *"mitmproxy CA private key file is present in the cage filesystem (defense-in-depth only)"*: explicit recommendation was to "mount the **public** cert (`mitmproxy-ca-cert.pem`) into the cage, not the full keypair volume."

Both reports recommended the same fix shape. Apple-container shipped it in #208; this PR completes the cleanup for the remaining two backends.

## Change shape

- **New quadlet** `<name>-public-certs.volume` → `agentcage-public-certs-<name>` podman volume. Holds the published public cert only.
- **Egress** now mounts BOTH:
  - `agentcage-certs-<name>:/home/acproxy/.mitmproxy:Z` (RW, mitmproxy's own state including the private key)
  - `agentcage-public-certs-<name>:/home/acproxy/public-certs:Z` (RW, target of `supervisor-egress.sh` Step E's `install -m 0644 ... mitmproxy-ca-cert.pem` — the publish step was already present, just gated on `[ -d /home/acproxy/public-certs ]`)
- **Cage** now mounts ONLY `agentcage-public-certs-<name>:/certs:ro,Z`. No path to the private key, regardless of uid mapping or file mode.
- **Lifecycle**: `backends/container.py` starts, restarts, enumerates (`_QUADLET_FILES`), recovers (`_cage_from_units`), and tears down (`destroy_resources` → `volume_remove`) the new volume. `backends/vm.py` adds the new volume service to `infra_services` so it starts in the right order. The vm `destroy_resources` is lima-instance-level; destroying the VM kills all in-VM volumes, no extra wiring needed.
- Suffix order in `_cage_from_units` matters: `-public-certs.volume` must be checked before `-certs.volume`, otherwise `myapp-public-certs.volume` strips to `myapp-public` instead of `myapp`. Tests cover this implicitly via destroy_resources roundtrip.

## Version note

CHANGELOG entry sits under `[Unreleased]`; pyproject.toml is unchanged at 0.22.7. Version bump happens on master after merge, not in this PR.

## Test plan

- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 1585 pass on this branch
- [x] `test_quadlets.py` file-count assertions updated from 4 → 5 (and 5 → 6 for nested with podman-storage)
- [x] New `TestVolumeQuadlet.test_public_certs_volume_content` asserts the new podman volume name
- [x] New `TestEgressQuadlet.test_egress_public_certs_volume` asserts the egress mounts the public-certs volume at `/home/acproxy/public-certs` and chowns it via ExecStartPre
- [x] `TestCageQuadlet.test_cage_basics` now asserts the cage mounts `test-public-certs.volume:/certs:ro,Z` **and** does NOT mount `test-certs.volume:/certs:ro,Z`
- [x] `TestRemovesPodmanResources` asserts `volume:agentcage-public-certs-myapp` appears in the destroy roundtrip
- [x] `TestRestartsNetworkAndVolumeFirst` asserts the new `<name>-public-certs-volume.service` gets restarted
- [x] `test_vm_backend` infra-ordering test includes `<name>-public-certs-volume.service` in the cage-must-start-after-infra invariant
- [ ] Manual smoke (not run locally — branch is from origin/master, no live cage yet on this branch). Expect: after `agentcage cage create + start`, `agentcage cage exec <name> -- ls /certs/` shows only `mitmproxy-ca-cert.pem` (no `mitmproxy-ca.pem`, no `*.p12`); `curl https://api.anthropic.com` from inside the cage still verifies against the proxy CA via `NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem`.

Apple-container backend already shipped this fix in #208 — no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)