### PR TITLE
fix(apple-container): workspace mount survives restart (bake volume paths at create time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **apple-container workspace mount no longer disappears on restart.** The
+  scaffold workspace bind is `${PROJECT_DIR}:/workspace`, and `PROJECT_DIR`
+  only exists in the environment of the `agentcage run` process. The backend
+  persisted that literal string into `metadata.json` and expanded it lazily
+  at every `start()` — so any start outside the original run process (launchd
+  autostart, reboot, `cage start`, `cage restart`) had no `PROJECT_DIR` set,
+  tripped `_user_volume_argv`'s unresolved-`$` guard, and silently dropped the
+  workspace (cage came up with no `/workspace`). `generate_units` now expands
+  and `$HOME`-validates volume host paths at create/update time and bakes the
+  absolute path into the unit JSON — matching how the container/vm backends
+  resolve volumes at generate time (`quadlets.py`). The mount now survives
+  restarts; `_user_volume_argv` at `start()` is an idempotent revalidation
+  rather than a re-expansion. Volumes that can't be resolved (unset variable)
+  or escape `$HOME` are dropped at create time with a warning instead of
+  failing silently later.
+
 ### Added
 
 - **`cage secret set`/`list`/`rm` now work on the apple-container

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -615,12 +615,24 @@ class AppleContainerBackend:
                 "relay_secret_envs": relay_secret_envs,
                 "autostart": bool(getattr(config, "apple_container_autostart", False)),
                 # User-defined host bind mounts. Apple's `container run`
-                # accepts `--volume host:cage[:mode]` just like podman, so
-                # we pass each through verbatim at start() time. Persisted
-                # in the unit JSON (rather than re-read from cage.yaml at
-                # start) so a `cage update` controls the surface, matching
-                # how the rest of the runtime config flows.
-                "volumes": list(config.container.volumes),
+                # accepts `--volume host:cage[:mode]` just like podman.
+                # Expand + validate the host path HERE (at generate_units
+                # / create-update time) and persist the resolved ABSOLUTE
+                # path, NOT the raw cage.yaml string. This is load-bearing:
+                # the scaffold workspace mount is `${PROJECT_DIR}:/workspace`
+                # and PROJECT_DIR only lives in the environment of the
+                # `agentcage run` process. If we persisted the literal
+                # `${PROJECT_DIR}` and expanded it lazily in start() (as we
+                # did pre-fix), any start() outside that process — launchd
+                # autostart, reboot, `cage start`, `cage restart` — has no
+                # PROJECT_DIR set, so _user_volume_argv's unresolved-`$`
+                # guard silently dropped the workspace. Baking the absolute
+                # path at create time (matching quadlets.py's
+                # expand-at-generate semantics for container/vm) makes the
+                # mount survive restarts. _user_volume_argv is idempotent on
+                # already-absolute paths, so start() re-running it is a safe
+                # revalidation, not a re-expansion.
+                "volumes": self._user_volume_argv(config.container.volumes),
                 # User-defined ``container.env:`` entries. Apple's
                 # `container run` accepts `-e KEY=VAL` like podman. The
                 # container backend wires these via quadlets.py:338;
@@ -906,7 +918,12 @@ class AppleContainerBackend:
             if not ph:
                 continue
             cage_argv += ["-e", f"{env_name}={ph}"]
-        # User-defined bind mounts (verbatim, after $HOME-containment check).
+        # User-defined bind mounts. meta["volumes"] already holds ABSOLUTE,
+        # expanded, $HOME-validated entries (baked by generate_units at
+        # create/update time — see the "volumes" comment there). Re-running
+        # _user_volume_argv here is an idempotent revalidation, NOT a
+        # re-expansion: absolute paths have no `~`/`$VAR` left to resolve, so
+        # this no longer depends on PROJECT_DIR being in the start() env.
         for vol_entry in self._user_volume_argv(meta.get("volumes") or []):
             cage_argv += ["--volume", vol_entry]
         # Apple's --cpus / --memory normalization (uppercase suffix, ceil

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1744,8 +1744,14 @@ def test_user_volume_argv_accepts_home_relative_paths(tmp_path, monkeypatch):
 def test_unit_json_persists_user_volumes(tmp_path, monkeypatch):
     """`generate_units` must include `volumes` in the unit JSON so a
     subsequent `start()` (which only reads the unit JSON, not the
-    cage.yaml) can re-emit them as --volume args. Was missing pre-fix."""
+    cage.yaml) can re-emit them as --volume args. The persisted value is
+    the EXPANDED, absolute host path — `~`/`$VAR` are resolved at
+    create/update time, not lazily at start() — so the mount survives a
+    restart that has no PROJECT_DIR/HOME-dependent env (see
+    test_unit_json_bakes_env_var_so_mount_survives_restart)."""
     from agentcage.config import Config, ContainerConfig
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "foo").mkdir()
     cfg = Config(
         name="demo",
         isolation="apple-container",
@@ -1757,7 +1763,65 @@ def test_unit_json_persists_user_volumes(tmp_path, monkeypatch):
     backend = AppleContainerBackend()
     out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
     parsed = json.loads(out["demo.json"])
-    assert parsed["volumes"] == ["~/foo:/workspace:rw"]
+    # `~` expanded to the absolute home path, not persisted verbatim.
+    assert parsed["volumes"] == [f"{tmp_path}/foo:/workspace:rw"]
+
+
+def test_unit_json_bakes_env_var_so_mount_survives_restart(tmp_path, monkeypatch):
+    """Regression: the scaffold workspace mount is `${PROJECT_DIR}:/workspace`
+    and PROJECT_DIR only exists in the `agentcage run` process env. Pre-fix,
+    generate_units persisted the literal `${PROJECT_DIR}` and start() expanded
+    it lazily — so a restart/launchd-autostart/reboot (no PROJECT_DIR set)
+    silently dropped the workspace via _user_volume_argv's unresolved-`$`
+    guard. generate_units must bake the ABSOLUTE path so it survives a
+    PROJECT_DIR-less start()."""
+    from agentcage.config import Config, ContainerConfig
+    monkeypatch.setenv("HOME", str(tmp_path))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.setenv("PROJECT_DIR", str(proj))
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(
+            image="localhost/test:latest",
+            volumes=["${PROJECT_DIR}:/workspace:rw"],
+        ),
+    )
+    backend = AppleContainerBackend()
+    out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
+    baked = json.loads(out["demo.json"])["volumes"]
+    # Baked to the absolute project path — no literal `${PROJECT_DIR}` left.
+    assert baked == [f"{proj}:/workspace:rw"]
+    assert not any("$" in v for v in baked)
+    # Simulate a restart: PROJECT_DIR no longer in the environment. start()
+    # re-runs _user_volume_argv on the baked metadata; the mount must remain.
+    monkeypatch.delenv("PROJECT_DIR")
+    assert AppleContainerBackend._user_volume_argv(baked) == [f"{proj}:/workspace:rw"]
+
+
+def test_generate_units_drops_unresolvable_volume_at_create_time(tmp_path, monkeypatch):
+    """Validation gate: a volume whose host path can't be resolved (unset
+    var) or escapes $HOME is dropped at generate_units time (with a stderr
+    warning from _user_volume_argv) rather than silently failing later. The
+    unit JSON only ever carries mountable, $HOME-contained absolute paths."""
+    from agentcage.config import Config, ContainerConfig
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("AGENTCAGE_NOPE", raising=False)
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(
+            image="localhost/test:latest",
+            volumes=[
+                "${AGENTCAGE_NOPE}/x:/cage:rw",  # unresolved var → dropped
+                "/etc:/cage-etc:ro",             # outside $HOME → dropped
+            ],
+        ),
+    )
+    backend = AppleContainerBackend()
+    out = backend.generate_units(cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo")
+    assert json.loads(out["demo.json"])["volumes"] == []
 
 
 def test_start_passes_user_env_as_container_run_args(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The apple-container workspace mount **silently disappears on any restart** — launchd autostart at login, reboot, `cage start`, or `cage restart`. This fixes it.

### Root cause

The scaffold workspace bind is `${PROJECT_DIR}:/workspace:rw`, and `PROJECT_DIR` is only set in the environment of the `agentcage run` process (`run.py:351`). `generate_units` persisted the **literal** `${PROJECT_DIR}` string into `metadata.json`, and `start()` expanded it **lazily** at every boot via `_user_volume_argv` (`os.path.expandvars`).

So the first `agentcage run` mounts the workspace fine — but any later `start()` runs in a process with no `PROJECT_DIR`, the variable stays unexpanded, `_user_volume_argv`'s unresolved-`$` guard skips it, and the cage comes up with no `/workspace` (only a stderr warning). The container/vm backends don't have this bug: `quadlets.py` expands volume paths at **generate** time and bakes the absolute path into the quadlet.

### Fix

`generate_units` now expands + `$HOME`-validates volume host paths at create/update time (when `PROJECT_DIR` is present) and persists the resolved **absolute** path into the unit JSON — matching the container/vm semantics. `_user_volume_argv` is idempotent on absolute paths, so `start()` re-running it is a safe **revalidation**, not a re-expansion, and no longer depends on the ambient `start()` environment.

- `src/agentcage/backends/apple_container.py` `generate_units()` — persist `self._user_volume_argv(config.container.volumes)` (expanded/validated/absolute) instead of `list(config.container.volumes)` (literal).
- `start()` volume site — comment clarifying metadata now holds baked paths; behavior unchanged.

### Validation gate (side benefit)

Volumes that can't be resolved (unset variable) or escape `$HOME` are now dropped at **create time** with a warning, instead of failing silently at every start.

### Scope note

This targets caveat #1 (the actual bug). Caveats #2 (`$HOME`-containment) and #3 (rw mount → host write at uid 1000 under apple-container's identity uid_map, CTF F4) are **intentional security behaviors** and are left in place — they already warn the operator.

## Testing

- New `test_unit_json_bakes_env_var_so_mount_survives_restart` — regression: a baked `${PROJECT_DIR}` resolves to an absolute path and survives a `PROJECT_DIR`-less `start()`.
- New `test_generate_units_drops_unresolvable_volume_at_create_time` — the gate: unset-var / out-of-home volumes are dropped at generate time.
- Updated `test_unit_json_persists_user_volumes` — now asserts the expanded absolute path (was asserting the literal buggy value).
- Full suite: **1605 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)