### PR TITLE
feat(scaffold): freeze cage.yaml + Containerfile at create; cage update never re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A scaffold is now a one-shot generator, not a live dependency — `cage
+  update` freezes a cage's `cage.yaml` and `Containerfile`.** Previously
+  `cage update` (without `-c`) silently re-staged the scaffold's
+  `Containerfile` over the cage's staged copy (clobbering any operator
+  edits), re-rendered the scaffold template to patch `command`/`env`, and
+  auto-bumped scaffold-declared build args. It now does none of that: the
+  cage owns its `cage.yaml` + `Containerfile` from create time onward, and
+  `cage update` only rebuilds the staged Containerfile, pulls fresh base
+  images, and restarts. The stored config is never mutated. The freeze
+  lives in the shared CLI path, so it is consistent across the container,
+  vm, and apple-container backends. To change config, edit the staged
+  files, use `cage edit`, or pass a new config with `cage update -c <file>`.
+- **apple-container builds the cage's own staged Containerfile, not the live
+  scaffold.** The apple-container backend previously (re)built the scaffold
+  image from the live scaffold directory on disk via `build_scaffold_images`,
+  using the scaffold's unpinned build args — so an agentcage upgrade that
+  changed a scaffold leaked into existing cages on `cage update`
+  (especially under `--no-cache`/`--pull`). It now builds `container.image`
+  from the cage's per-cage staged `Containerfile` with point-in-time build-arg
+  resolution, exactly like the container/vm backends. Verified on macOS 26 /
+  Apple `container` 0.12.3: an edit to the staged Containerfile is applied on
+  `cage update`, while a change to the live scaffold is not.
+
+### Added
+
+- **`cage show` now prints a `Build:` line** with the path of the staged
+  `Containerfile` that `cage update` actually builds — making it obvious
+  the cage builds its own copy in the state dir, not the file you authored
+  at create time. The build step also echoes the resolved Containerfile
+  path (`Building <image> from <path>...`).
+
 ## [0.22.16] - 2026-05-29
 
 ### Added

--- a/docs/how-to/upgrade-agentcage.md
+++ b/docs/how-to/upgrade-agentcage.md
@@ -3,7 +3,9 @@
 
 Bump agentcage on a host with running cages, propagate the upgrade to each cage, and recover if it goes wrong. Read this when a new release lands and you want to ship it without surprising your operators.
 
-The agentcage binary and the cages it manages are upgraded separately. Bumping the binary does not rebuild your cages; until you run `cage update`, each cage keeps the templates and patches it was created with.
+The agentcage binary and the cages it manages are upgraded separately. Bumping the binary does not rebuild your cages; until you run `cage update`, each cage keeps the generated runtime (quadlets, egress image, apple-container wrapper) it was created with.
+
+A cage's `cage.yaml` and `Containerfile` are **frozen at create time** — a scaffold is a one-shot generator, not a live dependency. `cage update` rebuilds the cage's *own* staged `Containerfile`, pulls fresh base images, and regenerates the agentcage-managed runtime — but it never re-reads the scaffold, so a newer agentcage's scaffold templates are **not** pulled into existing cages (on any backend). To adopt new scaffold templates, recreate the cage or edit its staged files (`cage edit` / edit the staged `Containerfile`, then `cage update`).
 
 ## Before you upgrade
 
@@ -43,7 +45,7 @@ agentcage doctor
 
 Cages keep their old generated quadlets and wrapper images until you explicitly update them. Pick the right command for what changed:
 
-- New agentcage version with template or patch changes → `cage update` (rebuilds the image and regenerates quadlets).
+- New agentcage version with runtime changes (quadlets, egress, supervisor, apple-container wrapper) → `cage update` (rebuilds the cage's own staged Containerfile, pulls fresh base images, and regenerates the runtime). It does **not** pull in new scaffold templates — the cage's `cage.yaml`/`Containerfile` are frozen at create.
 - `cage.yaml` field that live-reloads (`domains`, `inspectors`, `secret_injection`, `capture`, `protocol_relays`) → `cage edit` or `domain add` / `domain rm`; the proxy picks up the change in place.
 - `cage.yaml` field that needs a service restart (`ports`, `container.command`, `container.env`) → `cage restart` after editing.
 - `cage.yaml` field that needs a rebuild (`isolation`, `vm`, `container.image`) → `cage update`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -103,9 +103,11 @@ agentcage cage update <name> [-c <config>]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `-c, --config` | path | stored config | Update the stored config before rebuilding |
+| `-c, --config` | path | stored config | Replace the stored config before rebuilding |
 | `--no-cache` | flag | | Force a full image rebuild |
 | `--pull` | flag | | Force a re-pull of the base image |
+
+A cage's `cage.yaml` and `Containerfile` are **frozen at create time** — a scaffold is a one-shot generator, not a live dependency. Without `-c`, `cage update` rebuilds the **staged** Containerfile (the copy in the cage's state dir, shown as `Build:` in `cage show`), pulls fresh base images, and restarts. It never re-reads the scaffold and never mutates the stored config. To change config, edit the staged files and rerun, use `cage edit`, or pass a new config with `-c`.
 
 ### cage edit
 

