### PR TITLE
feat(cli): docker/podman/systemctl ergonomics — create positional, logs --tail/--since, status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI ergonomics for docker/podman/systemctl users.**
+  - `cage create` now accepts the config **positionally** (`agentcage create ./cage.yaml`) as well as via `-c` (docker/podman `create`/`run` style); giving it both ways errors.
+  - `cage logs` gained `--tail` (docker/podman alias for `-n/--lines`) and `--since` (journalctl/docker time filter, threaded to journalctl on container/vm; warned-and-ignored on apple-container, which can't honor it).
+  - `cage status [NAME]` is now a real `systemctl status`-style command: with a NAME it shows that cage's detail (same as `cage show`); with no argument it lists all cages. `status` (group + top-level) previously always listed and ignored any NAME.
+
 ## [0.22.17] - 2026-05-29
 
 ### Changed

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -65,6 +65,7 @@ Manage cages.
 | `cage destroy NAME` | Stop containers, remove quadlets, state, and scoped secrets |
 | `cage prune` | Remove all exited interactive and ephemeral cages |
 | `cage show NAME` | Show cage configuration and status |
+| `cage status [NAME]` | `systemctl`-style: detail for one cage (with NAME) or list all (without) |
 | `cage verify NAME` | Run health checks (containers, certs, proxy, egress, rootless) |
 | `cage stop NAME` | Stop a running cage without destroying it |
 | `cage start NAME` | Start a stopped cage |
@@ -83,17 +84,19 @@ Aliases: `ls`/`ps`/`status` → `list`, `rm`/`delete` → `destroy`, `reload` �
 ### cage create
 
 ```bash
-agentcage cage create -c <config>
+agentcage cage create <config>        # positional (docker/podman style)
+agentcage cage create -c <config>     # or with -c
 ```
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `-c, --config` | path | *(required)* | Path to `cage.yaml` |
+| `CONFIG` | path (positional) | | Path to `cage.yaml`. Alternative to `-c`. |
+| `-c, --config` | path | | Path to `cage.yaml`. Give the config positionally **or** with `-c`, not both. |
 | `-s, --set-secret` | repeatable | | Set a secret inline during creation (`KEY=VALUE`) |
 | `--no-cache` | flag | | Force a full image rebuild, ignoring podman's layer cache |
 | `--pull` | flag | | Force a re-pull of the base image from the registry |
 
-Fails with an actionable error if any required secrets are missing.
+The config is required — pass it positionally or with `-c`. Fails with an actionable error if any required secrets are missing.
 
 ### cage update
 
@@ -140,7 +143,15 @@ Runs health checks against a running cage: containers up, CA cert present, `HTTP
 
 ### cage show
 
-Show cage configuration and status: name, isolation mode, image, version, service status, ports, domain mode, and secrets status. Aliases: `describe`, `inspect`.
+Show cage configuration and status: name, isolation mode, image, `Build:` (the staged Containerfile path), version, service status, ports, domain mode, and secrets status. Aliases: `describe`, `inspect`.
+
+### cage status
+
+```bash
+agentcage cage status [name]
+```
+
+`systemctl status`-style: with a `NAME`, shows that cage's detail (identical to `cage show`); with no argument, lists every cage (identical to `cage list`). Available top-level as `agentcage status`.
 
 ### cage stop / start / restart
 
@@ -154,9 +165,10 @@ agentcage cage logs <name> [options]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `-s, --service` | repeatable `cage`\|`proxy`\|`dns` | all | Filter by service |
-| `-n, --lines` | int | `50` | Number of lines to show |
+| `-s, --service` | repeatable `cage`\|`egress` | all | Filter by service |
+| `-n, --lines, --tail` | int | `50` | Number of lines to show (`--tail` is a docker/podman alias) |
 | `-f, --follow` | flag | | Stream logs in real time |
+| `--since` | string | | Show entries since a time, journalctl syntax (`10 min ago`, `today`, `2026-05-29 14:00`). Not supported on apple-container. |
 | `-l, --severity` | `debug`\|`info`\|`warning`\|`error`\|`critical` | | Minimum severity level |
 
 ### cage shell

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -336,7 +336,7 @@ class _BannerGroup(click.Group):
             "rm": ("cage_destroy", "cage destroy"),
             "delete": ("cage_destroy", "cage destroy"),
             "ps": ("cage_list", "cage list"),
-            "status": ("cage_list", "cage list"),
+            "status": ("cage_status", "cage status"),
             "restart": ("cage_restart", "cage restart"),
             "reload": ("cage_restart", "cage restart"),
             "show": ("cage_show", "cage show"),
@@ -551,13 +551,15 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
 # ── cage group ────────────────────────────────────────────
 
 
-@main.group(cls=AliasGroup, aliases={"ls": "list", "rm": "destroy", "ps": "list", "status": "list", "reload": "restart", "delete": "destroy", "describe": "show", "inspect": "show", "config": "edit"})
+@main.group(cls=AliasGroup, aliases={"ls": "list", "rm": "destroy", "ps": "list", "reload": "restart", "delete": "destroy", "describe": "show", "inspect": "show", "config": "edit"})
 def cage():
     """Manage cages."""
 
 
 @cage.command("create")
-@click.option("-c", "--config", "config_path", required=True, type=click.Path(exists=True))
+@click.argument("config_pos", required=False, type=click.Path(exists=True))
+@click.option("-c", "--config", "config_path", required=False, type=click.Path(exists=True),
+              help="Path to the cage config (cage.yaml). May also be given positionally.")
 @click.option("-s", "--set-secret", "secrets", multiple=True,
               help="Set a secret (KEY=VALUE or KEY to prompt). Repeatable.")
 @click.option("--no-cache", is_flag=True,
@@ -566,12 +568,32 @@ def cage():
               help="Force re-pull of the base image from the registry.")
 @click.option("--time", "show_timing", is_flag=True,
               help="Echo per-phase wall times and print a summary on completion.")
-def cage_create(config_path: str, secrets: tuple, no_cache: bool, pull: bool,
-                show_timing: bool):
-    """Build images, generate quadlets, install, and start a new cage."""
+def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
+                no_cache: bool, pull: bool, show_timing: bool):
+    """Build images, generate quadlets, install, and start a new cage.
+
+    The config may be given positionally (`agentcage create ./cage.yaml`)
+    or with -c (`agentcage create -c ./cage.yaml`).
+    """
     from agentcage import output as _out
     from agentcage import _timing
     _out.banner(version("agentcage"))
+
+    # Reconcile the positional config and -c/--config: exactly one source.
+    if config_pos and config_path and config_pos != config_path:
+        click.echo(
+            "error: config given both positionally and with -c; specify it once",
+            err=True,
+        )
+        sys.exit(1)
+    config_path = config_path or config_pos
+    if not config_path:
+        click.echo(
+            "error: missing config — pass a path (e.g. `create ./cage.yaml`) "
+            "or use -c/--config",
+            err=True,
+        )
+        sys.exit(1)
 
     if show_timing:
         os.environ["AGENTCAGE_TIMING"] = "1"
@@ -1800,18 +1822,37 @@ def cage_show(name: str):
             click.echo(f"Secrets:    {len(expected)}/{len(expected)}")
 
 
+@cage.command("status")
+@click.argument("name", required=False)
+@click.pass_context
+def cage_status(ctx, name):
+    """Show status — one cage's detail (with NAME) or all cages (without).
+
+    Mirrors `systemctl status`: `agentcage status` lists every cage;
+    `agentcage status <name>` shows that cage's detail (same as `cage show`).
+    """
+    if name:
+        ctx.invoke(cage_show, name=name)
+    else:
+        ctx.invoke(cage_list)
+
+
 @cage.command("logs")
 @click.argument("name")
 @click.option("-s", "--service", "services", multiple=True,
               type=click.Choice(["cage", "egress"]))
-@click.option("-n", "--lines", default=50, show_default=True,
-              help="Number of lines to show.")
+@click.option("-n", "--lines", "--tail", "lines", default=50, show_default=True,
+              help="Number of lines to show (alias: --tail, like docker/podman).")
 @click.option("-f", "--follow", is_flag=True, help="Stream logs in real time.")
 @click.option("--no-follow", is_flag=True, hidden=True, help="Backward compat no-op.")
+@click.option("--since", default=None,
+              help="Show entries since a time, journalctl syntax "
+                   "(e.g. '10 min ago', 'today', '2026-05-29 14:00'). "
+                   "Not supported on apple-container.")
 @click.option("-l", "--severity", "min_level", default=None,
               type=click.Choice(["debug", "info", "warning", "error", "critical"]),
               help="Minimum severity level to show.")
-def cage_logs(name, services, lines, follow, no_follow, min_level):
+def cage_logs(name, services, lines, follow, no_follow, since, min_level):
     """Show journalctl logs for a cage."""
     if not state.deployment_exists(name):
         click.echo(f"error: cage '{name}' does not exist", err=True)
@@ -1824,11 +1865,16 @@ def cage_logs(name, services, lines, follow, no_follow, min_level):
     no_follow_effective = not follow
 
     if cfg.isolation == "vm":
-        _logs_vm(name, selected, lines, no_follow_effective, min_level)
+        _logs_vm(name, selected, lines, no_follow_effective, min_level, since=since)
     elif _is_apple_container(cfg):
+        if since:
+            click.echo(
+                "warning: --since is not supported on apple-container; ignoring",
+                err=True,
+            )
         _logs_apple_container(name, selected, lines, no_follow_effective, min_level, cfg=cfg)
     else:
-        _logs_container(name, selected, lines, no_follow_effective, min_level)
+        _logs_container(name, selected, lines, no_follow_effective, min_level, since=since)
 
 
 def _classify_line(service: str, line: str) -> str:
@@ -1867,13 +1913,15 @@ def _classify_line(service: str, line: str) -> str:
     return "info"
 
 
-def _logs_container(name, services, lines, no_follow, min_level=None):
+def _logs_container(name, services, lines, no_follow, min_level=None, since=None):
     """Exec into journalctl with one -u per host-level service unit."""
     units = [f"{name}-{svc}" for svc in services]
     cmd = ["journalctl", "--user"]
     for u in units:
         cmd += ["-u", u]
     cmd += ["-n", str(lines)]
+    if since:
+        cmd += ["--since", since]
     if not no_follow:
         cmd.append("-f")
 
@@ -1916,7 +1964,7 @@ def _level_grep_pattern(services: tuple, min_level: str | None) -> str:
     return rf"\[({svc_alt}):({lvl_alt})\]"
 
 
-def _logs_vm(name, services, lines, no_follow, min_level=None):
+def _logs_vm(name, services, lines, no_follow, min_level=None, since=None):
     """Show logs from inside the Lima VM via limactl shell."""
     inst = LimaInstance(name)
     # Quadlets run as systemd --user units, but conmon writes their logs to
@@ -1929,6 +1977,8 @@ def _logs_vm(name, services, lines, no_follow, min_level=None):
     for u in units:
         inner += ["--user-unit", u]
     inner += ["-n", str(lines), "-o", "cat"]
+    if since:
+        inner += ["--since", since]
     if not no_follow:
         inner.append("-f")
 

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -54,6 +54,33 @@ class TestCageCreate:
     def test_create_requires_config(self, mock_state, MockPodman, mock_systemd):
         result = _runner().invoke(main, ["cage", "create"])
         assert result.exit_code != 0
+        assert "missing config" in result.output
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_create_accepts_positional_config(self, mock_state, MockPodman, mock_systemd, minimal_yaml):
+        # Positional config is sugar for -c (docker/podman style). It reaches
+        # the same load path; deployment_exists=True short-circuits to the
+        # "already exists" error, proving the positional config resolved.
+        mock_state.deployment_exists.return_value = True
+        result = _runner().invoke(main, ["cage", "create", minimal_yaml])
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_create_rejects_conflicting_config_sources(
+        self, mock_state, MockPodman, mock_systemd, minimal_yaml, tmp_path,
+    ):
+        other = tmp_path / "other.yaml"
+        other.write_text("name: other\ncontainer:\n  image: x:latest\n")
+        result = _runner().invoke(
+            main, ["cage", "create", minimal_yaml, "-c", str(other)],
+        )
+        assert result.exit_code != 0
+        assert "specify it once" in result.output
 
     @patch("agentcage.config.platform.machine", return_value="arm64")
     @patch("agentcage.config.platform.system", return_value="Darwin")
@@ -1285,6 +1312,36 @@ class TestCageLogs:
             "journalctl", "--user",
             "-u", "basic-cage", "-u", "basic-egress",
             "-n", "50", "-f",
+        ])
+
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_logs_tail_alias(self, mock_state, mock_execvp):
+        """`--tail N` is a docker/podman-style alias for `-n/--lines`."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("container")
+        result = _runner().invoke(main, ["cage", "logs", "basic", "--tail", "7"])
+        assert result.exit_code == 0
+        mock_execvp.assert_called_once_with("journalctl", [
+            "journalctl", "--user",
+            "-u", "basic-cage", "-u", "basic-egress",
+            "-n", "7",
+        ])
+
+    @patch("agentcage.cli.os.execvp")
+    @patch("agentcage.cli.state")
+    def test_logs_since(self, mock_state, mock_execvp):
+        """`--since` threads through to journalctl (docker/journalctl style)."""
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = _mock_config("container")
+        result = _runner().invoke(
+            main, ["cage", "logs", "basic", "--since", "10 min ago"],
+        )
+        assert result.exit_code == 0
+        mock_execvp.assert_called_once_with("journalctl", [
+            "journalctl", "--user",
+            "-u", "basic-cage", "-u", "basic-egress",
+            "-n", "50", "--since", "10 min ago",
         ])
 
     @patch("agentcage.cli.os.execvp")

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -29,10 +29,21 @@ class TestCageAliases:
         assert result.exit_code == 0
 
     @patch("agentcage.cli.state")
-    def test_status_resolves_to_list(self, mock_state):
+    def test_status_without_name_lists(self, mock_state):
+        # `systemctl status`-style: no NAME → list every cage.
         mock_state.list_deployments.return_value = []
         result = _runner().invoke(main, ["cage", "status"])
         assert result.exit_code == 0
+
+    @patch("agentcage.cli.state")
+    def test_status_with_name_routes_to_show(self, mock_state):
+        # `systemctl status <unit>`-style: a NAME → single-cage detail (show),
+        # NOT the list. `show` checks existence and says "does not exist";
+        # `list` would print "No cages found." with exit 0.
+        mock_state.deployment_exists.return_value = False
+        result = _runner().invoke(main, ["cage", "status", "ghost"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
 
     def test_rm_resolves_to_destroy(self):
         result = _runner().invoke(main, ["cage", "rm", "--help"])

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.16"
+version = "0.22.17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Three additive CLI ergonomics improvements so agentcage feels familiar to **docker**, **podman**, and **systemctl** users. No new features — just convention alignment.

### 1. `cage create` accepts a positional config
`agentcage create ./cage.yaml` now works as sugar for `-c ./cage.yaml` (docker/podman `create`/`run` take a positional). `-c` still works; giving the config both ways errors. The config remains required (positional **or** `-c`).

### 2. `cage logs --tail` and `--since`
- `--tail N` — docker/podman alias for the existing `-n/--lines`.
- `--since` — journalctl/docker-style time filter (`'10 min ago'`, `'today'`, `'2026-05-29 14:00'`), threaded to `journalctl --since` on container/vm. apple-container's `container logs` has no time/-n filter, so `--since` is **warned-and-ignored** there (honest, no silent no-op).

### 3. `cage status [NAME]` is now `systemctl status`-style
Previously `status` was a pure alias for `list` that **ignored any NAME**. Now it's a real command: `agentcage status <name>` shows that cage's detail (= `cage show`); `agentcage status` (no arg) lists all (= `cage list`). Top-level `agentcage status` routes here too.

## Compatibility

- #1 and #2 are purely additive.
- #3 changes behavior only for `status <name>` (previously silently listed; now shows detail). Bare `status` still lists, so existing scripts/muscle memory are unaffected.

## Tests / docs

- +5 unit tests (create positional + conflicting-source, logs `--tail`/`--since`, `status <name>` routes to show). Full suite **1658 passing**.
- `docs/reference/cli.md` (create, logs, new `cage status` section, fixed stale `proxy|dns` → `egress`) and CHANGELOG (`[Unreleased]`) updated.

Deferred per discussion: `enable`/`disable` (autostart) is a feature, not ergonomics — separate PR later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)