### PR TITLE
feat(apple-container): wire egress TCP/UDP port policy from cage.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than a re-expansion. Volumes that can't be resolved (unset variable)
   or escape `$HOME` are dropped at create time with a warning instead of
   failing silently later.
+- **apple-container now honors `cage.yaml`'s egress port policy.** The
+  `{name}-egress` microVM's supervisor builds its iptables filter from
+  `INSPECTED_TCP_PORTS` / `PASSTHROUGH_TCP_PORTS` / `ALLOW_UDP_PORTS`, but
+  `start()` previously hardcoded only `ALLOW_UDP_PORTS=53` and never read
+  `ports.tcp.allow` / `ports.tcp.passthrough` / `ports.udp.allow` — so a
+  cage that narrowed, widened, or added passthrough/UDP ports had its
+  policy silently dropped and fell back to the supervisor's default
+  "80 443". `generate_units()` now persists the resolved policy (computed
+  via the same `_effective_port_policy` the container/vm quadlet path
+  uses) into `metadata.json`, and `start()` feeds all three env vars to
+  the egress argv. Port 53 remains unioned into the UDP set so in-cage
+  DNS keeps working even when `ports.udp.allow` is empty.
 
 ### Added
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -49,6 +49,7 @@ from agentcage.apple_container import prerequisites as ac_prereq
 from agentcage.apple_container import scaffold as ac_scaffold
 from agentcage.apple_container import wrapper as ac_wrapper
 from agentcage.config import Config
+from agentcage.quadlets import _effective_port_policy
 
 
 # Shared agentcage-egress image is built once per host (tagged with the
@@ -603,6 +604,16 @@ class AppleContainerBackend:
                 scheme, _, var = (src or "").partition(":")
                 if scheme and var and var not in relay_secret_envs:
                     relay_secret_envs.append(var)
+        # Resolve cage.yaml's nested ``ports.*`` into the three int lists the
+        # egress supervisor's Step A turns into iptables rules. Computed HERE
+        # (at unit-generation time, when we have a live Config) and persisted
+        # into metadata.json so ``start()`` — which works only from the meta
+        # dict, not a Config — can feed them to the egress argv. Reuses the
+        # SAME ``_effective_port_policy`` the container/vm quadlet path uses
+        # (quadlets.py:152) so the policy resolution can never diverge between
+        # backends. Pre-this-fix apple-container hardcoded only ALLOW_UDP_PORTS=53
+        # and silently dropped a cage.yaml's ports.tcp.* / ports.udp.* policy.
+        inspected_tcp, passthrough_tcp, allow_udp = _effective_port_policy(config)
         unit_json = json.dumps(
             {
                 "name": deploy_name,
@@ -648,6 +659,12 @@ class AppleContainerBackend:
                     k: os.path.expandvars(str(v))
                     for k, v in (config.container.env or {}).items()
                 },
+                # Egress port policy (see _effective_port_policy above). Three
+                # lists of ints; start() space-joins them onto the egress argv
+                # as INSPECTED_TCP_PORTS / PASSTHROUGH_TCP_PORTS / ALLOW_UDP_PORTS.
+                "inspected_tcp_ports": inspected_tcp,
+                "passthrough_tcp_ports": passthrough_tcp,
+                "allow_udp_ports": allow_udp,
             },
             indent=2,
             sort_keys=True,
@@ -816,16 +833,38 @@ class AppleContainerBackend:
             "-e", "AGENTCAGE_CONFIG=/etc/agentcage/config.yaml",
             "-e", "AGENTCAGE_AUDIT_LOG=/var/log/agentcage/audit.jsonl",
             "-e", "AGENTCAGE_CAPTURE=/var/log/agentcage/capture.jsonl",
