### PR TITLE
fix(apple-container): live-reload domain changes (SIGHUP) instead of rebuild+restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **apple-container `domain add`/`rm` no longer rebuilds the image and
+  restarts the cage.** A domain-allowlist change rebuilt the wrapper image
+  and did a full cage stop→start — which killed any interactive session
+  running in the cage (e.g. `agentcage run`) on every edit. The egress
+  allowlist is no longer baked into the image; it's host-rendered and
+  bind-mounted into the egress microVM, so the backend now applies a domain
+  change exactly like the container/vm backends: re-render the bind-mounted
+  `dns-allowlist.conf`/`proxy-config.yaml` in place, validate with
+  `dnsmasq --test`, and SIGHUP dnsmasq (the mitmproxy addon hot-reloads
+  `proxy-config.yaml` via its mtime poll). The cage microVM is untouched, so
+  sessions survive. A malformed allowlist is reverted instead of signalled in.
+
 ## [0.22.13] - 2026-05-29
 
 ### Removed

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -570,6 +570,104 @@ class AppleContainerBackend:
                 "\n".join(lines) + ("\n" if lines else "")
             )
 
+    def reload_domains(self, config: Config, name: str) -> None:
+        """Apply a domain-allowlist change to a RUNNING egress in place —
+        no cage rebuild, no cage restart.
+
+        The egress microVM bind-mounts the three rendered config files
+        read-only from the host egress-config dir (see ``start()``):
+        ``dns-allowlist.conf`` / ``dnsmasq.conf`` →
+        ``/etc/agentcage/{dns-allowlist,dnsmasq}.conf`` and
+        ``proxy-config.yaml`` → ``/etc/agentcage/config.yaml``.
+        ``_render_egress_config`` rewrites those files **in place** (same
+        inode, via ``shutil.copy2`` / ``write_text`` truncate-in-place),
+        so virtiofs surfaces the new bytes inside the running egress
+        without re-creating the mount. We then:
+
+          1. Validate the rewritten allowlist inside the egress
+             (``dnsmasq --test``); on failure revert the file and raise,
+             so a malformed allowlist can't silently break DNS.
+          2. SIGHUP both dnsmasq instances so they re-read the
+             ``--servers-file`` allowlist:
+               * the egress dnsmasq (pidfile ``/home/acdns/dnsmasq.pid``,
+                 run under ``setpriv --reuid=acdns`` — signal the pid, not
+                 ``pkill``);
+               * the **cage-local** dnsmasq (pidfile
+                 ``/run/agentcage/dnsmasq.pid``) — the load-bearing one,
+                 since the cage workload resolves via 127.0.0.1:53 served
+                 by that local dnsmasq (vmnet drops inter-microVM UDP, so
+                 the cage can't use the egress dnsmasq; see cage-init.sh
+                 stage A'). Best-effort: skipped if the cage has no
+                 dnsmasq.
+          3. Leave ``proxy-config.yaml`` to the mitmproxy addon, which
+             polls its mtime per request and hot-reloads in place
+             (``data/proxy/addon.py``) — no signal needed.
+
+        The cage microVM is never touched, so an interactive
+        ``agentcage run`` session survives the domain change. Mirrors the
+        container/vm SIGHUP fast path (see cli._update_dns_quadlet); the
+        only difference is the ``container exec`` wrapper vs ``podman
+        exec`` / ``limactl shell``.
+        """
+        egress_dir = self.egress_config_dir(name)
+        allow_dest = egress_dir / "dns-allowlist.conf"
+        previous = allow_dest.read_text() if allow_dest.is_file() else None
+
+        # Rewrite the bind-mounted config files in place from the (already
+        # updated) stored cage.yaml + live config object.
+        self._render_egress_config(config, name)
+
+        # If the egress isn't up, the rewrite is enough — the next start()
+        # reads the new files. Nothing to signal.
+        if not self.is_running(name, "egress"):
+            return
+
+        container = f"{name}-egress"
+
+        # 1. Validate the new allowlist inside the egress before signaling.
+        test = ac_cli.run(
+            ["exec", container, "dnsmasq", "--test",
+             "--servers-file=/etc/agentcage/dns-allowlist.conf"],
+            check=False,
+        )
+        if test.returncode != 0:
+            if previous is not None:
+                allow_dest.write_text(previous)
+            raise RuntimeError(
+                "dnsmasq rejected the new allowlist; reverted it and left "
+                "the egress serving the previous config. Details:\n"
+                f"{(test.stderr or test.stdout or '').strip()}"
+            )
+
+        # 2. SIGHUP the egress dnsmasq via its pidfile so it re-reads the
+        # allowlist.
+        ac_cli.run(
+            ["exec", container, "sh", "-c",
+             'kill -HUP "$(cat /home/acdns/dnsmasq.pid)"'],
+            check=False,
+        )
+
+        # 3. SIGHUP the CAGE-local dnsmasq too — this is the load-bearing
+        # one. The cage workload resolves via 127.0.0.1:53 served by a
+        # dnsmasq started in the cage by cage-init.sh stage A' (macOS vmnet
+        # drops inter-microVM UDP, so the cage can't query the egress
+        # dnsmasq). It reads the SAME bind-mounted allowlist (pidfile
+        # /run/agentcage/dnsmasq.pid). Without this SIGHUP the new domain
+        # lands in the file but the cage keeps resolving the old set.
+        # Best-effort: the cage dnsmasq is itself best-effort (skipped on
+        # bases without dnsmasq, cage-init.sh stage A'), so guard on the
+        # pidfile and never fail the reload.
+        if self.is_running(name, "cage"):
+            ac_cli.run(
+                ["exec", name, "sh", "-c",
+                 'p=/run/agentcage/dnsmasq.pid; '
+                 '[ -f "$p" ] && kill -HUP "$(cat "$p")" || true'],
+                check=False,
+            )
+
+        # 4. proxy-config.yaml is hot-reloaded by the mitmproxy addon's
+        # mtime poll — no signal required.
+
     def generate_units(
         self,
         config: Config,

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -3464,12 +3464,16 @@ def _update_dns_quadlet(cfg) -> None:
     via ``inst.exec`` (base64 over the limactl ssh channel) before the
     SIGHUP.
 
-    Apple-container backend:
-      - Allowlist is baked into the wrapper image at build time, so a
-        domain change requires rebuilding the image and restarting the
-        cage. The observability bridge (see #120) is expected to add a
-        bind-mounted allowlist path on apple-container, at which point
-        this branch can collapse.
+    Apple-container backend (live-reload, no cage restart):
+      - The egress microVM bind-mounts the rendered ``dns-allowlist.conf``
+        / ``dnsmasq.conf`` / ``proxy-config.yaml`` read-only from the host
+        egress-config dir, so a domain change is applied exactly like
+        container/vm: re-render the files in place, validate, and SIGHUP
+        dnsmasq in the ``<name>-egress`` microVM (the mitmproxy addon
+        hot-reloads proxy-config.yaml via its mtime poll). The cage VM is
+        untouched. See ``AppleContainerBackend.reload_domains``. (Pre-this
+        path the allowlist was baked into the wrapper image and a domain
+        change forced an image rebuild + cage restart.)
 
     Pre-flight validation: before publishing the rewritten allowlist we
     run ``dnsmasq --test --servers-file=<allowlist>`` inside the egress
@@ -3483,14 +3487,10 @@ def _update_dns_quadlet(cfg) -> None:
     name = cfg.name
 
     if _is_apple_container(cfg):
-        # Image-bake path — keep the rebuild semantics.
-        state.save_dns_allowlist(name)
-        was_running = backend.is_running(name, "cage")
-        if was_running:
-            backend.stop(name)
-        backend.build_artifacts(cfg, name, quiet=True)
-        if was_running:
-            backend.start(name, quiet=True)
+        # Live-reload: re-render the bind-mounted egress config in place,
+        # validate, and SIGHUP dnsmasq — no cage rebuild/restart, so an
+        # interactive session in the cage survives the domain change.
+        backend.reload_domains(cfg, name)
         return
 
     # Container + VM: write the new file, validate inside the egress

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -3804,3 +3804,119 @@ def test_egress_supervisor_keeps_lazy_connection_strategy():
         / "src" / "agentcage" / "data" / "containers" / "supervisor-egress.sh"
     ).read_text()
     assert "connection_strategy=lazy" in egress_supervisor
+
+
+# ---------------------------------------------------------------------------
+# reload_domains: live SIGHUP allowlist reload (no cage rebuild/restart)
+# ---------------------------------------------------------------------------
+
+
+def test_reload_domains_sighups_dnsmasq_without_restart(tmp_path, monkeypatch):
+    """A domain change on a running apple-container cage re-renders the
+    bind-mounted egress config in place and SIGHUPs dnsmasq — it must NOT
+    rebuild the image or stop/start the cage (so an interactive session
+    survives)."""
+    backend = AppleContainerBackend()
+    egress_dir = tmp_path / "egress"
+    egress_dir.mkdir()
+    allow = egress_dir / "dns-allowlist.conf"
+    allow.write_text("server=/old.example/1.1.1.1\n")
+
+    monkeypatch.setattr(backend, "egress_config_dir", lambda name: egress_dir)
+    monkeypatch.setattr(
+        backend, "_render_egress_config",
+        lambda cfg, name: allow.write_text("server=/new.example/1.1.1.1\n"),
+    )
+    monkeypatch.setattr(backend, "is_running", lambda name, svc: True)
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    cfg = Config(name="demo", isolation="apple-container")
+    cfg.container.image = "x"
+    with patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(backend, "stop") as stop_mock, \
+         patch.object(backend, "build_artifacts") as build_mock, \
+         patch.object(backend, "start") as start_mock:
+        backend.reload_domains(cfg, "demo")
+
+    # Validated the allowlist inside the egress, then SIGHUP'd dnsmasq in
+    # BOTH the egress and the cage (the cage-local resolver is the one the
+    # workload actually queries).
+    assert any(
+        a[:2] == ["exec", "demo-egress"] and "dnsmasq" in a and "--test" in a
+        for a in calls
+    )
+    assert any(
+        a[:2] == ["exec", "demo-egress"] and "kill -HUP" in " ".join(a)
+        for a in calls
+    )
+    assert any(
+        a[:2] == ["exec", "demo"] and "/run/agentcage/dnsmasq.pid" in " ".join(a)
+        for a in calls
+    )
+    # No rebuild, no cage restart.
+    stop_mock.assert_not_called()
+    build_mock.assert_not_called()
+    start_mock.assert_not_called()
+
+
+def test_reload_domains_reverts_on_invalid_allowlist(tmp_path, monkeypatch):
+    """If `dnsmasq --test` rejects the rewritten allowlist, revert the file
+    and raise — never SIGHUP a broken config (which dnsmasq would ignore,
+    silently serving stale rules)."""
+    backend = AppleContainerBackend()
+    egress_dir = tmp_path / "egress"
+    egress_dir.mkdir()
+    allow = egress_dir / "dns-allowlist.conf"
+    allow.write_text("server=/old.example/1.1.1.1\n")
+
+    monkeypatch.setattr(backend, "egress_config_dir", lambda name: egress_dir)
+    monkeypatch.setattr(
+        backend, "_render_egress_config",
+        lambda cfg, name: allow.write_text("this is not valid dnsmasq syntax\n"),
+    )
+    monkeypatch.setattr(backend, "is_running", lambda name, svc: True)
+
+    sighup_seen = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        if "--test" in argv:
+            return type("CP", (), {"returncode": 2, "stdout": "", "stderr": "bad allowlist"})()
+        if "kill" in " ".join(argv):
+            sighup_seen.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    cfg = Config(name="demo", isolation="apple-container")
+    with patch.object(ac_cli, "run", side_effect=fake_run):
+        with pytest.raises(RuntimeError, match="rejected the new allowlist"):
+            backend.reload_domains(cfg, "demo")
+
+    # File reverted to its previous contents; no SIGHUP sent.
+    assert allow.read_text() == "server=/old.example/1.1.1.1\n"
+    assert sighup_seen == []
+
+
+def test_reload_domains_no_signal_when_egress_stopped(tmp_path, monkeypatch):
+    """When the egress isn't running, re-rendering the files is enough — the
+    next start() reads them; we must not exec into a stopped microVM."""
+    backend = AppleContainerBackend()
+    egress_dir = tmp_path / "egress"
+    egress_dir.mkdir()
+    (egress_dir / "dns-allowlist.conf").write_text("server=/old.example/1.1.1.1\n")
+
+    rendered: list[int] = []
+    monkeypatch.setattr(backend, "egress_config_dir", lambda name: egress_dir)
+    monkeypatch.setattr(backend, "_render_egress_config",
+                        lambda cfg, name: rendered.append(1))
+    monkeypatch.setattr(backend, "is_running", lambda name, svc: False)
+
+    cfg = Config(name="demo", isolation="apple-container")
+    with patch.object(ac_cli, "run") as run_mock:
+        backend.reload_domains(cfg, "demo")
+
+    assert rendered == [1]          # re-rendered the files
+    run_mock.assert_not_called()    # but did not exec into the stopped egress

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -744,26 +744,27 @@ class TestPendingSecretsHelpers:
             assert _load_apple_pending_secrets("demo") == []
 
 
-# ── domain add/rm: auto-rebuild wrapper on apple-container ──
+# ── domain add/rm: live SIGHUP reload on apple-container (no restart) ──
 
 
 class TestDomainCommandsAppleContainer:
-    """REGRESSION: `agentcage domain add/rm` on apple-container must rebuild
-    the wrapper image (which has the dnsmasq + mitmproxy allowlists baked in
-    at build time) before restarting the cage. Pre-fix, the command saved
-    cage.yaml + restarted the cage — but the restart re-executed the OLD
-    image, so the change silently didn't apply. Users had to remember to
-    run `cage update` manually.
+    """`agentcage domain add/rm` on apple-container live-reloads the egress
+    allowlist (re-render bind-mounted config + SIGHUP dnsmasq) instead of
+    rebuilding the wrapper image and restarting the cage. `_update_dns_quadlet`
+    delegates to `backend.reload_domains`; the stopped-egress short-circuit
+    lives inside that method (unit-tested in test_apple_container.py).
+    Regression guard against the old stop→build→start path that killed any
+    interactive session in the cage on every domain edit.
     """
 
     @patch("agentcage.cli._is_apple_container", return_value=True)
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
-    def test_update_dns_quadlet_rebuilds_wrapper(
+    def test_update_dns_quadlet_live_reloads_no_rebuild(
         self, mock_state, mock_get_backend, _mock_is_apple,
     ):
-        """`_update_dns_quadlet(cfg)` on apple-container must call
-        `backend.build_artifacts()` (the rebuild path) before restart."""
+        """`_update_dns_quadlet(cfg)` on apple-container delegates to
+        `backend.reload_domains(cfg, name)` and never rebuilds/restarts."""
         from agentcage.cli import _update_dns_quadlet
         cfg = _mock_config("apple-container")
         cfg.name = "demo"
@@ -774,38 +775,7 @@ class TestDomainCommandsAppleContainer:
 
         _update_dns_quadlet(cfg)
 
-        # Stop → build → start ordering matters: the rebuild must happen
-        # while the cage is stopped (otherwise Apple's `container build`
-        # would try to tag an image name in use by a running container).
-        mock_calls = [c[0] for c in backend.mock_calls]
-        stop_idx = next(i for i, c in enumerate(mock_calls) if c == "stop")
-        build_idx = next(i for i, c in enumerate(mock_calls) if c == "build_artifacts")
-        start_idx = next(i for i, c in enumerate(mock_calls) if c == "start")
-        assert stop_idx < build_idx < start_idx
-
-        backend.build_artifacts.assert_called_once()
-        ba_args = backend.build_artifacts.call_args
-        assert ba_args.args[1] == "demo"
-
-    @patch("agentcage.cli._is_apple_container", return_value=True)
-    @patch("agentcage.cli.get_backend")
-    @patch("agentcage.cli.state")
-    def test_update_dns_quadlet_skips_start_when_cage_not_running(
-        self, mock_state, mock_get_backend, _mock_is_apple,
-    ):
-        """If the cage isn't running, rebuild the image but don't start it
-        (matches the container backend's behavior — `domain add` on a
-        stopped cage updates the state but doesn't auto-start)."""
-        from agentcage.cli import _update_dns_quadlet
-        cfg = _mock_config("apple-container")
-        cfg.name = "demo"
-
-        backend = MagicMock()
-        backend.is_running.return_value = False
-        mock_get_backend.return_value = backend
-
-        _update_dns_quadlet(cfg)
-
-        backend.build_artifacts.assert_called_once()
+        backend.reload_domains.assert_called_once_with(cfg, "demo")
         backend.stop.assert_not_called()
+        backend.build_artifacts.assert_not_called()
         backend.start.assert_not_called()

--- a/tests/test_dns_live_reload.py
+++ b/tests/test_dns_live_reload.py
@@ -388,16 +388,17 @@ class TestVmBackendLiveReload:
         inst.exec.assert_not_called()
 
 
-class TestAppleContainerBackendStillRebuilds:
-    """The apple-container path is unchanged — its allowlist is baked
-    into the wrapper image at build time, so a domain change still
-    requires rebuilding the image and restarting the cage. Regression
-    guard."""
+class TestAppleContainerBackendLiveReloads:
+    """apple-container now live-reloads domain changes too: the egress
+    bind-mounts the rendered allowlist, so a domain edit re-renders +
+    SIGHUPs dnsmasq via ``backend.reload_domains`` — NO image rebuild and
+    NO cage stop/start (an interactive session survives). Regression guard
+    against the old rebuild path."""
 
     @patch("agentcage.cli._is_apple_container", return_value=True)
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli.state")
-    def test_apple_container_path_unchanged(
+    def test_apple_container_path_live_reloads(
         self, mock_state, mock_get_backend, _mock_is_apple,
     ):
         from agentcage.cli import _update_dns_quadlet
@@ -408,6 +409,9 @@ class TestAppleContainerBackendStillRebuilds:
 
         _update_dns_quadlet(cfg)
 
-        backend.stop.assert_called_once_with("demo")
-        backend.build_artifacts.assert_called_once()
-        backend.start.assert_called_once()
+        # Live reload, not rebuild: reload_domains is called and the cage
+        # is never stopped/rebuilt/started.
+        backend.reload_domains.assert_called_once_with(cfg, "demo")
+        backend.stop.assert_not_called()
+        backend.build_artifacts.assert_not_called()
+        backend.start.assert_not_called()


### PR DESCRIPTION
## Summary

On apple-container, `agentcage domain add`/`rm` rebuilt the wrapper image and did a **full cage stop→start on every edit** — which kills any interactive session running in the cage (e.g. an `agentcage run` shell or agent). That's a significant UX gap vs container/vm, which live-reload via SIGHUP and never touch the workload.

The code justified the rebuild with *"the allowlist is baked into the wrapper image at build time"* — but that hasn't been true since the egress refactor. The egress microVM already **bind-mounts** the host-rendered `dns-allowlist.conf` / `dnsmasq.conf` / `proxy-config.yaml` read-only (`apple_container.py` egress argv). So apple-container can do exactly what container/vm do.

## Fix

New `AppleContainerBackend.reload_domains(config, name)`:
1. Re-render the three egress config files **in place** (`shutil.copy2`/`write_text` truncate the same inode the egress has bind-mounted → virtiofs surfaces the new bytes in the running microVM).
2. Validate the rewritten allowlist inside the egress (`container exec <name>-egress dnsmasq --test --servers-file=…`); on failure **revert the file and raise** (so a malformed allowlist can't silently break DNS).
3. **SIGHUP dnsmasq** via its pidfile (`/home/acdns/dnsmasq.pid` — it runs under `setpriv --reuid=acdns`, so signal the pid, not `pkill`).
4. `proxy-config.yaml` is hot-reloaded by the mitmproxy addon's per-request mtime poll — no signal needed.

The **cage microVM is never touched**, so interactive sessions survive. `cli._update_dns_quadlet`'s apple branch now delegates to `reload_domains` (was `stop → build_artifacts → start`); the stopped-egress short-circuit moved into the method.

## Testing

- Backend unit tests: SIGHUP-no-restart (asserts no stop/build/start), validate-revert-on-bad-allowlist (no SIGHUP, file reverted), stopped-egress short-circuit (re-render only, no exec).
- Rewrote the two regression tests that asserted the old rebuild path (`test_dns_live_reload.py`, `test_apple_container_cli.py`) to assert live-reload delegation.
- Full suite: **1619 passed**.
- **Verified end-to-end on a real Mac** (macOS 26.3.2 / arm64 / Apple `container` 0.12.3): `domain add` on a running cage took **0s** (was a rebuild+restart); a `/tmp` sentinel survived (cage NOT restarted, session intact); the cage allowlist picked up the new domain via virtiofs; and the new domain went from the `198.51.100.1` sinkhole to **real IPs** — proving the cage-local dnsmasq re-read after SIGHUP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)