### PR TITLE
chore: remove dead code surfaced by complexity sweep (no behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Dead code cleanup (no behavior change).** Removed unreachable/dead internals surfaced by a complexity sweep: the never-called `_exit_apple_container_unsupported` helper, the permanent no-op `_ensure_dns_quadlet_current` stub (and its call sites + tests), the unused `_systemd_creds_usable` shim, a redundant second `get_backend()` call in `cage exec`, two unused imports in `config.py`, and the write-only `InspectionResult.score` field. Purely subtractive; all behavior is unchanged.
+
 ## [0.22.18] - 2026-05-29
 
 ### Added

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -151,22 +151,6 @@ def _is_rw_host_bind(volume_spec: str) -> bool:
     return "ro" not in mode.split(",")
 
 
-def _exit_apple_container_unsupported(command: str) -> None:
-    """Exit cleanly when a subcommand isn't implemented on apple-container.
-
-    The apple-container backend does not yet support every cage subcommand
-    that container/vm do. Rather than fall through to host podman (which
-    crashes on macOS without podman installed), we exit non-zero with a
-    helpful message. Tracked as a follow-up in issue #120.
-    """
-    click.echo(
-        f"error: 'cage {command}' is not yet implemented for the "
-        f"apple-container backend (see issue #120)",
-        err=True,
-    )
-    sys.exit(1)
-
-
 def _parse_version(ver: str) -> tuple[int, int]:
     """Parse 'X.Y[.Z…]' → (X, Y); return (0, 0) on garbage."""
     try:
@@ -291,17 +275,15 @@ def _restart_cage(name: str, cfg=None):
       part of the systemd unit, so updating it doesn't require a
       daemon-reload — just a service restart, which we're about to do anyway.
 
-    The DNS quadlet itself almost never has to change (its content no longer
-    depends on the domain list); :func:`_ensure_dns_quadlet_current` handles
-    the rare migration case where an older agentcage left a stale unit on
-    disk. Delegates the actual service restart to
+    The DNS quadlet itself no longer has to change (its content no longer
+    depends on the domain list — the allowlist lives in a bind-mounted
+    sidecar file). Delegates the actual service restart to
     :func:`agentcage.services.restart_cage`.
     """
     if cfg is None:
         cfg = state.load_deployment_config(name)
     state.save_proxy_config(name)
     state.save_dns_allowlist(name)
-    _ensure_dns_quadlet_current(cfg)
     from agentcage.services import restart_cage
     restart_cage(name, cfg)
 
@@ -1740,7 +1722,6 @@ def cage_start(name: str):
         # itself only needs rewriting on the (rare) migration case.
         state.save_proxy_config(name)
         state.save_dns_allowlist(name)
-        _ensure_dns_quadlet_current(cfg)
 
     backend = get_backend(cfg)
     backend.start(name)
@@ -2165,7 +2146,6 @@ def cage_exec(name: str, service: str, command: tuple[str, ...], as_root: bool):
     # with CAP_NET_ADMIN). container / vm ignore the kwarg — their proxy
     # / dns / cage units already drop privileges per Quadlet.
     from agentcage.backend import BackendUnsupported
-    backend = get_backend(cfg)
     try:
         argv = backend.exec_argv(
             name, service, cmd,
@@ -3482,25 +3462,6 @@ def domain_list(name: str):
     for d in sorted(passthrough):
         if d not in domain_entries:
             click.echo(f"{d} [passthrough only]")
-
-
-def _ensure_dns_quadlet_current(cfg) -> bool:
-    """No-op in the v0.22 2-service shape.
-
-    Kept as a callable so the cage-restart path's invocation site doesn't
-    need a conditional. In the legacy 3-service shape this helper rendered
-    a fresh ``<name>-dns.container`` quadlet and ``daemon-reload``-ed when
-    the rendered content drifted from disk (e.g. after a pre-allowlist-
-    sidecar upgrade). In the v0.22 shape the egress quadlet is the only
-    DNS-bearing unit, its content is stable across domain edits (the
-    allowlist lives in a bind-mounted sidecar file), and the file rewrite
-    + SIGHUP fast path handled by :func:`_update_dns_quadlet` is sufficient.
-
-    Always returns ``False`` so existing call sites that branch on a
-    "quadlet was rewritten" return value (e.g. tests pinning the
-    legacy-migration ``systemctl restart`` path) take the no-op branch.
-    """
-    return False
 
 
 def _update_dns_quadlet(cfg) -> None:

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -11,9 +11,7 @@ from dataclasses import dataclass, field
 import yaml
 
 from agentcage.data.proxy.relays._validate import (
-    KNOWN_RELAY_TYPES,
     validate_relay_entry,
-    validate_relay_type,
 )
 
 

--- a/src/agentcage/data/proxy/inspectors/base.py
+++ b/src/agentcage/data/proxy/inspectors/base.py
@@ -14,7 +14,6 @@ class InspectionResult:
     action: str = "block"  # "block" or "flag"
     reason: str = ""
     severity: str = "warning"  # "debug", "info", "warning", "error", "critical"
-    score: float = 0.0  # for anomaly-scoring mode
     metadata: dict = field(default_factory=dict)
 
 

--- a/src/agentcage/data/proxy/inspectors/entropy.py
+++ b/src/agentcage/data/proxy/inspectors/entropy.py
@@ -147,7 +147,6 @@ class EntropyInspector(Inspector):
                     f"(threshold {self.threshold})"
                 ),
                 severity="error",
-                score=ctx.body_entropy,
                 metadata={
                     "entropy": ctx.body_entropy,
                     "threshold": self.threshold,
@@ -191,7 +190,6 @@ class EntropyInspector(Inspector):
                             f"(threshold {self.url_threshold})"
                         ),
                         severity="error",
-                        score=ent,
                         metadata={
                             "entropy": ent,
                             "url_threshold": self.url_threshold,
@@ -232,7 +230,6 @@ class EntropyInspector(Inspector):
                         f"(threshold {self.url_threshold})"
                     ),
                     severity="error",
-                    score=ent,
                     metadata={
                         "entropy": ent,
                         "url_threshold": self.url_threshold,

--- a/src/agentcage/secret_resolver.py
+++ b/src/agentcage/secret_resolver.py
@@ -116,11 +116,6 @@ def _systemd_creds_works(scope: str) -> bool:
         return False
 
 
-def _systemd_creds_usable() -> bool:
-    """Back-compat shim: True if any scope works."""
-    return detect_default_scope() is not None
-
-
 def resolve(source: str, env_name: str, state_dir: Path) -> ResolveResult:
     """Resolve a secret value from the configured backend.
 

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -804,10 +804,9 @@ class TestCageRestart:
         assert result.exit_code != 0
         assert "does not exist" in result.output
 
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.services.get_backend")
     @patch("agentcage.cli.state")
-    def test_restart_restarts_container(self, mock_state, mock_get_backend, _mock_ensure_dns):
+    def test_restart_restarts_container(self, mock_state, mock_get_backend):
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("container")
         backend = mock_get_backend.return_value
@@ -816,10 +815,9 @@ class TestCageRestart:
         assert "Restarted" in result.output
         backend.restart.assert_called_once_with("test")
 
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.services.get_backend")
     @patch("agentcage.cli.state")
-    def test_restart_restarts_vm(self, mock_state, mock_get_backend, _mock_ensure_dns):
+    def test_restart_restarts_vm(self, mock_state, mock_get_backend):
         mock_state.deployment_exists.return_value = True
         mock_state.load_deployment_config.return_value = _mock_config("vm")
         backend = mock_get_backend.return_value
@@ -828,11 +826,9 @@ class TestCageRestart:
         assert "Restarted" in result.output
         backend.restart.assert_called_once_with("test")
 
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.services.get_backend")
     @patch("agentcage.cli.state")
-    def test_restart_regenerates_proxy_config(self, mock_state, mock_get_backend,
-                                              mock_ensure_dns):
+    def test_restart_regenerates_proxy_config(self, mock_state, mock_get_backend):
         """Restart must regenerate proxy-config.yaml from cage.yaml so
         out-of-band edits to cage.yaml are picked up on reload."""
         mock_state.deployment_exists.return_value = True
@@ -842,21 +838,17 @@ class TestCageRestart:
         assert result.exit_code == 0
         mock_state.save_proxy_config.assert_called_once_with("test")
 
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.services.get_backend")
     @patch("agentcage.cli.state")
-    def test_restart_regenerates_dns_allowlist(self, mock_state, mock_get_backend,
-                                               mock_ensure_dns):
+    def test_restart_regenerates_dns_allowlist(self, mock_state, mock_get_backend):
         """Restart must regenerate the dns-allowlist.conf sidecar file so
-        dnsmasq picks up domain changes — and must run the quadlet-current
-        check too, which is the (cheap) migration safety net."""
+        dnsmasq picks up domain changes."""
         mock_state.deployment_exists.return_value = True
         cfg = _mock_config("container")
         mock_state.load_deployment_config.return_value = cfg
         result = _runner().invoke(main, ["cage", "restart", "test"])
         assert result.exit_code == 0
         mock_state.save_dns_allowlist.assert_called_once_with("test")
-        mock_ensure_dns.assert_called_once_with(cfg)
 
 
 class TestCageEdit:
@@ -1093,7 +1085,6 @@ class TestCageEdit:
 
 
 class TestCageStart:
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.secret_resolver.resolve_and_populate")
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli._ensure_patches")
@@ -1101,8 +1092,7 @@ class TestCageStart:
     @patch("agentcage.cli.state")
     def test_start_regenerates_proxy_config(self, mock_state, MockPodman,
                                             mock_ensure_patches,
-                                            mock_get_backend, mock_resolve,
-                                            mock_ensure_dns):
+                                            mock_get_backend, mock_resolve):
         """Start must regenerate proxy-config.yaml from cage.yaml so any
         edits made while the cage was stopped are applied on next start."""
         mock_state.deployment_exists.return_value = True
@@ -1112,7 +1102,6 @@ class TestCageStart:
         mock_state.save_proxy_config.assert_called_once_with("test")
         mock_get_backend.return_value.start.assert_called_once_with("test")
 
-    @patch("agentcage.cli._ensure_dns_quadlet_current")
     @patch("agentcage.secret_resolver.resolve_and_populate")
     @patch("agentcage.cli.get_backend")
     @patch("agentcage.cli._ensure_patches")
@@ -1120,39 +1109,14 @@ class TestCageStart:
     @patch("agentcage.cli.state")
     def test_start_regenerates_dns_allowlist(self, mock_state, MockPodman,
                                              mock_ensure_patches,
-                                             mock_get_backend, mock_resolve,
-                                             mock_ensure_dns):
-        """Start must regenerate dns-allowlist.conf and run the quadlet
-        migration check before starting services."""
+                                             mock_get_backend, mock_resolve):
+        """Start must regenerate dns-allowlist.conf before starting services."""
         mock_state.deployment_exists.return_value = True
         cfg = _mock_config("container")
         mock_state.load_deployment_config.return_value = cfg
         result = _runner().invoke(main, ["cage", "start", "test"])
         assert result.exit_code == 0
         mock_state.save_dns_allowlist.assert_called_once_with("test")
-        mock_ensure_dns.assert_called_once_with(cfg)
-
-
-class TestEnsureDnsQuadletCurrent:
-    """In the v0.22 2-service shape there is no separate dns quadlet to
-    migrate — the egress quadlet's content is stable across allowlist
-    edits (the allowlist lives in a bind-mounted sidecar file rather
-    than being baked into ``--server=/…/…`` flags on the command line).
-    ``_ensure_dns_quadlet_current`` is a stub that always returns False
-    so existing callers that condition on a "quadlet was rewritten" flag
-    take the no-op branch."""
-
-    def test_returns_false_unconditionally_for_container_cage(self):
-        from agentcage.cli import _ensure_dns_quadlet_current
-        cfg = _mock_config("container")
-        cfg.name = "test"
-        assert _ensure_dns_quadlet_current(cfg) is False
-
-    def test_returns_false_unconditionally_for_vm_cage(self):
-        from agentcage.cli import _ensure_dns_quadlet_current
-        cfg = _mock_config("vm")
-        cfg.name = "test"
-        assert _ensure_dns_quadlet_current(cfg) is False
 
 
 class TestCageVerify:


### PR DESCRIPTION
## What

First, lowest-risk batch from a full over-engineering sweep of the codebase: **purely subtractive dead-code removal, zero behavior change.** Each deletion was verified dead against the entire `src/` + `tests/` tree before removal.

| Removed | Why it's dead |
|---|---|
| `cli._exit_apple_container_unsupported` | Never called anywhere |
| `cli._ensure_dns_quadlet_current` + 2 call sites + tests | Permanent `return False` no-op; both call sites discarded the return |
| Redundant 2nd `get_backend(cfg)` in `cage exec` | Same scope, `cfg` unchanged between the two calls |
| `secret_resolver._systemd_creds_usable` | Zero callers |
| 2 unused imports in `config.py` | `KNOWN_RELAY_TYPES`/`validate_relay_type` stay defined+used in `_validate.py`; only the config.py imports were dead |
| `InspectionResult.score` field | Written by `entropy.py`, read nowhere in the tree |

Net: **-97 / +15 lines**, full suite green (**1656**; the -2 vs 1658 are the no-op stub's own pinning tests, deleted with it).

## Safety

Nothing user-facing changes. I deliberately **held back** everything that touches a user-visible surface or needs a product decision, for separate review:
- logging-level config fields (wire up vs delete),
- hidden compat flags (`--no-follow`, audit/har `--lines`/`--json` aliases),
- the `redact_to` feature (built but unused by any shipped config),
- the apple-container parity-warning table (~160 lines),
- the `timeout_start_sec` default mismatch (600 vs 120 — a latent bug worth its own fix).

Follow-up PRs from the sweep: (1) de-duplicate the secret inject/redact logic shared across the proxy `SecretInjector` and the Apple allowlist addon (highest value, security path — isolated + Mac-e2e'd); (2) structural consolidations (`shell_argv`, unify `build_and_deploy`, shared relay utils).

🤖 Generated with [Claude Code](https://claude.com/claude-code)