### PR TITLE
fix(apple-container): honor --no-cache / --pull on cage create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **apple-container `cage create`/`update` now honor `--no-cache` and
+  `--pull`.** Both flags were silently ignored on apple-container: they were
+  only wired into the container backend's image build, while
+  `build_and_deploy` never forwarded them to `AppleContainerBackend.
+  build_artifacts`, and the egress/scaffold builds short-circuited whenever
+  the image tag already existed. Now the flags thread through every apple
+  build step — the shared egress image, the scaffold image, and the per-cage
+  wrapper — mapping to `container build --no-cache` / `--pull` and bypassing
+  the "skip if present" checks so a forced rebuild actually rebuilds.
+  `--pull` additionally re-pulls a genuinely-remote user image even when a
+  copy is cached (a local-only `localhost/` ref is still never pulled — its
+  freshness comes from the forced scaffold rebuild).
+
 ## [0.22.14] - 2026-05-29
 
 ### Fixed

--- a/src/agentcage/apple_container/scaffold.py
+++ b/src/agentcage/apple_container/scaffold.py
@@ -20,13 +20,24 @@ from agentcage.apple_container import cli as ac_cli
 from agentcage.init import load_scaffold_meta, resolve_scaffold
 
 
-def build_scaffold_images(scaffold: str, *, quiet: bool = False) -> None:
+def build_scaffold_images(
+    scaffold: str,
+    *,
+    quiet: bool = False,
+    no_cache: bool = False,
+    pull: bool = False,
+) -> None:
     """Build every image declared in *scaffold*'s ``scaffold.yaml``.
 
     Mirrors the surface of :func:`agentcage.init.run_scaffold_setup`
     but builds via Apple ``container build`` rather than host podman.
-    Build args, cap-add hints, and the "skip if image exists" check
-    all carry over.
+    Build args and cap-add hints carry over.
+
+    ``no_cache`` / ``pull`` map to ``container build --no-cache`` /
+    ``--pull`` (force `cage create/update --no-cache/--pull`). When either
+    is set the "skip if image already exists" short-circuit is bypassed —
+    the whole point of those flags is to rebuild from scratch / re-pull the
+    base, so a cached image must NOT be reused.
 
     No-op when *scaffold* is empty (cage.yaml without a scaffold).
     """
@@ -43,9 +54,10 @@ def build_scaffold_images(scaffold: str, *, quiet: bool = False) -> None:
         if not quiet:
             click.echo(msg)
 
+    force = no_cache or pull
     for entry in meta.get("build", []):
         image = entry["image"]
-        if ac_cli.image_inspect(image):
+        if not force and ac_cli.image_inspect(image):
             _echo(f"Image {image} already exists, skipping build.")
             continue
         if "containerfile" not in entry:
@@ -59,6 +71,10 @@ def build_scaffold_images(scaffold: str, *, quiet: bool = False) -> None:
         containerfile = str(scaffold_dir / entry["containerfile"])
         _echo(f"Building {image} (apple-container)...")
         argv = ["build", "-t", image, "-f", containerfile]
+        if no_cache:
+            argv.append("--no-cache")
+        if pull:
+            argv.append("--pull")
         # build_args are scaffold-resolved templating, e.g. registry tags.
         # Apple's `container build` accepts --build-arg KEY=VALUE.
         for k, v in (entry.get("build_args") or {}).items():

