### PR TITLE
fix(apple-container): check local image store before pulling; never pull localhost/ refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **apple-container no longer attempts a doomed registry pull of local
+  images.** `build_artifacts` pulled `container.image` unconditionally,
+  before checking the local image store — so every scaffold `cage create`
+  ran `container image pull localhost/agentcage-scaffold-<name>:latest`,
+  which can never resolve in a registry. That burned a multi-second
+  connection timeout and printed an alarming `POSIXErrorCode 61 / Connection
+  refused` on the happy path (it only succeeded via a local fallback), and a
+  mistyped/unbuilt `localhost/` tag surfaced as that same cryptic error
+  instead of a clear cause. Now the local store is checked first: a present
+  image is used as-is (no pull), a missing `localhost/` ref fails fast with
+  an actionable message (it's never pulled), and only a genuinely-remote,
+  genuinely-absent image is pulled from a registry.
+
 - **apple-container workspace mount no longer disappears on restart.** The
   scaffold workspace bind is `${PROJECT_DIR}:/workspace`, and `PROJECT_DIR`
   only exists in the environment of the `agentcage run` process. The backend

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -403,19 +403,46 @@ class AppleContainerBackend:
         if scaffold_name:
             ac_scaffold.build_scaffold_images(scaffold_name, quiet=quiet)
 
-        # 3. Pull the user image (no-op if it was just built by the
-        # scaffold step above, or if it's already local).
-        if not quiet:
-            click.echo(f"Ensuring user image is available: {user_image}")
-        pull_result = ac_cli.run(
-            ["image", "pull", user_image],
-            check=False,
-            capture_output=False,
-        )
-        if pull_result.returncode != 0 and not ac_cli.image_inspect(user_image):
+        # 3. Ensure the user image is available locally — checking the local
+        # store FIRST, before any registry pull. This matters because:
+        #   * The scaffold step above (and any Containerfile build) produces a
+        #     `localhost/...` image that can NEVER resolve in a registry. The
+        #     old code pulled unconditionally, so every scaffold cage create
+        #     burned a multi-second `container image pull` that was guaranteed
+        #     to fail (POSIXErrorCode 61 / "Connection refused" when offline)
+        #     and only "worked" via the local fallback below — wasting time
+        #     and printing an alarming error on the happy path.
+        #   * A mistyped or unbuilt `localhost/` tag previously surfaced as that
+        #     same cryptic pull error instead of a clear "not built" message.
+        # So: use the local image if present; pull only a genuinely-remote ref
+        # that is genuinely absent; never try to pull a local-only `localhost/`
+        # ref (fail fast with an actionable message instead).
+        if ac_cli.image_inspect(user_image):
+            if not quiet:
+                click.echo(f"Using local image: {user_image}")
+        elif user_image.startswith("localhost/"):
             raise RuntimeError(
-                f"failed to pull user image {user_image!r} and it is not built locally"
+                f"image {user_image!r} is a local-only ('localhost/') reference "
+                f"but is not present in the local image store. It is never "
+                f"pulled from a registry. If it should be built from a "
+                f"Containerfile, set 'container.build.containerfile' (and, for a "
+                f"scaffold, ensure 'container.image' matches the tag the build "
+                f"produces, e.g. 'localhost/agentcage-scaffold-<name>:latest'); "
+                f"otherwise build/load it first with "
+                f"'container build -t {user_image} ...'."
             )
+        else:
+            if not quiet:
+                click.echo(f"Pulling user image: {user_image}")
+            pull_result = ac_cli.run(
+                ["image", "pull", user_image],
+                check=False,
+                capture_output=False,
+            )
+            if pull_result.returncode != 0 and not ac_cli.image_inspect(user_image):
+                raise RuntimeError(
+                    f"failed to pull user image {user_image!r} and it is not built locally"
+                )
 
         # 4. Resolve the cage's CMD. Precedence: cage.yaml `container.command:`
         # wins (explicit intent, portable across backends); fall back to the

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1376,8 +1376,9 @@ def test_build_artifacts_prefers_cage_yaml_command():
     assert build_mock.call_count == 1
     kwargs = build_mock.call_args.kwargs
     assert kwargs["user_cmd"] == ["sh", "-c", "exec sleep infinity"]
-    # `image pull` must still have run.
-    assert any(
+    # The image is already present locally (image_inspect truthy), so we must
+    # NOT pull it — pulling an already-local image is wasted, doomed work.
+    assert not any(
         call.args and call.args[0][:2] == ["image", "pull"]
         for call in run_mock.call_args_list
     )
@@ -1400,15 +1401,14 @@ def test_build_artifacts_falls_back_to_user_cmd_when_unset():
     assert build_mock.call_args.kwargs["user_cmd"] == ["/bin/sh"]
 
 
-def test_build_artifacts_orders_scaffold_then_pull_then_wrapper():
-    """Scaffold images must build BEFORE pull, and pull BEFORE wrapper build.
-
-    The wrapper's `FROM <user_image>` references a scaffold-produced tag, so
-    flipping these would leave the wrapper build referencing a tag that
-    doesn't yet exist.
+def test_build_artifacts_orders_scaffold_before_wrapper_no_pull_for_local():
+    """Scaffold images build BEFORE the wrapper (the wrapper's
+    `FROM <user_image>` references the scaffold-produced tag), and a
+    locally-present `localhost/` scaffold image is NOT pulled — pulling a
+    local-only ref is guaranteed to fail and is pure wasted work.
     """
     cfg = Config(name="t", isolation="apple-container")
-    cfg.container.image = "localhost/agentcage-ubuntu:latest"
+    cfg.container.image = "localhost/agentcage-scaffold-ubuntu:latest"
     cfg.scaffold = "ubuntu"
 
     calls: list[str] = []
@@ -1432,10 +1432,69 @@ def test_build_artifacts_orders_scaffold_then_pull_then_wrapper():
          patch.object(ac_wrapper, "build_wrapper", side_effect=build_wrapper_side_effect):
         AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
 
-    # Only the first occurrence of each matters; pull can be called more than
-    # once depending on internal retries, but the ordering invariant is fixed.
-    first_idx = {step: calls.index(step) for step in ("scaffold", "pull", "wrapper")}
-    assert first_idx["scaffold"] < first_idx["pull"] < first_idx["wrapper"]
+    assert "pull" not in calls  # local image present → never pulled
+    assert calls.index("scaffold") < calls.index("wrapper")
+
+
+def test_build_artifacts_localhost_image_missing_raises_clear_error():
+    """A `localhost/` image that isn't in the local store must fail fast with
+    an actionable message and must NOT attempt a (doomed) registry pull.
+
+    Regression: a mistyped/unbuilt scaffold tag previously fell through to
+    `container image pull localhost/...`, which can never resolve in a
+    registry — surfacing as a cryptic 'Connection refused' after a multi-
+    second timeout instead of 'this local image was not built'.
+    """
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/agentcage-scaffold-alpine-typo:latest"
+
+    with patch.object(ac_cli, "run", side_effect=_ok_run) as run_mock, \
+         patch.object(ac_cli, "image_inspect", return_value=None), \
+         patch.object(ac_wrapper, "build_wrapper", new=MagicMock()):
+        with pytest.raises(RuntimeError, match="local-only.*not present|not present.*local"):
+            AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
+
+    # No registry pull was attempted for the local-only ref.
+    assert not any(
+        call.args and call.args[0][:2] == ["image", "pull"]
+        for call in run_mock.call_args_list
+    )
+
+
+def test_build_artifacts_pulls_remote_image_when_absent():
+    """A genuinely-remote image that is absent locally IS pulled (the only
+    case where a registry pull is warranted)."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "docker.io/library/debian:stable-slim"
+    cfg.container.command = ["sleep", "infinity"]
+
+    with patch.object(ac_cli, "run", side_effect=_ok_run) as run_mock, \
+         patch.object(ac_cli, "image_inspect", return_value=None), \
+         patch.object(ac_wrapper, "build_wrapper", return_value="img"):
+        AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
+
+    assert any(
+        call.args and call.args[0][:3]
+        == ["image", "pull", "docker.io/library/debian:stable-slim"]
+        for call in run_mock.call_args_list
+    )
+
+
+def test_build_artifacts_remote_pull_fails_and_absent_raises():
+    """A remote image whose pull fails AND that isn't local → clear error."""
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "docker.io/library/does-not-exist:latest"
+    cfg.container.command = ["sleep", "infinity"]
+
+    def fail_pull(argv, **kwargs):  # noqa: ARG001
+        rc = 1 if argv[:2] == ["image", "pull"] else 0
+        return type("CP", (), {"returncode": rc, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "run", side_effect=fail_pull), \
+         patch.object(ac_cli, "image_inspect", return_value=None), \
+         patch.object(ac_wrapper, "build_wrapper", new=MagicMock()):
+        with pytest.raises(RuntimeError, match="failed to pull user image"):
+            AppleContainerBackend().build_artifacts(cfg, "deploy", quiet=True)
 
 
 def test_build_artifacts_no_cmd_anywhere_raises_helpful_error():


### PR DESCRIPTION
## Summary

The apple-container backend's `build_artifacts` pulled `container.image` **unconditionally**, *before* checking whether the image was already in the local store. For a scaffold cage the image is `localhost/agentcage-scaffold-<name>:latest` — a local-only ref that can **never** resolve in a registry — so every `cage create` ran a doomed `container image pull`:

- it burned a multi-second connection timeout (~40s) and printed an alarming `Error: POSIXErrorCode(rawValue: 61): Connection refused` **on the happy path**, only succeeding via the local fallback;
- a mistyped or unbuilt `localhost/` tag surfaced as that same cryptic pull error (`Connection refused` → `failed to pull ... and it is not built locally`) instead of a clear cause.

(Both observed live while verifying the apple-container PRs on real hardware — a wrong `container.image` tag produced the connection-refused failure, and even correct scaffold cages wasted ~40s on the doomed pull.)

## Fix

Reorder step 3 of `build_artifacts` to check the local store first (`src/agentcage/backends/apple_container.py`):

1. **present locally** → use as-is, no pull (the common scaffold case — eliminates the ~40s waste + scary output on every create);
2. **missing `localhost/` ref** → fail fast with an actionable message (it's local-only by convention; never pulled);
3. **genuinely-remote, genuinely-absent** → pull from the registry, then re-check, as before.

## Testing

- New: `skips_pull...no_pull_for_local`, `localhost_image_missing_raises_clear_error` (asserts **no** pull attempted), `pulls_remote_image_when_absent`, `remote_pull_fails_and_absent_raises`.
- Updated the command-precedence + ordering tests that previously asserted the old unconditional-pull behavior.
- Full suite: **1615 passed**.

Note: `--pull` (force re-pull) is still not plumbed into apple-container's `build_artifacts` — out of scope here; this PR only stops the *doomed/unwanted* pulls. Filing/mentioning separately if you want force-refresh support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)