-            # CTF F2 (0.22.6): the cage's local dnsmasq (cage-init.sh
-            # stage A') queries upstream resolvers via UDP :53. Those
-            # packets route through the egress sibling (the cage's
-            # default gateway). supervisor-egress.sh sets FORWARD policy
-            # to DROP and only ACCEPTs ports listed in $ALLOW_UDP_PORTS,
-            # which is otherwise unset. Without :53 in the list, the
-            # cage's dnsmasq sees its upstream forwarders timeout and
-            # returns SERVFAIL — even for allowlisted apexes. Setting
-            # ALLOW_UDP_PORTS=53 here closes that gap.
-            "-e", "ALLOW_UDP_PORTS=53",
+        ]
+        # Egress port policy. generate_units() persisted these three int
+        # lists (from cage.yaml's nested ``ports.*`` via the shared
+        # _effective_port_policy). supervisor-egress.sh Step A turns them
+        # into iptables rules: INSPECTED_TCP_PORTS → nat:PREROUTING REDIRECT
+        # to mitmproxy, PASSTHROUGH_TCP_PORTS → FORWARD ACCEPT uninspected,
+        # ALLOW_UDP_PORTS → FORWARD ACCEPT for UDP.
+        inspected_tcp = [int(p) for p in (meta.get("inspected_tcp_ports") or [])]
+        passthrough_tcp = [int(p) for p in (meta.get("passthrough_tcp_ports") or [])]
+        allow_udp = [int(p) for p in (meta.get("allow_udp_ports") or [])]
+        # INSPECTED_TCP_PORTS MUST be set explicitly: the supervisor only
+        # falls back to "80 443" when the var is UNSET, so a cage that
+        # narrows or widens its inspected set has to be honored here.
+        egress_argv += [
+            "-e", f"INSPECTED_TCP_PORTS={' '.join(str(p) for p in inspected_tcp)}",
+            "-e", f"PASSTHROUGH_TCP_PORTS={' '.join(str(p) for p in passthrough_tcp)}",
+        ]
+        # CTF F2 (0.22.6): the cage's local dnsmasq (cage-init.sh
+        # stage A') queries upstream resolvers via UDP :53. Those
+        # packets route through the egress sibling (the cage's
+        # default gateway). supervisor-egress.sh sets FORWARD policy
+        # to DROP and only ACCEPTs ports listed in $ALLOW_UDP_PORTS,
+        # which is otherwise unset. Without :53 in the list, the
+        # cage's dnsmasq sees its upstream forwarders timeout and
+        # returns SERVFAIL — even for allowlisted apexes. So 53 MUST
+        # remain present even when the operator's config.udp.allow is
+        # empty: we union it in and dedupe (preserving operator order).
+        udp_with_dns = list(allow_udp)
+        if 53 not in udp_with_dns:
+            udp_with_dns.append(53)
+        egress_argv += [
+            "-e", f"ALLOW_UDP_PORTS={' '.join(str(p) for p in udp_with_dns)}",
         ]
         # Egress is small — 512M is plenty. We don't normalize here
         # because the value is internal, not operator-supplied.