--- a/src/agentcage/apple_container/wrapper.py
+++ b/src/agentcage/apple_container/wrapper.py
@@ -218,6 +218,7 @@ def build_wrapper(
     user_image: str,
     *,
     user_cmd: list[str] | None = None,
+    no_cache: bool = False,
     # Back-compat kwargs — see stage_build_context's docstring. None of
     # these flow into the wrapper image anymore; the per-cage egress
     # config (dnsmasq.conf, allowlist, secret_injection.json, etc.) is
@@ -247,8 +248,12 @@ def build_wrapper(
         tmpdir = Path(tmp)
         (tmpdir / "Containerfile").write_text(containerfile)
         stage_build_context(tmpdir, user_cmd)
+        argv = ["build", "-t", image, "-f", str(tmpdir / "Containerfile")]
+        if no_cache:
+            argv.append("--no-cache")
+        argv.append(str(tmpdir))
         ac_cli.run(
-            ["build", "-t", image, "-f", str(tmpdir / "Containerfile"), str(tmpdir)],
+            argv,
             capture_output=False,  # stream output to user
         )
     return image

--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -15,8 +15,16 @@ class Backend(Protocol):
         """Return list of unmet prerequisite descriptions (empty = all OK)."""
         ...
 
-    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
-        """Build container images or VM rootfs as needed."""
+    def build_artifacts(
+        self, config: Config, deploy_name: str, *, quiet: bool = False,
+        no_cache: bool = False, pull: bool = False,
+    ) -> None:
+        """Build container images or VM rootfs as needed.
+
+        ``no_cache``/``pull`` come from ``cage create/update
+        --no-cache/--pull``. Backends that build images here should honor
+        them; backends that build images elsewhere may ignore them.
+        """
         ...
 
     def generate_units(

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -362,7 +362,8 @@ class AppleContainerBackend:
         return ac_prereq.check_prerequisites()
 
     def build_artifacts(
-        self, config: Config, deploy_name: str, *, quiet: bool = False
+        self, config: Config, deploy_name: str, *, quiet: bool = False,
+        no_cache: bool = False, pull: bool = False,
     ) -> None:
         """Build (or refresh) the per-cage wrapper + the shared egress image,
         and stage per-cage egress config files on the host.
@@ -385,6 +386,14 @@ class AppleContainerBackend:
           1. <egress_config>/proxy-config.yaml — mitmproxy addon config.
           2. <egress_config>/dnsmasq.conf      — dnsmasq main config.
           3. <egress_config>/dns-allowlist.conf — dnsmasq --servers-file.
+
+        ``no_cache`` / ``pull`` come from ``cage create/update
+        --no-cache/--pull`` and are honored across every build step here
+        (egress image, scaffold image, wrapper image) — they map to
+        ``container build --no-cache`` / ``--pull`` and bypass the
+        "skip if image already present" short-circuits, so a forced
+        rebuild actually rebuilds. ``pull`` also forces a re-pull of a
+        genuinely-remote user image even when a copy is already cached.
         """
         user_image = config.container.image
         if not user_image:
@@ -393,7 +402,10 @@ class AppleContainerBackend:
         # 1. Build (or skip) the shared agentcage-egress image. Tagged with
         # the agentcage version so a wheel upgrade triggers a rebuild even
         # if the user already has a stale tag from an older release.
-        self._build_egress_image_if_missing(quiet=quiet)
+        # --no-cache/--pull force a rebuild even when the tag is present.
+        self._build_egress_image_if_missing(
+            quiet=quiet, no_cache=no_cache, pull=pull,
+        )
 
         # 2. If the cage came from a scaffold (cage.yaml has `scaffold:`),
         # build any scaffold-declared images via Apple `container build`
@@ -401,7 +413,9 @@ class AppleContainerBackend:
         # references one of these tags, so it must exist first.
         scaffold_name = getattr(config, "scaffold", "") or ""
         if scaffold_name:
-            ac_scaffold.build_scaffold_images(scaffold_name, quiet=quiet)
+            ac_scaffold.build_scaffold_images(
+                scaffold_name, quiet=quiet, no_cache=no_cache, pull=pull,
+            )
 
         # 3. Ensure the user image is available locally — checking the local
         # store FIRST, before any registry pull. This matters because:
@@ -417,7 +431,14 @@ class AppleContainerBackend:
         # So: use the local image if present; pull only a genuinely-remote ref
         # that is genuinely absent; never try to pull a local-only `localhost/`
         # ref (fail fast with an actionable message instead).
-        if ac_cli.image_inspect(user_image):
+        #
+        # --pull overrides the "use local if present" shortcut for remote
+        # refs: the operator explicitly asked for the latest from the
+        # registry. A `localhost/` ref is still never pulled (no registry
+        # source) — its freshness comes from the --no-cache/--pull rebuild
+        # of the scaffold image above, not from a pull.
+        force_pull_remote = pull and not user_image.startswith("localhost/")
+        if ac_cli.image_inspect(user_image) and not force_pull_remote:
             if not quiet:
                 click.echo(f"Using local image: {user_image}")
         elif user_image.startswith("localhost/"):
@@ -471,20 +492,29 @@ class AppleContainerBackend:
         # the legacy kwargs are accepted but ignored by the new wrapper.
         if not quiet:
             click.echo(f"Building apple-container wrapper for {deploy_name}...")
-        ac_wrapper.build_wrapper(deploy_name, user_image, user_cmd=user_cmd)
+        ac_wrapper.build_wrapper(
+            deploy_name, user_image, user_cmd=user_cmd, no_cache=no_cache,
+        )
         if not quiet:
             click.echo(f"Built {ac_wrapper.wrapped_image_name(deploy_name)}")
 
-    def _build_egress_image_if_missing(self, *, quiet: bool = False) -> None:
+    def _build_egress_image_if_missing(
+        self, *, quiet: bool = False, no_cache: bool = False, pull: bool = False,
+    ) -> None:
         """Build localhost/agentcage-egress:<version> if not already present.
 
         The Containerfile lives at src/agentcage/data/containers/Containerfile.egress
         (PR 1). It expects the build context to be src/agentcage/data/ so
         `COPY containers/supervisor-egress.sh ...` resolves — same context
         the smoke-test in tests/test_egress_image.py uses.
+
+        ``no_cache`` / ``pull`` force a rebuild even when the version-tagged
+        image is already present (``cage create/update --no-cache/--pull``):
+        the operator asked for a clean rebuild / fresh base, so the shared
+        egress image is rebuilt too rather than served from the cached tag.
         """
         image = _egress_image_name()
-        if ac_cli.image_inspect(image) is not None:
+        if not (no_cache or pull) and ac_cli.image_inspect(image) is not None:
             if not quiet:
                 click.echo(f"Egress image {image} already present; skipping rebuild")
             return
@@ -500,10 +530,13 @@ class AppleContainerBackend:
                 f"egress Containerfile missing at {containerfile} — "
                 f"is the agentcage install complete?"
             )
-        ac_cli.run(
-            ["build", "-t", image, "-f", str(containerfile), str(data_dir)],
-            capture_output=False,
-        )
+        argv = ["build", "-t", image, "-f", str(containerfile)]
+        if no_cache:
+            argv.append("--no-cache")
+        if pull:
+            argv.append("--pull")
+        argv.append(str(data_dir))
+        ac_cli.run(argv, capture_output=False)
 
     def _render_egress_config(self, config: Config, deploy_name: str) -> None:
         """Render proxy-config.yaml + dnsmasq.conf + dns-allowlist.conf to

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -46,7 +46,14 @@ class ContainerBackend:
             issues.append("Podman is not available")
         return issues
 
-    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
+    def build_artifacts(
+        self, config: Config, deploy_name: str, *, quiet: bool = False,
+        no_cache: bool = False, pull: bool = False,  # noqa: ARG002
+    ) -> None:
+        # The container backend builds/pulls the user image separately in
+        # cli (_build_container_image + podman.pull), which already honor
+        # --no-cache/--pull; this builds only the static helper/proxy
+        # images, so the flags are accepted for protocol parity and ignored.
         data_dir = Path(__file__).resolve().parent.parent / "data"
         containers_dir = str(data_dir / "containers")
         build_context = str(data_dir)

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -175,8 +175,15 @@ class VmBackend:
     def check_prerequisites(self, config: Config) -> list[str]:
         return lima_prerequisites.check_prerequisites()
 
-    def build_artifacts(self, config: Config, deploy_name: str, *, quiet: bool = False) -> None:
+    def build_artifacts(
+        self, config: Config, deploy_name: str, *, quiet: bool = False,
+        no_cache: bool = False, pull: bool = False,  # noqa: ARG002
+    ) -> None:
         """Build the egress image inside the VM.
+
+        ``no_cache``/``pull`` are accepted for protocol parity; the VM
+        backend builds/pulls the user image inside the VM via the cli
+        path, so they are not used here.
 
         The build context (package data directory) is copied into the VM
         via ``limactl copy`` since the home directory is not mounted

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -731,7 +731,8 @@ def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool,
     used_octets = collect_used_octets()
 
     try:
-        _build_and_deploy(cfg, config_host_path, name, podman, used_octets=used_octets)
+        _build_and_deploy(cfg, config_host_path, name, podman, used_octets=used_octets,
+                           no_cache=no_cache, pull=pull)
     except Exception:
         # Stop partially-started services but preserve state for debugging
         backend = get_backend(cfg)
@@ -1056,6 +1057,8 @@ def cage_update(name: str | None, config_path: str | None,
         podman,
         used_octets=_collect_update(exclude=name),
         network_octet=_existing_octet,
+        no_cache=no_cache,
+        pull=pull,
     )
     click.echo(f"Updated cage '{name}'")
 

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -232,6 +232,8 @@ def build_and_deploy(
     used_octets: set[int] | None = None,
     network_octet: int | None = None,
     quiet: bool = False,
+    no_cache: bool = False,
+    pull: bool = False,
 ):
     """Build images, generate quadlets, install, and start.
 
@@ -257,7 +259,9 @@ def build_and_deploy(
     with open(resolv_path, "w") as f:
         f.write(f"nameserver {addrs['ip_egress']}\n")
 
-    backend.build_artifacts(cfg, deploy_name, quiet=quiet)
+    backend.build_artifacts(
+        cfg, deploy_name, quiet=quiet, no_cache=no_cache, pull=pull,
+    )
 
     units = backend.generate_units(
         cfg,

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1413,7 +1413,7 @@ def test_build_artifacts_orders_scaffold_before_wrapper_no_pull_for_local():
 
     calls: list[str] = []
 
-    def scaffold_side_effect(scaffold, *, quiet=False):  # noqa: ARG001
+    def scaffold_side_effect(scaffold, **kwargs):  # noqa: ARG001
         calls.append("scaffold")
 
     def run_side_effect(argv, **kwargs):  # noqa: ARG001
@@ -3920,3 +3920,132 @@ def test_reload_domains_no_signal_when_egress_stopped(tmp_path, monkeypatch):
 
     assert rendered == [1]          # re-rendered the files
     run_mock.assert_not_called()    # but did not exec into the stopped egress
+
+
+# ---------------------------------------------------------------------------
+# --no-cache / --pull propagation (cage create/update flags)
+# ---------------------------------------------------------------------------
+
+
+def test_egress_build_no_cache_forces_rebuild_even_when_present():
+    """`_build_egress_image_if_missing(no_cache=True)` must rebuild with
+    --no-cache even though the version-tagged egress image already exists —
+    the whole point of --no-cache is to not reuse the cached image."""
+    backend = AppleContainerBackend()
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}):
+        backend._build_egress_image_if_missing(quiet=True, no_cache=True, pull=True)
+
+    builds = [a for a in calls if a[:1] == ["build"]]
+    assert builds, "egress must rebuild when --no-cache/--pull is set"
+    assert "--no-cache" in builds[0]
+    assert "--pull" in builds[0]
+
+
+def test_egress_build_skips_when_present_and_not_forced():
+    """Without the flags, a present egress image is still skipped (default)."""
+    backend = AppleContainerBackend()
+    with patch.object(ac_cli, "run") as run_mock, \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}):
+        backend._build_egress_image_if_missing(quiet=True)
+    run_mock.assert_not_called()
+
+
+def test_scaffold_build_no_cache_pull_bypasses_skip_and_passes_flags():
+    """`build_scaffold_images(no_cache=True, pull=True)` rebuilds even when
+    the scaffold image exists and forwards both flags to `container build`."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}):
+        ac_scaffold.build_scaffold_images(
+            "debian", quiet=True, no_cache=True, pull=True,
+        )
+
+    builds = [a for a in calls if a[:1] == ["build"]]
+    assert builds, "scaffold image must rebuild when forced"
+    assert "--no-cache" in builds[0]
+    assert "--pull" in builds[0]
+
+
+def test_build_artifacts_threads_no_cache_and_pull_to_all_builders():
+    """`build_artifacts(no_cache=True, pull=True)` propagates both flags to
+    the egress build, the scaffold build, and the wrapper build (no-cache)."""
+    backend = AppleContainerBackend()
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/agentcage-scaffold-debian:latest"
+    cfg.container.command = ["sh", "-c", "sleep infinity"]
+    cfg.scaffold = "debian"
+
+    with patch.object(backend, "_build_egress_image_if_missing") as egress, \
+         patch.object(ac_scaffold, "build_scaffold_images") as scaffold, \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}), \
+         patch.object(backend, "_render_egress_config"), \
+         patch.object(ac_wrapper, "build_wrapper") as wrapper:
+        backend.build_artifacts(cfg, "t", quiet=True, no_cache=True, pull=True)
+
+    assert egress.call_args.kwargs.get("no_cache") is True
+    assert egress.call_args.kwargs.get("pull") is True
+    assert scaffold.call_args.kwargs.get("no_cache") is True
+    assert scaffold.call_args.kwargs.get("pull") is True
+    assert wrapper.call_args.kwargs.get("no_cache") is True
+
+
+def test_build_artifacts_pull_forces_repull_of_cached_remote_image():
+    """`--pull` re-pulls a genuinely-remote image even when it's already
+    cached locally (operator asked for the latest)."""
+    backend = AppleContainerBackend()
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "docker.io/library/debian:stable-slim"
+    cfg.container.command = ["sh"]
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "_build_egress_image_if_missing"), \
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}), \
+         patch.object(backend, "_render_egress_config"), \
+         patch.object(ac_wrapper, "build_wrapper"):
+        backend.build_artifacts(cfg, "t", quiet=True, pull=True)
+
+    assert any(a[:2] == ["image", "pull"] for a in calls), \
+        "--pull must re-pull a cached remote image"
+
+
+def test_build_artifacts_pull_does_not_pull_localhost_ref():
+    """`--pull` never pulls a `localhost/` ref (no registry source); a
+    present localhost image is used as-is."""
+    backend = AppleContainerBackend()
+    cfg = Config(name="t", isolation="apple-container")
+    cfg.container.image = "localhost/agentcage-scaffold-debian:latest"
+    cfg.container.command = ["sh"]
+
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(backend, "_build_egress_image_if_missing"), \
+         patch.object(ac_scaffold, "build_scaffold_images"), \
+         patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch.object(ac_cli, "image_inspect", return_value={"present": True}), \
+         patch.object(backend, "_render_egress_config"), \
+         patch.object(ac_wrapper, "build_wrapper"):
+        backend.build_artifacts(cfg, "t", quiet=True, pull=True)
+
+    assert not any(a[:2] == ["image", "pull"] for a in calls)