--- a/src/agentcage/apple_container/scaffold.py
+++ b/src/agentcage/apple_container/scaffold.py
@@ -1,83 +1,76 @@
-"""Scaffold image building for the apple-container backend.
+"""Image building for the apple-container backend.
 
 The host-side ``run_scaffold_setup`` in ``agentcage.init`` invokes
 ``podman build`` directly on the host. That path is fine for the Linux
 container backend, but on macOS there is no host podman — Apple's
 `container` CLI is the only builder available. This module mirrors the
-``run_scaffold_setup`` logic but routes every build through
+container backend's ``build_container_image`` but routes the build through
 ``ac_cli.run(['build', ...])`` instead.
 
-Called by :meth:`AppleContainerBackend.build_artifacts` BEFORE the
-per-cage wrapper image is built — the wrapper's ``FROM <user_image>``
-references the scaffold-built image, so it must exist first.
+Called by :meth:`AppleContainerBackend.build_artifacts` BEFORE the per-cage
+wrapper image is built — the wrapper's ``FROM <user_image>`` references the
+image produced here, so it must exist first.
+
+Crucially, the build reads the cage's OWN staged Containerfile (frozen into
+the cage state dir at create), NOT the live scaffold on disk. A scaffold is
+a one-shot generator, not a live dependency: an agentcage upgrade that
+changes a scaffold therefore can never leak into an existing cage on
+``cage update`` — identical to the container/vm backends, which rebuild the
+cage's staged Containerfile.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from agentcage.apple_container import cli as ac_cli
-from agentcage.init import load_scaffold_meta, resolve_scaffold
 
 
-def build_scaffold_images(
-    scaffold: str,
+def build_image_from_staged(
+    image: str,
+    containerfile: Path,
+    context_dir: Path,
+    build_args: dict[str, str] | None = None,
     *,
     quiet: bool = False,
     no_cache: bool = False,
     pull: bool = False,
 ) -> None:
-    """Build every image declared in *scaffold*'s ``scaffold.yaml``.
+    """Build *image* from a cage's staged Containerfile via Apple
+    ``container build``.
 
-    Mirrors the surface of :func:`agentcage.init.run_scaffold_setup`
-    but builds via Apple ``container build`` rather than host podman.
-    Build args and cap-add hints carry over.
+    *containerfile* / *context_dir* point at the cage's per-cage staged copy
+    (in the cage state dir), so the build is frozen to what was captured at
+    create time — never the live scaffold.
 
-    ``no_cache`` / ``pull`` map to ``container build --no-cache`` /
-    ``--pull`` (force `cage create/update --no-cache/--pull`). When either
-    is set the "skip if image already exists" short-circuit is bypassed —
-    the whole point of those flags is to rebuild from scratch / re-pull the
-    base, so a cached image must NOT be reused.
-
-    No-op when *scaffold* is empty (cage.yaml without a scaffold).
+    Build args are resolved point-in-time exactly as the container backend
+    does (untagged registry refs get a concrete tag), so ``--pull`` fetches a
+    fresh base without mutating the frozen cage.yaml. ``no_cache`` / ``pull``
+    map to ``container build --no-cache`` / ``--pull``.
     """
-    if not scaffold:
-        return
-    meta = load_scaffold_meta(scaffold)
-    if meta is None:
-        return
-    scaffold_dir = resolve_scaffold(scaffold)
-    if scaffold_dir is None:
-        return
+    from agentcage.registry import resolve_build_args
+
+    resolved_args, changes = resolve_build_args(dict(build_args or {}))
 
     def _echo(msg: str) -> None:
         if not quiet:
             click.echo(msg)
 
-    force = no_cache or pull
-    for entry in meta.get("build", []):
-        image = entry["image"]
-        if not force and ac_cli.image_inspect(image):
-            _echo(f"Image {image} already exists, skipping build.")
-            continue
-        if "containerfile" not in entry:
-            # The host podman flow supports other build types (pull,
-            # registry tag) — apple-container backend only handles
-            # local Containerfile builds in v1. Anything else is a no-op
-            # here and the wrapper build will fail later with a clear
-            # "image not found" error.
-            _echo(f"warning: scaffold entry for {image!r} has no containerfile; skipping")
-            continue
-        containerfile = str(scaffold_dir / entry["containerfile"])
-        _echo(f"Building {image} (apple-container)...")
-        argv = ["build", "-t", image, "-f", containerfile]
-        if no_cache:
-            argv.append("--no-cache")
-        if pull:
-            argv.append("--pull")
-        # build_args are scaffold-resolved templating, e.g. registry tags.
-        # Apple's `container build` accepts --build-arg KEY=VALUE.
-        for k, v in (entry.get("build_args") or {}).items():
-            argv += ["--build-arg", f"{k}={v}"]
-        argv.append(str(scaffold_dir))
-        ac_cli.run(argv, capture_output=False)
+    for key, _old, new in changes:
+        _echo(f"Build arg {key}: {new}")
+    _echo(
+        f"Building {image} from {containerfile}"
+        f"{' (no-cache)' if no_cache else ''} (apple-container)..."
+    )
+
+    argv = ["build", "-t", image, "-f", str(containerfile)]
+    if no_cache:
+        argv.append("--no-cache")
+    if pull:
+        argv.append("--pull")
+    for k, v in resolved_args.items():
+        argv += ["--build-arg", f"{k}={v}"]
+    argv.append(str(context_dir))
+    ac_cli.run(argv, capture_output=False)

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -407,15 +407,28 @@ class AppleContainerBackend:
             quiet=quiet, no_cache=no_cache, pull=pull,
         )
 
-        # 2. If the cage came from a scaffold (cage.yaml has `scaffold:`),
-        # build any scaffold-declared images via Apple `container build`
-        # BEFORE the wrapper build. The wrapper's `FROM <user_image>`
-        # references one of these tags, so it must exist first.
-        scaffold_name = getattr(config, "scaffold", "") or ""
-        if scaffold_name:
-            ac_scaffold.build_scaffold_images(
-                scaffold_name, quiet=quiet, no_cache=no_cache, pull=pull,
-            )
+        # 2. Build the cage's image from its OWN staged Containerfile (frozen
+        # into the cage state dir at create) — mirroring the container/vm
+        # backends. The build must precede the wrapper build, whose
+        # `FROM <user_image>` references the tag produced here. A scaffold is
+        # a one-shot generator, not a live dependency: we never re-read it
+        # here, so an agentcage upgrade that changes a scaffold cannot leak
+        # into an existing cage on `cage update`.
+        bc = config.container.build
+        if bc.containerfile:
+            from agentcage import state
+            staged_cf = state.deployment_dir(deploy_name) / bc.containerfile
+            if staged_cf.is_file():
+                ac_scaffold.build_image_from_staged(
+                    user_image, staged_cf, staged_cf.parent, bc.args,
+                    quiet=quiet, no_cache=no_cache, pull=pull,
+                )
+            elif not quiet:
+                click.echo(
+                    f"warning: no staged Containerfile at {staged_cf}; "
+                    f"relying on a prebuilt or pullable {user_image}",
+                    err=True,
+                )
 
         # 3. Ensure the user image is available locally — checking the local
         # store FIRST, before any registry pull. This matters because:

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -864,116 +864,14 @@ def cage_update(name: str | None, config_path: str | None,
             click.echo(f"error: cage '{name}' does not exist", err=True)
             sys.exit(1)
         _ensure_v022_cage(name)
-        # Auto-resolve latest image tags for stored configs
-        from agentcage.init import (
-            infer_scaffold_from_image,
-            load_scaffold_meta,
-        )
-        from agentcage.registry import resolve_build_args, resolve_latest_tag
-
-        raw = state.load_raw_config(name)
-
-        # Resolve the scaffold name for this cage. Precedence:
-        #   1. metadata.json "scaffold" (populated by cage create / run)
-        #   2. raw.get("scaffold") (legacy inline field)
-        #   3. infer from container.image naming convention
-        stored_meta = state.load_metadata(name) or {}
-        scaffold_name = (
-            stored_meta.get("scaffold")
-            or raw.get("scaffold", "")
-            or infer_scaffold_from_image(raw.get("container", {}).get("image", ""))
-            or ""
-        )
-
-        # Top-level container.image — skip scaffold-built local images
-        # (e.g. "localhost/agentcage-scaffold-openclaw:latest") since those
-        # are never in a real registry.
-        current_image = raw.get("container", {}).get("image", "")
-        image_base, _, current_tag = current_image.rpartition(":")
-        if image_base and current_tag and not image_base.startswith("localhost/"):
-            new_tag = resolve_latest_tag(image_base)
-            if new_tag and new_tag != current_tag:
-                raw["container"]["image"] = f"{image_base}:{new_tag}"
-                state.save_raw_config(name, raw)
-                click.echo(f"Image: {image_base}:{current_tag} \u2192 {new_tag}")
-            elif new_tag is None:
-                click.echo(
-                    f"warning: could not resolve latest tag for {image_base}, "
-                    f"keeping {current_tag}",
-                    err=True,
-                )
-
-        # Build args — scaffold.yaml declaration is authoritative.
-        # Untagged-in-scaffold ⇒ auto-bump on every update (tracks upstream).
-        # Tagged-in-scaffold   ⇒ respected (author pinned on purpose).
-        # User-added args      ⇒ resolved once if untagged, then respected.
-        scaffold_declared_args: dict[str, str] = {}
-        if scaffold_name:
-            scaffold_meta = load_scaffold_meta(scaffold_name) or {}
-            for entry in scaffold_meta.get("build", []):
-                scaffold_declared_args.update(entry.get("build_args") or {})
-
-        build_raw = raw.get("container", {}).get("build", {})
-        stored_args = build_raw.get("args") or {}
-        resolved_args, changes = resolve_build_args(
-            stored_args, scaffold_declared_args,
-        )
-        for key, old, new in changes:
-            click.echo(f"Build arg {key}: {old} \u2192 {new}")
-            old_base = old.rsplit(":", 1)[0]
-            new_base = new.rsplit(":", 1)[0]
-            if old_base != new_base:
-                click.echo(
-                    f"warning: base image for {key} changed "
-                    f"({old_base} \u2192 {new_base}) \u2014 scaffold updated "
-                    f"upstream reference",
-                    err=True,
-                )
-        if changes:
-            raw.setdefault("container", {}).setdefault("build", {})["args"] = resolved_args
-            state.save_raw_config(name, raw)
-
-        # Refresh scaffold build artifacts and command if scaffold is known
-        if scaffold_name:
-            from agentcage.init import resolve_scaffold, render_config
-
-            scaffold_dir = resolve_scaffold(scaffold_name)
-            if scaffold_dir is not None:
-                # Copy fresh Containerfile + sibling build inputs (files and
-                # directory trees) from the scaffold
-                _stage_build_context(scaffold_dir, state.deployment_dir(name))
-
-                # Re-render scaffold template and patch command + new env vars
-                try:
-                    import yaml
-                    rendered = render_config(name, scaffold=scaffold_name)
-                    scaffold_cfg = yaml.safe_load(rendered) or {}
-                    scaffold_container = scaffold_cfg.get("container", {})
-
-                    # Update command
-                    new_cmd = scaffold_container.get("command")
-                    old_cmd = raw.get("container", {}).get("command")
-                    if new_cmd and new_cmd != old_cmd:
-                        raw.setdefault("container", {})["command"] = new_cmd
-                        click.echo(f"Command updated from scaffold")
-
-                    # Merge new env vars (additive — never remove user's vars)
-                    scaffold_env = scaffold_container.get("env", {})
-                    stored_env = raw.get("container", {}).get("env", {})
-                    for key, val in scaffold_env.items():
-                        if key not in stored_env:
-                            stored_env[key] = val
-                            click.echo(f"Added env: {key}")
-                    if stored_env:
-                        raw.setdefault("container", {})["env"] = stored_env
-
-                    state.save_raw_config(name, raw)
-                except Exception as e:
-                    click.echo(
-                        f"warning: could not refresh scaffold: {e}",
-                        err=True,
-                    )
-
+        # The cage's cage.yaml + Containerfile are frozen at create time and
+        # owned by the cage from then on — a scaffold is a one-shot
+        # generator, not a live dependency. `cage update` (without -c)
+        # deliberately never re-reads the scaffold and never mutates the
+        # stored config: it rebuilds the staged Containerfile, pulls fresh
+        # base images (--pull), and restarts. To change config, edit it
+        # explicitly via `cage edit` or supply a new config with
+        # `cage update -c <file>`.
         cfg = state.load_deployment_config(name)
         try:
             warnings = validate_config(cfg)
@@ -1854,6 +1752,15 @@ def cage_show(name: str):
     click.echo(f"Name:       {cfg.name}")
     click.echo(f"Isolation:  {cfg.isolation}")
     click.echo(f"Image:      {cfg.container.image}")
+    # Surface the staged Containerfile — the copy `cage update` actually
+    # builds (any backend). It's owned by the cage, not the file authored at
+    # create time, so edits to the original have no effect; this is the one
+    # to edit. Only shown when a staged copy really exists on disk.
+    if cfg.container.build.containerfile:
+        staged_cf = (state.deployment_dir(name)
+                     / cfg.container.build.containerfile)
+        if staged_cf.is_file():
+            click.echo(f"Build:      {staged_cf}")
     click.echo(f"Version:    {meta.get('agentcage_version', '-')}")
     click.echo(f"Status:     {status}")
 

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -212,7 +212,13 @@ def build_container_image(
             echo(f"Build arg {key}: {new}")
 
     if echo:
-        echo(f"Building {cfg.container.image}{' (no-cache)' if no_cache else ''}...")
+        # Show the resolved Containerfile path so the operator can see which
+        # copy is actually built — for an existing cage this is the staged
+        # copy in the cage's state dir, NOT the file they authored at create
+        # time. Editing the original has no effect; edit this one (or use
+        # `cage update -c <config>` to re-stage from a config you control).
+        echo(f"Building {cfg.container.image} from {containerfile}"
+             f"{' (no-cache)' if no_cache else ''}...")
     podman.build_image(
         cfg.container.image,
         str(containerfile),

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1401,19 +1401,21 @@ def test_build_artifacts_falls_back_to_user_cmd_when_unset():
     assert build_mock.call_args.kwargs["user_cmd"] == ["/bin/sh"]
 
 
-def test_build_artifacts_orders_scaffold_before_wrapper_no_pull_for_local():
-    """Scaffold images build BEFORE the wrapper (the wrapper's
-    `FROM <user_image>` references the scaffold-produced tag), and a
-    locally-present `localhost/` scaffold image is NOT pulled — pulling a
-    local-only ref is guaranteed to fail and is pure wasted work.
+def test_build_artifacts_orders_scaffold_before_wrapper_no_pull_for_local(tmp_path):
+    """The cage image (built from its staged Containerfile) builds BEFORE the
+    wrapper (the wrapper's `FROM <user_image>` references that tag), and a
+    locally-present `localhost/` image is NOT pulled — pulling a local-only
+    ref is guaranteed to fail and is pure wasted work.
     """
+    (tmp_path / "Containerfile").write_text("FROM scratch\n")
     cfg = Config(name="t", isolation="apple-container")
     cfg.container.image = "localhost/agentcage-scaffold-ubuntu:latest"
+    cfg.container.build.containerfile = "Containerfile"
     cfg.scaffold = "ubuntu"
 
     calls: list[str] = []
 
-    def scaffold_side_effect(scaffold, **kwargs):  # noqa: ARG001
+    def staged_side_effect(*args, **kwargs):  # noqa: ARG001
         calls.append("scaffold")
 
     def run_side_effect(argv, **kwargs):  # noqa: ARG001
@@ -1425,7 +1427,8 @@ def test_build_artifacts_orders_scaffold_before_wrapper_no_pull_for_local():
         calls.append("wrapper")
         return "img"
 
-    with patch.object(ac_scaffold, "build_scaffold_images", side_effect=scaffold_side_effect), \
+    with patch.object(ac_scaffold, "build_image_from_staged", side_effect=staged_side_effect), \
+         patch("agentcage.state.deployment_dir", return_value=tmp_path), \
          patch.object(ac_cli, "run", side_effect=run_side_effect), \
          patch.object(ac_cli, "image_inspect", return_value={"config": {"Cmd": ["/bin/bash"]}}), \
          patch.object(ac_wrapper, "_user_cmd", return_value=["/bin/bash"]), \
@@ -3957,9 +3960,12 @@ def test_egress_build_skips_when_present_and_not_forced():
     run_mock.assert_not_called()
 
 
-def test_scaffold_build_no_cache_pull_bypasses_skip_and_passes_flags():
-    """`build_scaffold_images(no_cache=True, pull=True)` rebuilds even when
-    the scaffold image exists and forwards both flags to `container build`."""
+def test_build_image_from_staged_passes_flags_and_build_args(tmp_path):
+    """`build_image_from_staged(no_cache=True, pull=True)` forwards both flags
+    and the (resolved) build args to `container build`, building the cage's
+    own staged Containerfile."""
+    cf = tmp_path / "Containerfile"
+    cf.write_text("FROM scratch\n")
     calls: list[list[str]] = []
 
     def fake_run(argv, **kwargs):  # noqa: ARG001
@@ -3967,28 +3973,37 @@ def test_scaffold_build_no_cache_pull_bypasses_skip_and_passes_flags():
         return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     with patch.object(ac_cli, "run", side_effect=fake_run), \
-         patch.object(ac_cli, "image_inspect", return_value={"present": True}):
-        ac_scaffold.build_scaffold_images(
-            "debian", quiet=True, no_cache=True, pull=True,
+         patch("agentcage.registry.resolve_build_args",
+               return_value=({"BASE_IMAGE": "x:1"}, [])):
+        ac_scaffold.build_image_from_staged(
+            "localhost/agentcage-scaffold-debian:latest", cf, tmp_path,
+            {"BASE_IMAGE": "x"}, quiet=True, no_cache=True, pull=True,
         )
 
     builds = [a for a in calls if a[:1] == ["build"]]
-    assert builds, "scaffold image must rebuild when forced"
+    assert builds, "image must be built from the staged Containerfile"
     assert "--no-cache" in builds[0]
     assert "--pull" in builds[0]
+    assert "-f" in builds[0] and str(cf) in builds[0]
+    assert "--build-arg" in builds[0] and "BASE_IMAGE=x:1" in builds[0]
+    assert builds[0][-1] == str(tmp_path)  # context dir
 
 
-def test_build_artifacts_threads_no_cache_and_pull_to_all_builders():
+def test_build_artifacts_threads_no_cache_and_pull_to_all_builders(tmp_path):
     """`build_artifacts(no_cache=True, pull=True)` propagates both flags to
-    the egress build, the scaffold build, and the wrapper build (no-cache)."""
+    the egress build, the staged-Containerfile build, and the wrapper build
+    (no-cache)."""
+    (tmp_path / "Containerfile").write_text("FROM scratch\n")
     backend = AppleContainerBackend()
     cfg = Config(name="t", isolation="apple-container")
     cfg.container.image = "localhost/agentcage-scaffold-debian:latest"
+    cfg.container.build.containerfile = "Containerfile"
     cfg.container.command = ["sh", "-c", "sleep infinity"]
     cfg.scaffold = "debian"
 
     with patch.object(backend, "_build_egress_image_if_missing") as egress, \
-         patch.object(ac_scaffold, "build_scaffold_images") as scaffold, \
+         patch.object(ac_scaffold, "build_image_from_staged") as staged, \
+         patch("agentcage.state.deployment_dir", return_value=tmp_path), \
          patch.object(ac_cli, "image_inspect", return_value={"present": True}), \
          patch.object(backend, "_render_egress_config"), \
          patch.object(ac_wrapper, "build_wrapper") as wrapper:
@@ -3996,8 +4011,8 @@ def test_build_artifacts_threads_no_cache_and_pull_to_all_builders():
 
     assert egress.call_args.kwargs.get("no_cache") is True
     assert egress.call_args.kwargs.get("pull") is True
-    assert scaffold.call_args.kwargs.get("no_cache") is True
-    assert scaffold.call_args.kwargs.get("pull") is True
+    assert staged.call_args.kwargs.get("no_cache") is True
+    assert staged.call_args.kwargs.get("pull") is True
     assert wrapper.call_args.kwargs.get("no_cache") is True
 
 
@@ -4041,7 +4056,6 @@ def test_build_artifacts_pull_does_not_pull_localhost_ref():
         return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     with patch.object(backend, "_build_egress_image_if_missing"), \
-         patch.object(ac_scaffold, "build_scaffold_images"), \
          patch.object(ac_cli, "run", side_effect=fake_run), \
          patch.object(ac_cli, "image_inspect", return_value={"present": True}), \
          patch.object(backend, "_render_egress_config"), \

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -360,180 +360,43 @@ class TestCageUpdateNoCache:
         assert mock_build.call_args.kwargs.get("no_cache") is True
 
 
-class TestCageUpdateBuildArgs:
-    """Verify `cage update` re-resolves scaffold-declared-untagged build args."""
+class TestCageUpdateFreezesConfig:
+    """`cage update` (without -c) treats cage.yaml + the staged Containerfile
+    as frozen: it rebuilds the staged image and restarts, but never re-reads
+    the scaffold and never mutates the stored config.
 
-    def _mock_stored_raw(self, build_args: dict[str, str], scaffold: str = "openclaw"):
-        """Return a minimal raw config dict with the given build_args."""
-        return {
+    Regression for the old behavior where update re-staged the scaffold's
+    Containerfile (clobbering operator edits), re-rendered command/env, and
+    auto-bumped scaffold-declared build args.
+    """
+
+    def _run_update(self, mock_state, MockPodman, tmp_path):
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+        stored = {
             "name": "test",
-            "scaffold": scaffold,
+            "scaffold": "openclaw",
             "container": {
-                "image": "localhost/agentcage-scaffold-openclaw:latest",
+                # A real registry ref (not localhost/) so the OLD code would
+                # have tried resolve_latest_tag; an untagged build arg so the
+                # OLD code would have auto-bumped it. Freeze must do neither.
+                "image": "ghcr.io/openclaw/openclaw:2026.3.13-1",
                 "build": {
                     "containerfile": "Containerfile",
-                    "args": dict(build_args),
+                    "args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"},
                 },
             },
             "domains": {"allow": ["example.com"]},
         }
-
-    def _run_update(
-        self,
-        stored_raw,
-        scaffold_meta,
-        resolver_returns,
-        mock_state,
-        MockPodman,
-        mock_systemd,
-        tmp_path,
-    ):
-        """Invoke `cage update test` with everything below the resolver mocked out."""
-        mock_state.deployment_exists.return_value = True
-        mock_state.load_raw_config.return_value = stored_raw
-        # After save_raw_config, capture the raw dict so tests can assert on it.
-        saved: dict = {}
-
-        def _save(name, raw):
-            saved.clear()
-            saved.update(raw)
-
-        mock_state.save_raw_config.side_effect = _save
-        # Make load_deployment_config pass through validate_config by reusing the
-        # raw dict the test handed in (state saves are captured but we want
-        # validation to succeed regardless).
-        from agentcage.config import Config, ContainerConfig, BuildConfig
-        mock_cfg = Config(
-            name=stored_raw["name"],
-            isolation="container",
-            container=ContainerConfig(
-                image=stored_raw["container"]["image"],
-                build=BuildConfig(
-                    containerfile="Containerfile",
-                    args=stored_raw["container"]["build"]["args"],
-                ),
-            ),
-        )
-        mock_state.load_deployment_config.return_value = mock_cfg
-        mock_state.load_metadata.return_value = {"scaffold": "openclaw", "agentcage_version": "0.22.0"}
-        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
-        mock_state.save_metadata.return_value = None
-        # Use a real tmp dir so scaffold-refresh's shutil.copy2 call doesn't
-        # create a file named after the MagicMock's repr in the cwd.
-        mock_state.deployment_dir.return_value = tmp_path
-
-        podman = MockPodman.return_value
-        podman.secret_exists.return_value = True
-        podman.pull.return_value = True
-
-        with patch("agentcage.init.load_scaffold_meta", return_value=scaffold_meta), \
-             patch("agentcage.registry.resolve_latest_tag", side_effect=resolver_returns), \
-             patch("agentcage.cli._build_container_image"), \
-             patch("agentcage.cli._build_and_deploy"), \
-             patch("agentcage.cli._check_port_availability", return_value=[]), \
-             patch("agentcage.cli._check_secrets", return_value=[]), \
-             patch("agentcage.cli.get_backend") as mock_backend:
-            mock_backend.return_value.stop.return_value = None
-            result = _runner().invoke(main, ["cage", "update", "test"])
-        return result, saved
-
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_bumps_scaffold_untagged_arg(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
-        result, saved = self._run_update(
-            stored, scaffold_meta, lambda _: "2026.4.1-1",
-            mock_state, MockPodman, mock_systemd, tmp_path,
-        )
-        assert result.exit_code == 0, result.output
-        assert "Build arg BASE_IMAGE:" in result.output
-        assert "2026.3.13-1" in result.output
-        assert "2026.4.1-1" in result.output
-        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.4.1-1"
-
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_respects_scaffold_pinned_arg(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:v1.0.0"})
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw:v1.0.0"}}]}
-        resolve_calls: list[str] = []
-
-        def _resolver(base):
-            resolve_calls.append(base)
-            return "v9.9.9"
-
-        result, _saved = self._run_update(
-            stored, scaffold_meta, _resolver,
-            mock_state, MockPodman, mock_systemd, tmp_path,
-        )
-        assert result.exit_code == 0, result.output
-        # Scaffold pin matches stored pin — nothing changed, no resolver call
-        assert "Build arg BASE_IMAGE:" not in result.output
-        # resolve_latest_tag MUST NOT have been called for the scaffold-pinned arg
-        # (may have been called for container.image but that starts with "localhost/"
-        # so we short-circuited that path too)
-        assert resolve_calls == []
-
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_preserves_pin_on_resolver_failure(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        """REGRESSION: offline update MUST NOT un-pin a working build."""
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
-        result, saved = self._run_update(
-            stored, scaffold_meta, lambda _: None,  # resolver fails
-            mock_state, MockPodman, mock_systemd, tmp_path,
-        )
-        assert result.exit_code == 0, result.output
-        assert "Build arg BASE_IMAGE:" not in result.output
-        # No state write for build_args happened — saved is either empty (never
-        # called) or has the original value untouched.
-        if saved:
-            assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.3.13-1"
-
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_migrates_on_scaffold_base_change(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        """Scaffold author renamed the upstream image — users auto-migrate + warning."""
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/old/base:v1"})
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/new/base"}}]}
-        result, saved = self._run_update(
-            stored, scaffold_meta, lambda _: "v2",
-            mock_state, MockPodman, mock_systemd, tmp_path,
-        )
-        assert result.exit_code == 0, result.output
-        assert "Build arg BASE_IMAGE:" in result.output
-        assert "ghcr.io/new/base:v2" in result.output
-        # Drift warning visible
-        assert "base image for BASE_IMAGE changed" in result.output
-        assert "ghcr.io/old/base" in result.output
-        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/new/base:v2"
-
-    @patch("agentcage.cli.systemd")
-    @patch("agentcage.cli.Podman")
-    @patch("agentcage.cli.state")
-    def test_infers_scaffold_from_image_when_metadata_missing(
-        self, mock_state, MockPodman, mock_systemd, tmp_path,
-    ):
-        """Cages created before scaffold-persistence landed still auto-bump."""
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
-        # Legacy cage: no scaffold field anywhere — only the image name hints at it
-        stored.pop("scaffold", None)
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
-        # Metadata has NO scaffold key — force inference from image name
-        mock_state.load_metadata.return_value = {"agentcage_version": "0.22.0"}
         mock_state.deployment_exists.return_value = True
         mock_state.load_raw_config.return_value = stored
-        saved: dict = {}
-        mock_state.save_raw_config.side_effect = lambda _n, r: saved.update(r) or None
-        from agentcage.config import Config, ContainerConfig, BuildConfig
+        mock_state.load_metadata.return_value = {
+            "scaffold": "openclaw", "agentcage_version": "0.22.0",
+        }
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
         mock_state.load_deployment_config.return_value = Config(
-            name=stored["name"], isolation="container",
+            name="test",
+            isolation="container",
             container=ContainerConfig(
                 image=stored["container"]["image"],
                 build=BuildConfig(
@@ -542,41 +405,67 @@ class TestCageUpdateBuildArgs:
                 ),
             ),
         )
-        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
-        mock_state.deployment_dir.return_value = tmp_path
         podman = MockPodman.return_value
         podman.secret_exists.return_value = True
         podman.pull.return_value = True
 
-        with patch("agentcage.init.load_scaffold_meta", return_value=scaffold_meta), \
-             patch("agentcage.registry.resolve_latest_tag", side_effect=lambda _b: "2026.4.9"), \
-             patch("agentcage.cli._build_container_image"), \
+        with patch("agentcage.init.load_scaffold_meta") as mock_meta, \
+             patch("agentcage.registry.resolve_latest_tag") as mock_tag, \
+             patch("agentcage.cli._stage_build_context") as mock_stage, \
+             patch("agentcage.cli._build_container_image") as mock_build, \
              patch("agentcage.cli._build_and_deploy"), \
              patch("agentcage.cli._check_port_availability", return_value=[]), \
              patch("agentcage.cli._check_secrets", return_value=[]), \
              patch("agentcage.cli.get_backend") as mock_backend:
             mock_backend.return_value.stop.return_value = None
             result = _runner().invoke(main, ["cage", "update", "test"])
-
-        assert result.exit_code == 0, result.output
-        # Scaffold inferred from "localhost/agentcage-scaffold-openclaw:latest"
-        assert "Build arg BASE_IMAGE:" in result.output
-        assert saved["container"]["build"]["args"]["BASE_IMAGE"] == "ghcr.io/openclaw/openclaw:2026.4.9"
+        return result, mock_meta, mock_tag, mock_stage, mock_build, podman
 
     @patch("agentcage.cli.systemd")
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
-    def test_suppresses_localhost_warning(self, mock_state, MockPodman, mock_systemd, tmp_path):
-        """localhost/... image refs must not produce `could not resolve latest tag` noise."""
-        stored = self._mock_stored_raw({"BASE_IMAGE": "ghcr.io/openclaw/openclaw:2026.3.13-1"})
-        scaffold_meta = {"build": [{"build_args": {"BASE_IMAGE": "ghcr.io/openclaw/openclaw"}}]}
-        # stored["container"]["image"] is "localhost/agentcage-scaffold-openclaw:latest"
-        result, _saved = self._run_update(
-            stored, scaffold_meta, lambda _: "2026.4.1-1",
-            mock_state, MockPodman, mock_systemd, tmp_path,
-        )
+    def test_does_not_mutate_stored_config(
+        self, mock_state, MockPodman, mock_systemd, tmp_path,
+    ):
+        result, *_ = self._run_update(mock_state, MockPodman, tmp_path)
         assert result.exit_code == 0, result.output
-        assert "could not resolve latest tag" not in result.output
+        # The frozen config is never rewritten...
+        assert not mock_state.save_raw_config.called
+        # ...and none of the old mutation chatter appears.
+        assert "Build arg" not in result.output
+        assert "Image:" not in result.output
+        assert "Command updated" not in result.output
+        assert "Added env" not in result.output
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_does_not_read_or_restage_scaffold(
+        self, mock_state, MockPodman, mock_systemd, tmp_path,
+    ):
+        result, mock_meta, mock_tag, mock_stage, _build, _podman = \
+            self._run_update(mock_state, MockPodman, tmp_path)
+        assert result.exit_code == 0, result.output
+        # The scaffold is never consulted...
+        mock_meta.assert_not_called()
+        mock_tag.assert_not_called()
+        # ...and the staged Containerfile is never overwritten.
+        mock_stage.assert_not_called()
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_still_rebuilds_and_pulls(
+        self, mock_state, MockPodman, mock_systemd, tmp_path,
+    ):
+        result, _meta, _tag, _stage, mock_build, podman = \
+            self._run_update(mock_state, MockPodman, tmp_path)
+        assert result.exit_code == 0, result.output
+        # Freeze still rebuilds the staged image from the cage's state dir...
+        mock_build.assert_called_once()
+        assert mock_build.call_args.args[1] == tmp_path
+        # ...and pulls a fresh base image.
+        assert podman.pull.called
 
 
 class TestCageUpdatePreservesNetworkOctet:


### PR DESCRIPTION
## What

A scaffold is a **one-shot generator, not a live dependency**. Once a cage is created, it owns its `cage.yaml` + `Containerfile`, and `cage update` never re-reads the scaffold or mutates the stored config — consistently across the **container, vm, and apple-container** backends.

This started from an operator hitting "I edited the Containerfile but `cage update` ignores my changes" — the old no-`-c` update path silently re-staged the scaffold's Containerfile over their edits, re-rendered `command`/`env`, and auto-bumped build args.

## Changes

**`cli.py` (shared, all backends).** The no-`-c` branch of `cage_update` no longer:
- re-stages the scaffold `Containerfile` (clobbering operator edits),
- re-renders the scaffold template to patch `command`/`env`,
- bumps scaffold-declared build args, or
- rewrites the `container.image` tag.

It now only loads + validates the stored config, rebuilds the **staged** Containerfile, pulls fresh base images, and restarts. The stored config is never mutated. To change config: edit the staged files, `cage edit`, or `cage update -c <file>`.

**apple-container parity.** Previously the backend (re)built the scaffold image from the **live scaffold dir** (`build_scaffold_images`) using unpinned build args — so an agentcage upgrade leaked scaffold changes into existing cages on update (especially under `--no-cache`/`--pull`). It now builds `container.image` from the cage's **own staged `Containerfile`** with point-in-time build-arg resolution, exactly like the container/vm backends (`build_image_from_staged`).

**Discoverability** (the operator couldn't tell which Containerfile is built):
- `cage show` prints a `Build:` line with the staged Containerfile path.
- the build step echoes `Building <image> from <path>...`.

## Verification

- Full Python suite: **1653 passing**.
- Real hardware (macOS 26.3 / Apple `container` 0.12.3): created an `ubuntu` scaffold cage, appended a marker to the **staged** Containerfile and a *different* marker to the **live** scaffold, then `cage update --no-cache`. Result: the staged-edit marker is present in the rebuilt image; the live-scaffold marker is **absent** — proving the freeze holds on apple-container exactly as on linux.

## Docs

`docs/reference/cli.md` (cage update contract) and `docs/how-to/upgrade-agentcage.md` (scaffold templates are not pulled into existing cages) updated. CHANGELOG under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)