--- a/tests/test_apple_container_egress_ports.py
+++ b/tests/test_apple_container_egress_ports.py
@@ -1,0 +1,212 @@
+"""Tests for the apple-container egress port-policy wiring.
+
+The apple-container backend runs an ``{name}-egress`` microVM whose
+``supervisor-egress.sh`` builds its iptables filter from three env vars
+(``INSPECTED_TCP_PORTS`` / ``PASSTHROUGH_TCP_PORTS`` / ``ALLOW_UDP_PORTS``).
+Pre-fix, ``start()`` hardcoded only ``ALLOW_UDP_PORTS=53`` and silently
+dropped a cage.yaml's ``ports.*`` policy.
+
+These tests cover the argv/env construction only (no live Apple runtime,
+which doesn't exist on Linux CI):
+  - ``generate_units()`` persists the three int lists into metadata.json
+    via the shared ``_effective_port_policy``.
+  - ``start()`` reads them back and emits the three ``-e`` flags on the
+    egress ``container run`` argv, with 53 always unioned into the UDP set.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from unittest.mock import patch
+
+from agentcage.backends.apple_container import AppleContainerBackend
+from agentcage.config import load_config
+
+
+def _config(tmp_path, body: str):
+    p = tmp_path / "cage.yaml"
+    p.write_text(textwrap.dedent(body))
+    return load_config(str(p))
+
+
+# ── generate_units(): Config → metadata port lists ──────────
+
+
+class TestGenerateUnitsPortPolicy:
+    def test_default_policy_persisted(self, tmp_path):
+        """A cage with no ``ports:`` override persists the default policy:
+        inspected=[80,443], no passthrough, no UDP."""
+        cfg = _config(tmp_path, """\
+            name: demo
+            container:
+              image: test:latest
+        """)
+        units = AppleContainerBackend().generate_units(
+            cfg, "/c.yaml", "/patches", "demo",
+        )
+        meta = json.loads(units["demo.json"])
+        assert meta["inspected_tcp_ports"] == [80, 443]
+        assert meta["passthrough_tcp_ports"] == []
+        assert meta["allow_udp_ports"] == []
+
+    def test_custom_policy_persisted(self, tmp_path):
+        """Operator ports.tcp.allow/passthrough/udp.allow flow into
+        metadata. Inspected = allow MINUS passthrough (shared
+        _effective_port_policy semantics)."""
+        cfg = _config(tmp_path, """\
+            name: demo
+            container:
+              image: test:latest
+            ports:
+              tcp:
+                allow: [80, 443, 8000, 22]
+                passthrough: [22]
+              udp:
+                allow: [123, 5353]
+        """)
+        units = AppleContainerBackend().generate_units(
+            cfg, "/c.yaml", "/patches", "demo",
+        )
+        meta = json.loads(units["demo.json"])
+        assert meta["inspected_tcp_ports"] == [80, 443, 8000]
+        assert meta["passthrough_tcp_ports"] == [22]
+        assert meta["allow_udp_ports"] == [123, 5353]
+
+
+# ── start(): metadata → egress run argv env ─────────────────
+
+
+def _start_with_meta(tmp_path, meta_extra: dict) -> list[str]:
+    """Drive AppleContainerBackend.start() far enough to capture the
+    egress ``container run`` argv, with all the live-runtime side effects
+    stubbed out. Returns the egress argv (the first ``run -d`` invocation).
+    """
+    backend = AppleContainerBackend()
+
+    base_meta = {
+        "name": "demo",
+        "user_image": "test:latest",
+        "cpus": "",
+        "memory": "",
+        "lifecycle": "service",
+        "secret_envs": [],
+        "secret_env_placeholders": {},
+        "relay_secret_envs": [],
+        "autostart": False,
+        "volumes": [],
+        "env": {},
+    }
+    base_meta.update(meta_extra)
+
+    unit_dir = tmp_path / "units"
+    unit_dir.mkdir()
+    (unit_dir / "demo.json").write_text(json.dumps(base_meta))
+
+    state_dir = tmp_path / "state"
+    egress_cfg = state_dir / "egress-config"
+    egress_cfg.mkdir(parents=True)
+    # The three files start() binds in must exist for the egress_cfg_dir
+    # guard to pass.
+    for fn in ("proxy-config.yaml", "dnsmasq.conf", "dns-allowlist.conf"):
+        (egress_cfg / fn).touch()
+
+    captured: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        captured.append(list(argv))
+
+        class _R:
+            returncode = 0
+        return _R()
+
+    with patch.object(AppleContainerBackend, "unit_dir", return_value=unit_dir), \
+         patch.object(AppleContainerBackend, "egress_config_dir", return_value=egress_cfg), \
+         patch.object(AppleContainerBackend, "logs_dir", return_value=state_dir / "logs"), \
+         patch.object(AppleContainerBackend, "certs_dir", return_value=state_dir / "certs"), \
+         patch.object(AppleContainerBackend, "public_certs_dir", return_value=state_dir / "pub"), \
+         patch.object(AppleContainerBackend, "secrets_dir", return_value=state_dir / "secrets"), \
+         patch.object(AppleContainerBackend, "_stage_secrets", return_value=set()), \
+         patch.object(AppleContainerBackend, "_wait_supervisor_ready"), \
+         patch.object(AppleContainerBackend, "_container_ip", return_value="10.0.0.2"), \
+         patch("agentcage.backends.apple_container.ac_cli.run", side_effect=fake_run), \
+         patch("agentcage.backends.apple_container.ac_cli.inspect", return_value=None), \
+         patch("agentcage.backends.apple_container.ac_cli.image_inspect", return_value={"ok": 1}), \
+         patch("agentcage.backends.apple_container.ac_wrapper.wrapped_image_name",
+               return_value="wrapped:demo"), \
+         patch("agentcage.backends.apple_container._egress_image_name",
+               return_value="egress:latest"):
+        backend.start("demo", quiet=True)
+
+    # The egress run is the first `run -d --name demo-egress ...` call.
+    for argv in captured:
+        if argv[:4] == ["run", "-d", "--name", "demo-egress"]:
+            return argv
+    raise AssertionError(f"egress run argv not found in {captured!r}")
+
+
+def _env_value(argv: list[str], key: str) -> str | None:
+    """Return the value of a ``-e KEY=VAL`` pair in argv (or None)."""
+    for i, tok in enumerate(argv):
+        if tok == "-e" and i + 1 < len(argv) and argv[i + 1].startswith(f"{key}="):
+            return argv[i + 1].split("=", 1)[1]
+    return None
+
+
+class TestStartEgressArgvPortEnv:
+    def test_default_policy_env(self, tmp_path):
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [80, 443],
+            "passthrough_tcp_ports": [],
+            "allow_udp_ports": [],
+        })
+        # INSPECTED set explicitly even at the default — the supervisor
+        # only falls back to "80 443" when the var is UNSET.
+        assert _env_value(argv, "INSPECTED_TCP_PORTS") == "80 443"
+        assert _env_value(argv, "PASSTHROUGH_TCP_PORTS") == ""
+        # 53 is unioned in even when config.udp.allow is empty.
+        assert _env_value(argv, "ALLOW_UDP_PORTS") == "53"
+
+    def test_custom_policy_env_honored(self, tmp_path):
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [80, 443, 8000],
+            "passthrough_tcp_ports": [22],
+            "allow_udp_ports": [123, 5353],
+        })
+        assert _env_value(argv, "INSPECTED_TCP_PORTS") == "80 443 8000"
+        assert _env_value(argv, "PASSTHROUGH_TCP_PORTS") == "22"
+        # config UDP ports preserved AND 53 appended.
+        udp = _env_value(argv, "ALLOW_UDP_PORTS").split()
+        assert udp == ["123", "5353", "53"]
+
+    def test_dns_53_always_present(self, tmp_path):
+        """CTF F2: 53 must survive even when the operator narrows the
+        inspected set and lists no UDP ports — dropping it breaks all
+        in-cage DNS (dnsmasq upstream forwarding)."""
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [443],
+            "passthrough_tcp_ports": [],
+            "allow_udp_ports": [],
+        })
+        assert "53" in _env_value(argv, "ALLOW_UDP_PORTS").split()
+
+    def test_53_not_duplicated_when_already_present(self, tmp_path):
+        """If the operator explicitly lists 53 in udp.allow, it appears
+        exactly once (no duplicate from the union)."""
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [80, 443],
+            "passthrough_tcp_ports": [],
+            "allow_udp_ports": [53, 123],
+        })
+        udp = _env_value(argv, "ALLOW_UDP_PORTS").split()
+        assert udp.count("53") == 1
+        assert udp == ["53", "123"]
+
+    def test_legacy_metadata_without_port_lists(self, tmp_path):
+        """A cage last created before this fix has no *_ports keys in
+        metadata.json. start() must not crash: inspected/passthrough fall
+        back to empty, and 53 is still emitted so DNS keeps working."""
+        argv = _start_with_meta(tmp_path, {})
+        assert _env_value(argv, "INSPECTED_TCP_PORTS") == ""
+        assert _env_value(argv, "PASSTHROUGH_TCP_PORTS") == ""
+        assert _env_value(argv, "ALLOW_UDP_PORTS") == "53"


### PR DESCRIPTION
## Summary

The apple-container backend runs an `{name}-egress` microVM whose `supervisor-egress.sh` builds its iptables filter from three env vars (`INSPECTED_TCP_PORTS` / `PASSTHROUGH_TCP_PORTS` / `ALLOW_UDP_PORTS`). The supervisor already supports the full contract — but `AppleContainerBackend.start()` hardcoded only `ALLOW_UDP_PORTS=53` and never read `config.ports.*`. So a `cage.yaml` that narrowed, widened, or added passthrough/UDP ports had its policy **silently dropped**, falling back to the supervisor default `80 443`.

## What changed

- **`generate_units()`** (`src/agentcage/backends/apple_container.py`) now resolves the policy via the shared `_effective_port_policy` (`quadlets.py:152` — the same function the container/vm quadlet path uses, so the two backends can never diverge) and persists the three int lists into `metadata.json`.
- **`start()`** reads them back and emits all three `-e` flags on the egress `container run` argv. `INSPECTED_TCP_PORTS` is set explicitly even at the default (the supervisor only falls back to `80 443` when the var is *unset*).
- **Port 53** is unioned into the UDP set (deduped, order-preserving) so in-cage dnsmasq upstream forwarding keeps working even when `ports.udp.allow` is empty (CTF F2). The existing explanatory comments are preserved.

## Tests

New `tests/test_apple_container_egress_ports.py` (7 tests) covers both layers — metadata persistence from a `Config`, and the egress argv env construction (default policy, custom policy honored, 53 always present, 53 not duplicated, legacy metadata without port lists). Full suite: **1610 passed**.

No live Apple runtime is exercised (doesn't exist on Linux CI) — tests assert on the argv/env construction only, mirroring `tests/test_apple_container_cli.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)