### PR TITLE
fix(egress/dns): pin egress resolv.conf to upstreams, kill aardvark ordering race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fix(egress/dns)`: container/vm egress no longer intermittently
+  returns 502 Bad Gateway for allowlisted hosts (resolv.conf ordering
+  race).** The egress sidecar joins two aardvark-dns-enabled podman
+  networks — the per-cage `<name>-net` and the default `podman` network.
+  podman injected aardvark's address as the *first* nameserver in the
+  egress's auto-generated `/etc/resolv.conf`, ahead of the upstream
+  resolvers passed via the quadlet's `DNS=` directive. mitmproxy resolves
+  allowlisted upstream hostnames (e.g. `archive.ubuntu.com`) via that
+  resolv.conf, so whenever aardvark won the order and failed to forward
+  the external name — which it does intermittently after rapid
+  `cage create`/`cage destroy` churn degrades the aardvark network state
+  — mitmproxy got "Name or service not known" and returned
+  `502 Bad Gateway [IP: <egress>:8080]` to the cage for *every*
+  allowlisted host. (The allowlist-gate 403 path was unaffected because
+  it short-circuits before any upstream resolution, which is why blocked
+  domains still got a clean 403 while allowed ones 502'd.) The fix
+  bind-mounts a deterministic `resolv-egress-<name>.conf` (written by
+  `services.write_resolv_files` with only `config.dns_servers`) at the
+  egress's `/etc/resolv.conf` and drops the racy `DNS=` directive
+  entirely. The egress never needs aardvark name resolution — it only
+  resolves real upstream hostnames for mitmproxy, and the cage's DNS goes
+  through the egress's bundled allowlist-scoped dnsmasq — so removing
+  aardvark from the egress's resolution path eliminates the race
+  deterministically. Mirrors the cage's existing `resolv-<name>.conf`
+  bind and the apple-container resolv.conf rewrite (0.22.11). Replaces
+  the previous "restart the egress sidecar" band-aid workaround.
 - **`cage show` now reports per-secret present/missing status on
   apple-container.** It previously printed `N expected (status not tracked on
   apple-container)` because host podman — the secret store on the container

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -506,6 +506,7 @@ def generate_quadlets(
     files[f"{name}-egress.container"] = env.get_template("egress.container.j2").render(
         **common,
         agentcage_version=_pkg_version("agentcage"),
+        patches_host_dir=patches_host_dir,
         config_host_path=proxy_config_path,
         dns_allowlist_enabled=(config.domains.mode == "allowlist"),
         dns_allowlist_host_path=dns_allowlist_path_str,

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -224,6 +224,58 @@ def build_container_image(
     )
 
 
+def write_resolv_files(
+    patches_work: str,
+    name: str,
+    ip_egress: str,
+    dns_servers: list[str],
+) -> tuple[str, str]:
+    """Write the cage's and egress's resolv.conf files into *patches_work*.
+
+    Returns ``(cage_resolv_path, egress_resolv_path)``.
+
+    The cage's resolv.conf (``resolv-<name>.conf``) points at this cage's
+    egress sidecar, so the cage's DNS goes through the egress's bundled,
+    allowlist-scoped dnsmasq.
+
+    The egress's resolv.conf (``resolv-egress-<name>.conf``) is pinned to
+    the configured upstream resolvers (*dns_servers*) and NOTHING else.
+
+    Why the egress needs its own pinned resolv.conf — the resolv.conf
+    ordering race: the egress sidecar joins two podman networks — the
+    per-cage ``<name>-net`` and the default ``podman`` network — both of
+    which have aardvark-dns enabled. podman injects aardvark's address as
+    the FIRST nameserver in the egress's auto-generated /etc/resolv.conf,
+    ahead of any upstream servers passed via the quadlet's ``DNS=``
+    directive. mitmproxy resolves allowlisted upstream hostnames
+    (archive.ubuntu.com, …) via THIS resolv.conf. When aardvark wins the
+    order and intermittently fails to forward external names — which it
+    does after rapid create/destroy churn degrades the aardvark network
+    state — mitmproxy gets "Name or service not known" and returns 502 Bad
+    Gateway to the cage for every allowlisted host. (The allowlist-gate
+    403 path is unaffected because it short-circuits before upstream
+    resolution.)
+
+    The egress never needs aardvark name resolution: it only ever resolves
+    REAL upstream hostnames for mitmproxy, and the cage's own DNS goes
+    through the egress's bundled dnsmasq (not aardvark). So we bind-mount a
+    deterministic resolv.conf that lists only the upstream servers,
+    mirroring how the cage gets its own ``resolv-<name>.conf`` and how the
+    apple-container backend rewrites the cage's resolv.conf to its dnsmasq
+    (CHANGELOG 0.22.11). aardvark is never consulted, so the ordering race
+    cannot occur.
+    """
+    cage_resolv_path = os.path.join(patches_work, f"resolv-{name}.conf")
+    with open(cage_resolv_path, "w") as f:
+        f.write(f"nameserver {ip_egress}\n")
+
+    egress_resolv_path = os.path.join(patches_work, f"resolv-egress-{name}.conf")
+    with open(egress_resolv_path, "w") as f:
+        f.write("".join(f"nameserver {srv}\n" for srv in dns_servers))
+
+    return cage_resolv_path, egress_resolv_path
+
+
 def build_and_deploy(
     cfg,
     config_host_path: str,
@@ -251,13 +303,14 @@ def build_and_deploy(
 
     patches_work = ensure_patches(podman)
 
-    # Write per-cage resolv.conf pointing to this cage's dnsmasq sidecar
+    # Write the per-cage resolv.conf files (cage + egress) into the
+    # patches dir; the quadlets bind-mount them at /etc/resolv.conf.
     addrs = cage_network_addrs(
         cfg.name, used_octets=used_octets, network_octet=network_octet,
     )
-    resolv_path = os.path.join(patches_work, f"resolv-{cfg.name}.conf")
-    with open(resolv_path, "w") as f:
-        f.write(f"nameserver {addrs['ip_egress']}\n")
+    write_resolv_files(
+        patches_work, cfg.name, addrs["ip_egress"], cfg.dns_servers,
+    )
 
     backend.build_artifacts(
         cfg, deploy_name, quiet=quiet, no_cache=no_cache, pull=pull,

--- a/src/agentcage/templates/egress.container.j2
+++ b/src/agentcage/templates/egress.container.j2
@@ -6,9 +6,23 @@ ContainerName={{ name }}-egress
 Image=localhost/agentcage-egress:{{ agentcage_version }}
 Network={{ name }}-net.network:ip={{ ip_egress }}
 Network=podman
-{% for srv in dns_servers %}
-DNS={{ srv }}
-{% endfor %}
+# Pin the egress's OWN resolv.conf to the configured upstream resolvers
+# (config.dns_servers) and nothing else — do NOT use the racy `DNS=`
+# directive. The egress is on two aardvark-dns-enabled networks
+# ({{ name }}-net + podman), and podman injects aardvark as the FIRST
+# nameserver ahead of any `DNS=` entries. mitmproxy resolves allowlisted
+# upstream hostnames via this file; when aardvark wins the order and
+# intermittently fails to forward external names (degrades after rapid
+# create/destroy churn), mitmproxy returns "Name not known" → 502 Bad
+# Gateway for every allowlisted host. Bind-mounting a deterministic
+# resolv.conf that lists only the upstreams removes aardvark from the
+# egress's resolution path entirely, so the ordering race cannot happen.
+# The egress never needs aardvark name resolution: it only resolves real
+# upstream hostnames, and the cage's DNS goes through the egress's
+# bundled dnsmasq. Mirrors the cage's resolv-{{ name }}.conf bind and the
+# apple-container resolv.conf rewrite (CHANGELOG 0.22.11). The file is
+# written by services.write_resolv_files (resolv-egress-{{ name }}.conf).
+Volume={{ patches_host_dir }}/resolv-egress-{{ name }}.conf:/etc/resolv.conf:ro,Z
 Volume={{ config_host_path }}:/etc/agentcage/config.yaml:ro,Z
 {% if dns_allowlist_enabled %}
 Volume={{ dns_allowlist_host_path }}:/etc/agentcage/dns-allowlist.conf:ro,Z

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -235,6 +235,47 @@ class TestEgressQuadlet:
         # `--servers-file=...`.
         assert "/etc/agentcage/dns-allowlist.conf:ro,Z" in content
 
+    def test_egress_resolv_conf_pinned_not_dns_directive(self, tmp_path):
+        """REGRESSION GUARD (egress DNS resolv.conf ordering race).
+
+        The egress must NOT use the podman `DNS=` directive for its own
+        upstream resolution. The egress joins two aardvark-dns-enabled
+        networks (<name>-net + podman); podman injects aardvark as the
+        FIRST nameserver ahead of any `DNS=` entries. mitmproxy resolves
+        allowlisted upstream hostnames via the egress's /etc/resolv.conf,
+        so when aardvark wins the order and intermittently fails to
+        forward external names (after rapid create/destroy churn) every
+        allowlisted host returns 502 Bad Gateway (mitmproxy "Name not
+        known").
+
+        The deterministic fix bind-mounts resolv-egress-<name>.conf
+        (written by services.provision_cage with only the configured
+        upstream resolvers) at /etc/resolv.conf, mirroring the cage's own
+        resolv-<name>.conf mount. aardvark is never consulted, so the
+        ordering race cannot happen.
+        """
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            dns_servers:
+              - 1.1.1.1
+              - 8.8.8.8
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/c.yaml", "/patches", deploy_name="test")
+        content = files["test-egress.container"]
+        # The deterministic resolv.conf is bind-mounted read-only at
+        # /etc/resolv.conf, sourced from the patches dir.
+        assert (
+            "Volume=/patches/resolv-egress-test.conf:/etc/resolv.conf:ro,Z"
+            in content
+        )
+        # The racy `DNS=` directive must NOT appear — that's the whole
+        # point. Match on the line-start form so we never reintroduce it.
+        assert "\nDNS=" not in content
+
     def test_egress_no_dns_allowlist_bind_in_blocklist_mode(self, tmp_path):
         """Blocklist / open-DNS mode does not produce an allowlist file,
         so the bind mount stays off."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,58 @@
+"""Unit tests for agentcage.services helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentcage.services import write_resolv_files
+
+
+class TestWriteResolvFiles:
+    """The cage and egress resolv.conf writers (the egress DNS race fix)."""
+
+    def test_cage_resolv_points_at_egress(self, tmp_path: Path):
+        """The cage's resolv.conf routes DNS through its egress sidecar
+        (the egress's bundled, allowlist-scoped dnsmasq)."""
+        cage_path, _ = write_resolv_files(
+            str(tmp_path), "test", "10.89.7.2", ["1.1.1.1", "8.8.8.8"],
+        )
+        assert Path(cage_path).name == "resolv-test.conf"
+        assert Path(cage_path).read_text() == "nameserver 10.89.7.2\n"
+
+    def test_egress_resolv_pins_upstreams_only(self, tmp_path: Path):
+        """REGRESSION GUARD (egress DNS resolv.conf ordering race).
+
+        The egress's resolv.conf must list ONLY the configured upstream
+        resolvers — never the egress sidecar IP, never an aardvark
+        address. mitmproxy resolves allowlisted upstream hostnames via
+        this file; if aardvark were ever consulted (which is what happens
+        when podman's auto-generated resolv.conf wins, via the racy `DNS=`
+        directive), external names intermittently fail to resolve and
+        every allowlisted host returns 502 Bad Gateway. Pinning the
+        upstreams here and bind-mounting the result removes aardvark from
+        the egress's resolution path entirely.
+        """
+        _, egress_path = write_resolv_files(
+            str(tmp_path), "test", "10.89.7.2", ["1.1.1.1", "8.8.8.8"],
+        )
+        assert Path(egress_path).name == "resolv-egress-test.conf"
+        content = Path(egress_path).read_text()
+        assert content == "nameserver 1.1.1.1\nnameserver 8.8.8.8\n"
+        # The egress IP must NOT appear — that would point mitmproxy's
+        # upstream resolution back at the egress's own dnsmasq (which is
+        # --no-resolv and refuses non-allowlisted recursion → no upstream
+        # IPs for real hosts).
+        assert "10.89.7.2" not in content
+
+    def test_egress_resolv_single_upstream(self, tmp_path: Path):
+        _, egress_path = write_resolv_files(
+            str(tmp_path), "solo", "10.89.9.2", ["192.0.2.53"],
+        )
+        assert Path(egress_path).read_text() == "nameserver 192.0.2.53\n"
+
+    def test_both_files_written_under_patches_dir(self, tmp_path: Path):
+        cage_path, egress_path = write_resolv_files(
+            str(tmp_path), "abc", "10.0.0.2", ["1.1.1.1"],
+        )
+        assert Path(cage_path).parent == tmp_path
+        assert Path(egress_path).parent == tmp_path


### PR DESCRIPTION
## Root cause

The container/vm **egress sidecar** intermittently comes up with broken upstream DNS, returning `502 Bad Gateway [IP: <egress>:8080]` to the cage for every allowlisted host (`apt-get update` against archive.ubuntu.com / security.ubuntu.com, etc.). mitmproxy returns 502 because it cannot resolve the upstream hostname ("Name or service not known").

The egress joins **two aardvark-dns-enabled podman networks** — the per-cage `<name>-net` and the default `podman` network (`egress.container.j2`: two `Network=` lines). podman injects aardvark's address as the **first** nameserver in the egress's auto-generated `/etc/resolv.conf`, ahead of the upstream resolvers we passed via the quadlet's `DNS={{ srv }}` directive.

mitmproxy resolves allowlisted upstream hostnames via that resolv.conf. When aardvark wins the order **and** intermittently fails to forward the external name — which it does after rapid `cage create`/`cage destroy` churn degrades the aardvark network state — mitmproxy gets NXDOMAIN/SERVFAIL → "Name not known" → **502**.

This matches the live evidence exactly:
- Intermittent; failure probability rises after back-to-back create/destroy churn.
- The **blocked** path is unaffected: the allowlist gate returns a clean 403 *before* any upstream resolution, so non-allowlisted domains 403 while allowlisted ones 502.

The old "restart the egress sidecar" advice was a band-aid (a restart re-rolls the resolv.conf order), not a fix.

## Fix

Mirror the pattern already used for the **cage** (`resolv-<name>.conf` pinned to the egress dnsmasq, no `DNS=`) and the apple-container resolv.conf rewrite (CHANGELOG 0.22.11):

- `services.write_resolv_files()` now also writes `resolv-egress-<name>.conf` containing **only** `config.dns_servers`.
- `egress.container.j2` bind-mounts it at `/etc/resolv.conf:ro` and **drops the racy `DNS=` directive entirely**.

The egress never needs aardvark name resolution: it only ever resolves **real upstream hostnames** for mitmproxy, and the cage's own DNS goes through the egress's bundled, allowlist-scoped dnsmasq (not aardvark). Removing aardvark from the egress's resolution path eliminates the ordering race deterministically. Fail-closed and consistent with the existing architecture — no new egress holes (the upstream set is unchanged; only the resolver *ordering* is now deterministic). The e2e `/etc/hosts` mock approach is unaffected (NSS resolves `files` before `dns`).

## Test coverage

- `tests/test_services.py` — `write_resolv_files()` pins the egress resolv.conf to the upstreams only, never the egress IP / an aardvark address; cage resolv.conf still points at the egress.
- `tests/test_quadlets.py::test_egress_resolv_conf_pinned_not_dns_directive` — regression guard: the egress quadlet bind-mounts `resolv-egress-<name>.conf` at `/etc/resolv.conf` **and emits no `DNS=` line**.

`uv run pytest tests/` → **1602 passed**.

## Reproduce (don't churn the host's podman state heavily)

1. `agentcage run ubuntu --as-root` on the container backend (rootless podman).
2. Inside the cage: `apt-get update` → before the fix, intermittently `502 Bad Gateway [IP: <egress>:8080]` for archive.ubuntu.com; a non-allowlisted domain still gets a clean 403.
3. On the egress: `podman exec <name>-egress cat /etc/resolv.conf` — before: aardvark IP first; after: only the configured upstreams.

Static repro (no cage churn): render the egress quadlet and confirm `Volume=.../resolv-egress-<name>.conf:/etc/resolv.conf:ro,Z` is present and no `DNS=` line is emitted — covered by the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)