### PR TITLE
fix(apple-container): report per-secret status in `cage show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cage show` now reports per-secret present/missing status on
+  apple-container.** It previously printed `N expected (status not tracked on
+  apple-container)` because host podman — the secret store on the container
+  backend — doesn't exist on macOS. But the staged keys already live in
+  `pending_secrets.json`, so `cage show` now reads them from there (the same
+  source `secret list` uses) and prints the same `Secrets: provided/expected
+  (N missing)` summary as the container/vm backends.
+
 ## [0.22.15] - 2026-05-29
 
 ### Fixed

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -1833,12 +1833,12 @@ def cage_show(name: str):
     except Exception:
         pass
 
-    # Secrets — host podman is the secret store, so skip the count on
-    # apple-container (which has no host podman) rather than crash.
+    # Secrets — host podman is the secret store, but apple-container has no
+    # host podman, so read present keys from pending_secrets.json instead
+    # (the same source `secret list` uses).
     if _is_apple_container(cfg):
         expected = _expected_secrets(cfg)
-        if expected:
-            click.echo(f"Secrets:    {len(expected)} expected (status not tracked on apple-container)")
+        present_keys = {k for k, _ in _load_apple_pending_secrets(name)}
     else:
         podman = _podman_for_cage(name)
         secrets = podman.secret_list(prefix=f"{name}.")
@@ -1847,12 +1847,13 @@ def cage_show(name: str):
             s.get("Name", "").removeprefix(f"{name}.")
             for s in secrets
         }
-        missing = [k for k in expected if k not in present_keys]
-        if expected:
-            if missing:
-                click.echo(f"Secrets:    {len(present_keys)}/{len(expected)} ({len(missing)} missing)")
-            else:
-                click.echo(f"Secrets:    {len(expected)}/{len(expected)}")
+    missing = [k for k in expected if k not in present_keys]
+    if expected:
+        provided = sum(1 for k in expected if k in present_keys)
+        if missing:
+            click.echo(f"Secrets:    {provided}/{len(expected)} ({len(missing)} missing)")
+        else:
+            click.echo(f"Secrets:    {len(expected)}/{len(expected)}")
 
 
 @cage.command("logs")

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -702,6 +702,75 @@ class TestSecretCommandsAppleContainer:
         assert "MISSING" in result.output
         mock_podman.assert_not_called()
 
+    @patch("agentcage.cli._ensure_v022_cage")
+    @patch("agentcage.cli._expected_secrets")
+    @patch("agentcage.cli._load_apple_pending_secrets")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._podman_for_cage")
+    @patch("agentcage.cli.state")
+    def test_show_reports_per_secret_present_and_missing(
+        self, mock_state, mock_podman, mock_get_backend,
+        mock_load, mock_expected, _mock_ensure,
+    ):
+        """`cage show` on apple-container reports the present/expected
+        secret count from pending_secrets.json (the same source as
+        `secret list`), not the old "status not tracked" placeholder, and
+        never instantiates host podman.
+        """
+        cfg = _mock_config("apple-container")
+        cfg.container.ports = []
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {"agentcage_version": "0.22.0"}
+        backend = MagicMock()
+        backend.service_names.return_value = ["cage", "egress"]
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+        # MY_KEY staged; ABSENT expected but missing.
+        mock_load.return_value = [("MY_KEY", "v")]
+        mock_expected.return_value = ["MY_KEY", "ABSENT"]
+
+        result = _runner().invoke(main, ["cage", "show", "demo"])
+
+        assert result.exit_code == 0
+        # 1 of 2 present, 1 missing — mirrors the container branch wording.
+        assert "Secrets:    1/2 (1 missing)" in result.output
+        assert "status not tracked" not in result.output
+        # Host podman must NEVER be instantiated on apple-container.
+        mock_podman.assert_not_called()
+
+    @patch("agentcage.cli._ensure_v022_cage")
+    @patch("agentcage.cli._expected_secrets")
+    @patch("agentcage.cli._load_apple_pending_secrets")
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli._podman_for_cage")
+    @patch("agentcage.cli.state")
+    def test_show_reports_all_secrets_present(
+        self, mock_state, mock_podman, mock_get_backend,
+        mock_load, mock_expected, _mock_ensure,
+    ):
+        """When every expected secret is staged, `cage show` reports the
+        full N/N count with no "missing" suffix.
+        """
+        cfg = _mock_config("apple-container")
+        cfg.container.ports = []
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = cfg
+        mock_state.load_metadata.return_value = {"agentcage_version": "0.22.0"}
+        backend = MagicMock()
+        backend.service_names.return_value = ["cage", "egress"]
+        backend.is_running.return_value = True
+        mock_get_backend.return_value = backend
+        mock_load.return_value = [("MY_KEY", "v"), ("OTHER", "w")]
+        mock_expected.return_value = ["MY_KEY", "OTHER"]
+
+        result = _runner().invoke(main, ["cage", "show", "demo"])
+
+        assert result.exit_code == 0
+        assert "Secrets:    2/2" in result.output
+        assert "missing" not in result.output
+        mock_podman.assert_not_called()
+
 
 class TestPendingSecretsHelpers:
     """The pending_secrets.json reader/writer must round-trip in exactly


### PR DESCRIPTION
## Problem

On apple-container, `agentcage cage show` printed a placeholder for secrets:

```
Secrets:    N expected (status not tracked on apple-container)
```

The container/vm backends instead report per-secret present/missing status. The reason apple-container couldn't was that host podman — the secret store on the container backend — doesn't exist on most macOS installs, so the count was skipped to avoid a crash.

But the data already exists: staged secrets live in `pending_secrets.json`, and `cage secret list` already computes per-secret ok/MISSING from it via `_load_apple_pending_secrets`.

## Fix

`cage show` now reads present keys from `pending_secrets.json` on apple-container (the exact same source `secret list` uses) and emits the same summary line as the container/vm branch:

```
Secrets:    1/2 (1 missing)
Secrets:    2/2
```

Present = key in `pending_secrets.json`; MISSING = expected but absent. No new format is introduced — it's identical to the existing container branch wording. Host podman is never instantiated on apple-container.

## Tests

- Added `test_show_reports_per_secret_present_and_missing` and `test_show_reports_all_secrets_present` to `tests/test_apple_container_cli.py`, mirroring the existing `secret list` test: patch state + `get_backend` + `_load_apple_pending_secrets` + `_expected_secrets`, invoke `cage show`, assert the present/missing counts and that host podman is never touched.
- Full suite: `uv run pytest tests/ -q` → 1627 passed.

Not yet hardware-verified on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)