### PR TITLE
v0.22.9 security(addon): enforce strict SNI ↔ Host header match (CTF F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.9] - 2026-05-28
+
+### Security
+
+- **Egress addon now enforces strict SNI ↔ Host header match.** CTF
+  finding F3 from the 0.22.6 re-run, HIGH severity. The previous
+  `request()` hook rewrote `flow.request.host = pretty_host`
+  unconditionally, so when a cage opened TLS with `SNI=A` and sent
+  HTTP `Host: B` inside the TLS, mitmproxy's upstream connection
+  followed the Host header (B) while every forensic identifier
+  downstream (audit logs, allowlist decisions, secret-injection rule
+  selection) keyed on A — the attacker chose which one fired at each
+  decision point. CTF demonstrated by reaching api.anthropic.com over
+  TLS with `SNI=evil.example` (Cloudflare's `set-cookie: Domain=
+  api.anthropic.com` confirmed the upstream was real api.anthropic.com,
+  no 403 from the addon). The fix adds a pre-rewrite check: if both
+  SNI and Host are present and don't match (case-insensitive, port-
+  stripped, trailing-dot tolerated), the addon emits 403 with reason
+  `SNI/Host header mismatch`. HTTP requests with no SNI fall through
+  to the Host header as before. Reverse-proxy flows are exempt — the
+  SNI/Host relationship there is between an external client and the
+  proxy's configured upstream.
+
 ## [0.22.7] - 2026-05-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.22.7"
+version = "0.22.9"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -426,6 +426,59 @@ class Agentcage:
         # Skip for reverse proxy flows — the host is the configured upstream
         # and must not be overwritten with the client's Host header.
         if not is_reverse:
+            # CTF F3 (0.22.6, HIGH): strict SNI ↔ Host header match.
+            # The rewrite below makes the proxy FOLLOW the Host header
+            # for the upstream connection. If the cage opened TLS with
+            # SNI=A and then sent an HTTP `Host: B` inside that TLS,
+            # the upstream connection would go to B while every
+            # forensic identifier downstream (audit logs, allowlist
+            # decisions, secret_injection rule selection) was keyed
+            # on either A or B — never both. The attacker controls
+            # which one is queried at each decision point. Closing
+            # this requires enforcing equality before any host rewrite.
+            #
+            # HTTP requests (no SNI) are exempt: the Host header is
+            # the only authority available, and the destination IP is
+            # already trusted to come from the cage's allowlisted
+            # resolver (or, in transparent mode, from SO_ORIGINAL_DST
+            # which mitmproxy preserves into flow.request.host).
+            sni = getattr(getattr(flow, "client_conn", None), "sni", None)
+            if isinstance(sni, bytes):
+                try:
+                    sni = sni.decode("idna")
+                except UnicodeError:
+                    sni = sni.decode("utf-8", "replace")
+            host_hdr = flow.request.host_header
+            if isinstance(sni, str) and sni and host_hdr:
+                # Strip optional port from the Host header before
+                # comparing; SNI is host-only by spec.
+                hh_host = host_hdr.rsplit(":", 1)[0] if ":" in host_hdr else host_hdr
+                sni_norm = sni.lower().rstrip(".")
+                hh_norm = hh_host.lower().rstrip(".")
+                if sni_norm != hh_norm:
+                    reason = (
+                        f"SNI/Host header mismatch: TLS was established "
+                        f"with SNI={sni!r} but HTTP Host header is "
+                        f"{host_hdr!r}; agentcage requires strict equality "
+                        f"so audit identity, allowlist decisions, and "
+                        f"secret-injection routing all reference the same "
+                        f"upstream"
+                    )
+                    flow.response = http.Response.make(
+                        403,
+                        json.dumps(
+                            {"blocked": True, "reason": reason,
+                             "host": host_hdr, "by": "agentcage"}
+                        ).encode(),
+                        {"Content-Type": "application/json"},
+                    )
+                    flow.metadata["agentcage_blocked"] = True
+                    self._log(
+                        flow, "blocked",
+                        "sni-host mismatch", [],
+                    )
+                    return
+
             pretty = flow.request.pretty_host
             if pretty != flow.request.host:
                 flow.request.host = pretty

--- a/tests/test_addon_sni_host_match.py
+++ b/tests/test_addon_sni_host_match.py
@@ -1,0 +1,306 @@
+"""Tests for the addon's SNI ↔ Host header match guard (CTF F3, 0.22.6).
+
+A cage that opens TLS with ``SNI=A`` and then sends an HTTP ``Host: B``
+inside that TLS gets *different* audit identities, allowlist decisions,
+and secret-injection rule selections — the attacker chooses which one
+fires at each decision point. mitmproxy's transparent mode happily
+follows the Host header for the upstream connection, so on the wire the
+request lands on B while audit logs and inspector context (keyed on the
+pre-rewrite ``flow.request.host``) reference A. The 0.22.6 CTF
+demonstrated this by reaching api.anthropic.com over TLS with
+``SNI=evil.example`` — Cloudflare's ``set-cookie: Domain=
+api.anthropic.com`` in the response confirmed the upstream was real
+api.anthropic.com, no 403 from the addon.
+
+The fix in ``addon.request()`` enforces strict equality between SNI and
+the Host header (case-insensitive, port-stripped) BEFORE the
+``flow.request.host = pretty_host`` rewrite. HTTP requests (no SNI)
+fall through to the Host header as before.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+# ── Stub mitmproxy before importing addon ────────────────
+
+
+_mitmproxy = types.ModuleType("mitmproxy")
+_mitmproxy.__path__ = []
+_mitmproxy.ctx = MagicMock()
+_mitmproxy.http = MagicMock()
+_proxy = types.ModuleType("mitmproxy.proxy")
+_proxy.__path__ = []
+_mode_specs = types.ModuleType("mitmproxy.proxy.mode_specs")
+_mitmproxy.proxy = _proxy
+_proxy.mode_specs = _mode_specs
+sys.modules.setdefault("mitmproxy", _mitmproxy)
+sys.modules.setdefault("mitmproxy.ctx", _mitmproxy.ctx)
+sys.modules.setdefault("mitmproxy.http", _mitmproxy.http)
+sys.modules.setdefault("mitmproxy.proxy", _proxy)
+sys.modules.setdefault("mitmproxy.proxy.mode_specs", _mode_specs)
+
+
+class _StubReverseMode:
+    """Real class so ``isinstance(..., ReverseMode)`` works.
+
+    Outbound-flow tests construct a ``client_conn.proxy_mode`` MagicMock
+    that is NOT an instance of this class — the addon treats those as
+    transparent outbound. The reverse-mode test passes an instance.
+    """
+
+
+sys.modules["mitmproxy.proxy.mode_specs"].ReverseMode = _StubReverseMode
+
+# Stage the proxy/ dir so ``from addon import Agentcage`` etc. resolve.
+_PROXY_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "agentcage" / "data" / "proxy"
+)
+if str(_PROXY_DIR) not in sys.path:
+    sys.path.insert(0, str(_PROXY_DIR))
+
+# Drop any previously-imported addon module so it re-imports with the
+# patched ReverseMode binding.
+for _mod in ("addon", "secret_injector"):
+    sys.modules.pop(_mod, None)
+
+from addon import Agentcage  # noqa: E402
+from secret_injector import SecretInjector  # noqa: E402
+
+
+# ── Shared helpers ──────────────────────────────────────
+
+
+class _Headers(dict):
+    def items(self, multi=False):  # noqa: ARG002
+        return list(super().items())
+
+    def get(self, key, default=None):  # type: ignore[override]
+        kl = key.lower()
+        for k, v in super().items():
+            if k.lower() == kl:
+                return v
+        return default
+
+    def keys(self):  # type: ignore[override]
+        return list(super().keys())
+
+
+def _build_addon(tmp_path):
+    """Minimal Agentcage. No inspectors; rate-limit disabled; injector
+    has no rules; audit file open. Just enough to reach the SNI/Host
+    check in ``request()`` and observe its block-or-not behavior."""
+    addon = Agentcage()
+    addon.cfg = {}
+    addon.log_allowed = False
+    addon.inspectors = []
+    addon._rl_rate = 0.0
+    addon._rl_burst = 0
+    addon._rl_buckets = {}
+    addon._audit_file = (tmp_path / "audit.jsonl").open("a")
+    addon._cap_pending = {}
+    addon.injector = SecretInjector()
+    addon.injector.rules = []
+    addon.injector.redact_to = []
+    addon._capture = None
+
+    # mitmproxy.http.Response.make is a MagicMock — make it record the
+    # status/body/headers on a sentinel object the tests can introspect.
+    def _make_response(status, body, headers):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.content = body
+        resp.headers = headers
+        return resp
+
+    from mitmproxy import http as _http
+    _http.Response.make.side_effect = _make_response
+    return addon
+
+
+def _make_flow(*, sni, host_header, reverse_mode=False,
+               url="https://api.anthropic.com/v1/messages",
+               method="POST"):
+    """Mock an outbound HTTPS HTTPFlow for the addon's ``request`` hook.
+
+    ``sni`` is the TLS SNI the cage committed to (or None for plain HTTP).
+    ``host_header`` is the Host header inside the HTTP request (or None
+    for HTTP/1.0 with no Host).
+    """
+    flow = MagicMock()
+    flow.id = "test-flow-sni-host"
+    flow.metadata = {}
+    flow.request.url = url
+    # Pre-rewrite, flow.request.host is the SO_ORIGINAL_DST hostname
+    # mitmproxy resolved from the Host header in transparent mode.
+    flow.request.host = host_header or "1.2.3.4"
+    flow.request.pretty_host = host_header or "1.2.3.4"
+    flow.request.host_header = host_header
+    flow.request.pretty_url = url
+    flow.request.path = "/v1/messages"
+    flow.request.port = 443
+    flow.request.method = method
+    flow.request.http_version = "HTTP/1.1"
+    h = {"Content-Type": "application/json"}
+    if host_header:
+        h["Host"] = host_header
+    flow.request.headers = _Headers(h)
+    flow.request.content = b"{}"
+    flow.request.get_text.side_effect = (
+        lambda strict=False: flow.request.content.decode("utf-8", "replace")
+    )
+
+    flow.client_conn.sni = sni
+    flow.client_conn.tls_established = sni is not None
+    flow.client_conn.address = ("127.0.0.1", 12345)
+    if reverse_mode:
+        flow.client_conn.proxy_mode = _StubReverseMode()
+    else:
+        flow.client_conn.proxy_mode = MagicMock()
+    flow.response = None
+    return flow
+
+
+def _was_blocked(flow):
+    return (
+        flow.response is not None
+        and getattr(flow.response, "status_code", None) == 403
+    )
+
+
+def _block_reason(flow):
+    return json.loads(flow.response.content.decode())["reason"]
+
+
+# ── Tests ────────────────────────────────────────────────
+
+
+def test_matching_sni_and_host_passes(tmp_path):
+    """SNI == Host (case-insensitive, no port) → no 403."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="api.anthropic.com",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_mismatched_sni_and_host_is_blocked(tmp_path):
+    """The exact CTF F3 case: SNI=evil.example, Host=api.anthropic.com
+    → 403 with reason naming both values."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="evil.example",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert _was_blocked(flow)
+    reason = _block_reason(flow)
+    assert "SNI/Host header mismatch" in reason
+    assert "evil.example" in reason
+    assert "api.anthropic.com" in reason
+
+
+def test_mismatched_sni_and_host_reversed_is_blocked(tmp_path):
+    """Same mismatch with the values swapped: SNI=api.anthropic.com,
+    Host=evil.example → 403. Symmetry matters — an attacker could
+    pick either direction depending on which inspector they want to
+    confuse."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="api.anthropic.com",
+                      host_header="evil.example")
+    addon.request(flow)
+    assert _was_blocked(flow)
+
+
+def test_http_without_sni_falls_through(tmp_path):
+    """Plain HTTP requests have no SNI — the Host header is the only
+    authority available. Don't block; the downstream domain inspector
+    still gets to enforce the allowlist on the Host header."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni=None,
+                      host_header="api.anthropic.com",
+                      url="http://api.anthropic.com/v1/messages")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_case_insensitive_match(tmp_path):
+    """Hostname comparison is case-insensitive (DNS spec). A SNI of
+    `Api.Anthropic.COM` must match Host `api.anthropic.com`."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="Api.Anthropic.COM",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_port_in_host_header_is_stripped(tmp_path):
+    """Host headers can carry an explicit port (`Host: x.example:443`).
+    SNI is host-only by spec, so the comparison strips the port from
+    the Host header before matching."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="api.anthropic.com",
+                      host_header="api.anthropic.com:443")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_trailing_dot_tolerated(tmp_path):
+    """The FQDN trailing-dot is semantically equivalent (RFC 1035 §3.1)
+    and must not cause a false-positive mismatch."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="api.anthropic.com.",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_bytes_sni_is_decoded(tmp_path):
+    """Some mitmproxy versions surface the SNI as bytes (IDN-encoded).
+    The check must decode to str before comparing."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni=b"api.anthropic.com",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert not _was_blocked(flow)
+
+
+def test_bytes_sni_mismatch_is_decoded_and_blocked(tmp_path):
+    """Bytes SNI that doesn't match Host should still trigger the block
+    — decoding must happen BEFORE the comparison, not just for the
+    passing path."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni=b"evil.example",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert _was_blocked(flow)
+
+
+def test_subdomain_is_not_treated_as_match(tmp_path):
+    """SNI is for a specific hostname; the cert mitmproxy minted is
+    keyed on it. Allowing `SNI=anthropic.com` to talk to
+    `Host: api.anthropic.com` (or vice versa) would re-introduce the
+    F3 ambiguity for wildcard-cert deployments. Strict equality only."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="anthropic.com",
+                      host_header="api.anthropic.com")
+    addon.request(flow)
+    assert _was_blocked(flow)
+
+
+def test_reverse_proxy_flow_skips_the_check(tmp_path):
+    """Reverse-proxy flows are inbound (host → cage via proxy); the
+    SNI/Host relationship is between an external client and the
+    proxy's configured upstream, not a cage-controlled mismatch. The
+    existing rewrite logic already exempts reverse-mode flows; the
+    SNI/Host check must do the same."""
+    addon = _build_addon(tmp_path)
+    flow = _make_flow(sni="evil.example",
+                      host_header="api.anthropic.com",
+                      reverse_mode=True)
+    addon.request(flow)
+    assert not _was_blocked(flow)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.6"
+version = "0.22.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

CTF finding F3 from the [0.22.6 re-run](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.6.md). HIGH severity (audit + secret-routing invariant violation).

The previous `request()` hook in `data/proxy/addon.py` unconditionally rewrote `flow.request.host = pretty_host` (the Host header) before any inspector or secret-injection logic ran. When a cage opened TLS with `SNI=A` and sent HTTP `Host: B` inside that TLS, mitmproxy's upstream connection followed the Host header (B), but every forensic identifier downstream (audit logs, allowlist decisions, secret-injection rule selection) keyed on either A or B depending on which call path ran first. **The attacker picked which identity fired at each decision point.**

CTF proof:

```
ctx = ssl.create_default_context(); ctx.check_hostname=False; ctx.verify_mode=ssl.CERT_NONE
s = socket.socket(); s.settimeout(3); s.connect(('1.1.1.1', 443))
ws = ctx.wrap_socket(s, server_hostname='evil.example')          # SNI = non-allowlist
ws.send(b'GET / HTTP/1.1\r\nHost: api.anthropic.com\r\nConnection: close\r\n\r\n')
ws.recv(2000)
# b'HTTP/1.1 404 Not Found\r\n...Server: cloudflare\r\n
#   set-cookie: _cfuvid=...; Domain=api.anthropic.com; ...'
```

The `set-cookie: Domain=api.anthropic.com` confirms the request reached the real api.anthropic.com upstream — no 403 from the addon. The plain-HTTP variant (arbitrary IP + `Host: api.anthropic.com`) had the same shape.

## Fix

`src/agentcage/data/proxy/addon.py:412-...` — before the `flow.request.host = pretty_host` rewrite, read both `flow.client_conn.sni` and `flow.request.host_header`. If both are present and don't match (case-insensitive, port-stripped, trailing-dot tolerated), emit a 403 response with reason `SNI/Host header mismatch` and short-circuit.

- HTTP requests with no SNI fall through to Host-header authority as before — the existing allowlist inspector still enforces domain restrictions.
- Reverse-proxy flows are exempt — the SNI/Host relationship there is between an external client and the proxy's configured upstream, not a cage-controlled mismatch.
- Bytes SNI (IDN-encoded) is decoded before comparing.
- Strict equality only — no subdomain hierarchy (`SNI=anthropic.com` + `Host=api.anthropic.com` blocks). Wildcard-cert deployments would re-introduce the F3 ambiguity.

## Verified live on m1 (apple-container backend, agentcage 0.22.9)

```
Before (0.22.7): SNI=evil.example, Host=api.anthropic.com
                 → b'HTTP/1.1 404 Not Found\r\n...Server: cloudflare\r\n
                    set-cookie: ...Domain=api.anthropic.com'
                 (request reached real api.anthropic.com, no block)

After  (0.22.9): SNI=evil.example, Host=api.anthropic.com
                 → b'HTTP/1.1 403 Forbidden\r\nContent-Type:
                    application/json\r\n...'
                 (blocked by agentcage with the new reason)

Control:         SNI=api.anthropic.com, Host=api.anthropic.com
                 → RC=404 from real upstream via egress proxy
                 (matching SNI/Host still works end-to-end)
```

## Test plan

- [x] New `tests/test_addon_sni_host_match.py` — 11 tests covering:
  - Matching SNI/Host passes
  - Mismatch is blocked (both directions)
  - HTTP without SNI falls through
  - Case-insensitive match
  - Port stripped from Host header
  - Trailing-dot tolerated
  - Bytes SNI decoded for both match and mismatch paths
  - Subdomain is NOT treated as a match (strict equality)
  - Reverse-proxy flows are exempt
- [x] Full suite: 1591 passed
- [x] Live verification on Mac

## Related

- Part 3 of 3 from the [0.22.6 CTF findings](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.6.md):
  - F1: cage→host-gateway TCP/non-DNS-UDP block — #210 (0.22.8)
  - F2: DNS-tunnel exfil — deferred to follow-up, see #213 (architectural blocker; cage→egress UDP :53 doesn't traverse apple-container's inter-microVM network without dnsmasq-in-cage)
  - **F3: SNI/Host mismatch — this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)