### PR TITLE
feat: add quality-of-life aliases to agentcage cli

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,7 +76,9 @@ Manage cages.
 | `cage backup NAME` | Create a backup tarball of a cage |
 | `cage restore TARBALL` | Restore a cage from a backup tarball |
 
-Aliases: `ls`/`ps`/`status` → `list`, `rm`/`delete` → `destroy`, `reload` → `restart`, `describe`/`inspect` → `show`, `config` → `edit`.
+Aliases: `ls`/`ps`/`status` → `list`, `rm`/`delete` → `destroy`, `reload` → `restart`, `describe`/`inspect` → `show`, `config` → `edit`, `update` → `update`.
+
+> **Note**: `agentcage` also supports dropping the `cage` group prefix for all standard cage commands and these aliases (e.g. `agentcage ls`, `agentcage start`, `agentcage stop`, `agentcage update`, `agentcage logs` function as their `cage` equivalents).
 
 ### cage create
 

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -329,9 +329,46 @@ class AliasGroup(click.Group):
 class _BannerGroup(click.Group):
     """Show the agentcage banner before help text."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._global_aliases = {
+            "ls": ("cage_list", "cage list"),
+            "rm": ("cage_destroy", "cage destroy"),
+            "delete": ("cage_destroy", "cage destroy"),
+            "ps": ("cage_list", "cage list"),
+            "status": ("cage_list", "cage list"),
+            "restart": ("cage_restart", "cage restart"),
+            "reload": ("cage_restart", "cage restart"),
+            "show": ("cage_show", "cage show"),
+            "describe": ("cage_show", "cage show"),
+            "inspect": ("cage_show", "cage show"),
+            "edit": ("cage_edit", "cage edit"),
+            "config": ("cage_edit", "cage edit"),
+            "stop": ("cage_stop", "cage stop"),
+            "start": ("cage_start", "cage start"),
+            "logs": ("cage_logs", "cage logs"),
+            "exec": ("cage_exec", "cage exec"),
+            "shell": ("cage_shell", "cage shell"),
+            "update": ("cage_update", "cage update"),
+        }
+
+    def get_command(self, ctx, cmd_name):
+        if cmd_name in self._global_aliases:
+            func_name, _ = self._global_aliases[cmd_name]
+            return globals().get(func_name)
+        return super().get_command(ctx, cmd_name)
+
     def get_help(self, ctx: click.Context) -> str:
         from agentcage.output import banner_text
         return banner_text(version("agentcage")) + "\n" + super().get_help(ctx)
+
+    def format_help(self, ctx, formatter):
+        super().format_help(ctx, formatter)
+        formatter.write_paragraph()
+        formatter.write_text("Aliases:")
+        with formatter.indentation():
+            for alias, (_, target) in sorted(self._global_aliases.items()):
+                formatter.write_text(f"{alias} → {target}")
 
 
 @click.group(cls=_BannerGroup)


### PR DESCRIPTION
This PR introduces quality-of-life aliases for the `agentcage` CLI, specifically focused on operations around managing cages.

### Changes
* Resolves global aliases at the `agentcage` top level by bypassing the `cage` group prefix for rapid interaction.
* Adds missing `update` mapped to `cage_update`.
* Supported aliased top-level commands:
  * `ls`, `ps`, `status` &rarr; `cage list`
  * `rm`, `delete` &rarr; `cage destroy`
  * `restart`, `reload` &rarr; `cage restart`
  * `show`, `describe`, `inspect` &rarr; `cage show`
  * `edit`, `config` &rarr; `cage edit`
  * `stop`, `start`, `logs`, `exec`, `shell`, `update` &rarr; their `cage <cmd>` equivalents.
* Proper layout rendering under `agentcage --help` through a customized `click` help format generator.