### PR DESCRIPTION
## Summary

`cage create`/`cage update --no-cache` and `--pull` were **silently ignored** on the apple-container backend. The flags were only wired into the container backend's `_build_container_image`; `build_and_deploy` never forwarded them to `AppleContainerBackend.build_artifacts`, and the egress + scaffold builds short-circuited whenever the image tag already existed — so even a forced rebuild reused the cached image.

## Fix

Thread `no_cache`/`pull` end to end:
- **cli** `cage create` / `cage update` → `build_and_deploy` → `backend.build_artifacts` (added to the `Backend` protocol; container/vm accept + ignore them since they build/pull the user image elsewhere, already honoring the flags).
- **apple `build_artifacts`** forwards to every build step:
  - `_build_egress_image_if_missing` — rebuild even when the version-tagged image is present; pass `--no-cache`/`--pull`.
  - `build_scaffold_images` — bypass the skip-if-present check when forced; pass `--no-cache`/`--pull`.
  - `build_wrapper` — pass `--no-cache`.
  - user-image step — `--pull` re-pulls a cached **remote** image; a `localhost/` ref is still never pulled (its freshness comes from the forced scaffold rebuild).

Apple's `container build` supports `--no-cache` and `--pull` (confirmed against the runtime, v0.12.3).

## Testing

- Unit: per-builder flag propagation; egress force-rebuild-when-present; scaffold bypass-skip + flags; `--pull` re-pulls a cached remote image; `--pull` never pulls a `localhost/` ref. Updated one existing mock whose signature didn't accept the new kwargs.
- Full suite: **1625 passed**.
- **Verified end-to-end on a real Mac** (Apple `container` 0.12.3): plain `cage update` skips (9s, "already present; skipping"); `cage update --no-cache` rebuilds all three images (26s, **zero** skip messages, only 2 CACHED layers vs a full apt-get re-run); `cage update --pull` likewise rebuilds (no skips). Both flags were no-ops before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)