### PR TITLE
feat(apple-container): warn on container.ports (inbound publishing unsupported)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the egress argv. Port 53 remains unioned into the UDP set so in-cage
   DNS keeps working even when `ports.udp.allow` is empty.
 
+### Changed
+
+- **apple-container now warns when `container.ports` (inbound published
+  ports) is set.** On the container/vm backends a `container.ports:` entry
+  becomes an egress `PublishPort=` plus a reverse-mode mitmdump listener,
+  exposing a cage service to the host through the inspector chain. Apple's
+  `container` runtime has no host-port-publishing equivalent (no
+  `--publish`; it uses VMNET_SHARED_MODE NAT and reaches containers by their
+  vmnet-assigned IP), so the entry was silently dropped. `validate_config`
+  now surfaces it alongside the other apple-container parity warnings so
+  operators stop being surprised by an inbound service that never becomes
+  reachable on the host. (Tracked in #120.)
+
 ### Added
 
 - **`cage secret set`/`list`/`rm` now work on the apple-container

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -1007,6 +1007,21 @@ def validate_config(config: Config) -> list[str]:
             ("container.nested_containers", bool(config.container.nested_containers),
              "nested container runtime (no podman-in-podman shim available in "
              "the Apple microVM)"),
+            # Inbound published ports. On the container/vm backends these
+            # become egress `PublishPort=host:host_port:container_port`
+            # entries plus reverse-mode mitmdump listeners, exposing a cage
+            # service to the host through the inspector chain. Apple's
+            # `container` runtime has no host-port-publishing equivalent —
+            # it uses VMNET_SHARED_MODE NAT and reaches containers by their
+            # vmnet-assigned IP, not via host port forwarding (verified
+            # against apple/container; see backends/apple_container.py
+            # NonisolatedInterfaceStrategy note). So a `container.ports:`
+            # entry is silently dropped here. Warn so operators stop being
+            # surprised by an inbound service that never becomes reachable.
+            ("container.ports", bool(config.container.ports),
+             "inbound published ports — Apple's runtime has no host "
+             "port-publishing (no `--publish`); reach the cage by its "
+             "vmnet IP instead"),
             # Scaffold default `userns: "keep-id"` exists for the container
             # backend's rootless-podman uid mapping. On apple-container,
             # the supervisor's drop-to-uid-1000 already achieves the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1779,6 +1779,35 @@ class TestAppleContainerSilentDrops:
         _, warnings = self._validate_under_apple(str(p))
         assert any("container.named_volumes" in w for w in warnings), warnings
 
+    def test_inbound_ports_warns(self, tmp_path):
+        """`container.ports` (inbound published ports) is silently dropped on
+        apple-container: Apple's runtime has no host port-publishing
+        (`--publish`/`PublishPort` equivalent). Warn so operators stop
+        expecting an inbound service to become reachable on the host."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: ac-demo
+            isolation: apple-container
+            container:
+              image: localhost/test:latest
+              ports:
+                - "127.0.0.1:8000:3000"
+        """))
+        _, warnings = self._validate_under_apple(str(p))
+        assert any("container.ports" in w for w in warnings), warnings
+
+    def test_no_inbound_ports_no_warn(self, tmp_path):
+        """No `container.ports:` → no inbound-ports warning (default cage)."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: ac-demo
+            isolation: apple-container
+            container:
+              image: localhost/test:latest
+        """))
+        _, warnings = self._validate_under_apple(str(p))
+        assert not any("container.ports" in w for w in warnings), warnings
+
     def test_tmpfs_non_default_warns(self, tmp_path):
         """Multi-entry tmpfs or non-/tmp target → operator intent that
         apple-container can't honor → warn."""


### PR DESCRIPTION
## Summary

This was scoped as "wire inbound published ports (`config.container.ports`) on apple-container, routed through the egress's mitmproxy reverse mode (same as container/vm)." On investigation, the feature **cannot be implemented cleanly** on Apple's runtime — so this PR ships the operator-facing consolation: a parity warning instead of a silent drop.

## Why inbound publishing is blocked on apple-container

Two independent hard blockers:

1. **No host port-publishing primitive.** Apple's `container` CLI has no `--publish`/`-p` flag and no `PublishPort=` equivalent. The runtime uses `VMNET_SHARED_MODE` NAT and exposes each container directly by its vmnet-assigned IP — there is no host→container port-forward mechanism. (This is already verified against `apple/container` source in `backends/apple_container.py:872` — the `NonisolatedInterfaceStrategy` note documenting why even inter-microVM UDP is NAT'd.) The container/vm path relies on `PublishPort=host:host_port:container_port` in `egress.container.j2:98`; there is nothing to translate that into on Apple.

2. **The cage-IP ordering problem.** Even if host publishing existed, the egress's reverse-mode mitmdump needs `AGENTCAGE_CAGE_IP` (`supervisor-egress.sh:291`), but the egress starts **before** the cage and the cage's IP is dynamically assigned (read post-start via `_container_ip` polling). The options were: (a) restart/signal the egress's mitmdump after the cage is up — fragile, adds a second egress boot to the hot path; or (b) static IPs — but Apple static IPs are documented-fragile ("requested static ip X not in any subnet on network Y-net"). Neither is sound.

A correct design would require **upstream Apple `container` support for host port publishing** (or a host-side `pf` rule installed by agentcage with elevated privileges, which is a much larger v0.23 networking effort, already noted in the module docstring). Faking it would leave operators with an inbound service that silently never becomes reachable.

## What this PR does

`validate_config` now warns when `container.ports` is set under `isolation: apple-container`, joining the existing parity-warning batch (`named_volumes`, `tmpfs`, capabilities, etc.) at `config.py`. The message tells the operator the entry has no effect and to reach the cage by its vmnet IP instead. Tracked in #120.

## Tests

`tests/test_config.py`: `test_inbound_ports_warns` (warning fires when `container.ports` set) and `test_no_inbound_ports_no_warn` (no false positive on a default cage). Full suite: **1605 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)