### PR TITLE
feat(secrets): fail-closed on Linux — refuse cleartext unless allow_plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Secrets are fail-closed on Linux — no silent cleartext fallback.** When systemd-creds encryption is unavailable or fails, `cage create -s` and `secret set` previously fell back to storing the value as an *unencrypted* podman secret. They now refuse and error out unless the operator explicitly opts in with `secrets.allow_plaintext: true` in cage.yaml (or uses an explicit `podman:` source). New `secrets.allow_plaintext` config field (default `false`); opting in prints an `UNENCRYPTED` warning. (macOS Keychain-backed storage for apple-container is a separate follow-up.)
+
 ## [0.22.19] - 2026-05-29
 
 ### Removed

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -109,6 +109,40 @@ def _write_apple_pending_secrets(name: str, pairs) -> None:
         os.close(fd)
 
 
+def _store_plaintext_secret_or_fail(podman, full_name: str, value: str,
+                                    cfg, key: str) -> None:
+    """Store *value* in the (unencrypted) podman secret store, or fail-closed.
+
+    agentcage refuses to persist cleartext secrets unless the operator has
+    explicitly opted in via ``secrets.allow_plaintext: true``. Reached only
+    when systemd-creds encryption is unavailable or fails — the default is to
+    error out rather than silently write an unencrypted secret to disk.
+    """
+    if not cfg.secrets.allow_plaintext:
+        click.echo(
+            f"error: refusing to store secret '{key}' as cleartext — "
+            f"systemd-creds encryption is unavailable on this host.",
+            err=True,
+        )
+        click.echo(
+            "  Fix: enable systemd-creds (systemd 250+ with a TPM2, host, or "
+            "per-user key), or — if you accept unencrypted at-rest storage — "
+            "set `secrets:\\n  allow_plaintext: true` in cage.yaml (or use a "
+            "'podman:' source for this rule).",
+            err=True,
+        )
+        sys.exit(1)
+    if podman.secret_exists(full_name):
+        podman.secret_remove(full_name)
+    podman.secret_create(full_name, value)
+    click.echo(
+        f"warning: secret '{full_name}' stored UNENCRYPTED in the podman "
+        f"store (secrets.allow_plaintext is set).",
+        err=True,
+    )
+    click.echo(f"Secret '{full_name}' set (unencrypted).")
+
+
 def _apple_restart_if_running(name: str, cfg) -> None:
     """Restart an apple-container cage so re-staged secrets take effect.
 
@@ -695,11 +729,11 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
                 source_scheme = ""
                 if rule and rule.source:
                     source_scheme = rule.source.partition(":")[0]
-                if source_scheme == "podman":
-                    use_creds = False  # operator explicitly asked for Podman store
-                else:
-                    use_creds = (source_scheme == "systemd-creds"
-                                 or (not source_scheme and default_backend == "systemd-creds"))
+                explicit_podman = source_scheme == "podman"
+                use_creds = (source_scheme == "systemd-creds"
+                             or (not source_scheme
+                                 and default_backend == "systemd-creds"))
+                full = f"{name}.{key}"
                 if use_creds:
                     from agentcage.secret_resolver import resolve_scope
                     try:
@@ -713,13 +747,23 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
                         )
                         continue
                     except ValueError as e:
-                        click.echo(f"warning: systemd-creds encrypt failed: {e}", err=True)
-                        click.echo("Falling back to Podman store.", err=True)
-                full = f"{name}.{key}"
-                if podman_secrets.secret_exists(full):
-                    podman_secrets.secret_remove(full)
-                podman_secrets.secret_create(full, val)
-                click.echo(f"Secret '{full}' set.")
+                        click.echo(
+                            f"warning: systemd-creds encrypt failed: {e}",
+                            err=True,
+                        )
+                        _store_plaintext_secret_or_fail(
+                            podman_secrets, full, val, cfg, key)
+                        continue
+                if explicit_podman:
+                    # Operator explicitly chose the podman store.
+                    if podman_secrets.secret_exists(full):
+                        podman_secrets.secret_remove(full)
+                    podman_secrets.secret_create(full, val)
+                    click.echo(f"Secret '{full}' set.")
+                else:
+                    # No scheme + systemd-creds unavailable → cleartext.
+                    _store_plaintext_secret_or_fail(
+                        podman_secrets, full, val, cfg, key)
         else:
             # VM mode: store secrets for bridging after VM starts.
             # We need host podman for this — prompt to install if missing.
@@ -3313,11 +3357,9 @@ def secret_set(name: str, key: str):
         source_scheme = rule.source.partition(":")[0]
 
     backend = detect_default_backend()
-    if source_scheme == "podman":
-        use_creds = False  # operator explicitly asked for Podman store
-    else:
-        use_creds = (source_scheme == "systemd-creds"
-                     or (not source_scheme and backend == "systemd-creds"))
+    explicit_podman = source_scheme == "podman"
+    use_creds = (source_scheme == "systemd-creds"
+                 or (not source_scheme and backend == "systemd-creds"))
 
     if use_creds:
         from agentcage.secret_resolver import resolve_scope
@@ -3334,17 +3376,17 @@ def secret_set(name: str, key: str):
                 f"({scope}-scope)."
             )
         except ValueError as e:
-            click.echo(f"error: {e}", err=True)
-            click.echo("Falling back to Podman secret store.", err=True)
-            if podman.secret_exists(full_name):
-                podman.secret_remove(full_name)
-            podman.secret_create(full_name, value)
-            click.echo(f"Secret '{full_name}' set (unencrypted).")
-    else:
+            click.echo(f"warning: systemd-creds encrypt failed: {e}", err=True)
+            _store_plaintext_secret_or_fail(podman, full_name, value, cfg, key)
+    elif explicit_podman:
+        # Operator explicitly chose the podman store.
         if podman.secret_exists(full_name):
             podman.secret_remove(full_name)
         podman.secret_create(full_name, value)
         click.echo(f"Secret '{full_name}' set.")
+    else:
+        # No scheme + systemd-creds unavailable → would be cleartext.
+        _store_plaintext_secret_or_fail(podman, full_name, value, cfg, key)
 
     # Auto-reload if cage is running
     if state.deployment_exists(name):

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -32,6 +32,10 @@ _VALID_SECRET_SCOPES = ("auto", "user", "system")
 @dataclass
 class SecretsConfig:
     scope: str = "auto"  # "auto" | "user" | "system"
+    # When systemd-creds encryption is unavailable, agentcage refuses to
+    # store secrets as cleartext podman secrets (fail-closed). Set this to
+    # true to explicitly opt into the unencrypted podman secret store.
+    allow_plaintext: bool = False
 
 
 @dataclass
@@ -503,7 +507,10 @@ def load_config(path: str) -> Config:
         raise ValueError(
             f"invalid secrets.scope: {scope!r}. Valid: {valid}"
         )
-    cfg.secrets = SecretsConfig(scope=scope)
+    cfg.secrets = SecretsConfig(
+        scope=scope,
+        allow_plaintext=bool(secrets_raw.get("allow_plaintext", False)),
+    )
 
     # Secret injection — accepts list or {"rules": [...]}
     si_cfg = raw.get("secret_injection") or []

--- a/tests/e2e/configs/secrets-source.yaml
+++ b/tests/e2e/configs/secrets-source.yaml
@@ -1,4 +1,7 @@
 name: e2e-secrets-src
+# CI has no usable systemd-creds; opt into the plaintext store for the test.
+secrets:
+  allow_plaintext: true
 container:
   image: "node:22-slim"
   command: ["node", "/app/agent.js"]

--- a/tests/e2e/configs/secrets.yaml
+++ b/tests/e2e/configs/secrets.yaml
@@ -1,4 +1,9 @@
 name: e2e-secrets
+# CI runners have no usable systemd-creds (no TPM2/host-key/user session),
+# so opt this test cage into the unencrypted podman secret store. On a real
+# host with systemd-creds this is unnecessary (and secrets are encrypted).
+secrets:
+  allow_plaintext: true
 container:
   image: "node:22-slim"
   command: ["node", "/app/agent.js"]

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -92,6 +92,15 @@ if not m:
 insert_at = m.end()
 extra = "    - httpbin.org\n    - postman-echo.com\n"
 text = text[:insert_at] + extra + text[insert_at:]
+
+# CI has no usable systemd-creds → opt secrets into the plaintext store so
+# `cage create -s` doesn't fail-closed in the sandbox. On a real host with
+# systemd-creds this is unnecessary and secrets are encrypted at rest.
+sm = re.search(r"^secrets:[ \t]*\n", text, re.M)
+if sm:
+    text = text[:sm.end()] + "  allow_plaintext: true\n" + text[sm.end():]
+else:
+    text += "\nsecrets:\n  allow_plaintext: true\n"
 path.write_text(text)
 PYEOF
 

--- a/tests/test_secret_cli.py
+++ b/tests/test_secret_cli.py
@@ -73,6 +73,54 @@ class TestSecretSet:
             assert "does not exist" in result.output
 
 
+class TestSecretFailClosed:
+    """Without systemd-creds, agentcage must refuse cleartext storage unless
+    the operator opted in via secrets.allow_plaintext."""
+
+    def _cfg(self, allow_plaintext):
+        cfg = MagicMock()
+        cfg.isolation = "container"
+        cfg.name = "myapp"
+        cfg.secret_injection = []
+        cfg.container.podman_secrets = []
+        cfg.secrets.scope = "auto"
+        cfg.secrets.allow_plaintext = allow_plaintext
+        return cfg
+
+    @patch("agentcage.secret_resolver.detect_default_backend", return_value="podman")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_set_fails_closed_without_systemd_creds(
+        self, mock_state, MockPodman, _backend,
+    ):
+        podman = MockPodman.return_value
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = self._cfg(False)
+        result = _runner().invoke(
+            main, ["secret", "set", "myapp", "API_KEY"], input="s3cret\n",
+        )
+        assert result.exit_code != 0
+        assert "refusing to store" in result.output
+        podman.secret_create.assert_not_called()
+
+    @patch("agentcage.secret_resolver.detect_default_backend", return_value="podman")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_set_allows_plaintext_when_opted_in(
+        self, mock_state, MockPodman, _backend,
+    ):
+        podman = MockPodman.return_value
+        podman.secret_exists.return_value = False
+        mock_state.deployment_exists.return_value = True
+        mock_state.load_deployment_config.return_value = self._cfg(True)
+        result = _runner().invoke(
+            main, ["secret", "set", "myapp", "API_KEY"], input="s3cret\n",
+        )
+        assert result.exit_code == 0
+        podman.secret_create.assert_called_once_with("myapp.API_KEY", "s3cret")
+        assert "UNENCRYPTED" in result.output
+
+
 class TestSecretList:
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")


### PR DESCRIPTION
## What

First half of "encrypt secrets at rest everywhere": **Linux fail-closed.** `cage create -s` and `secret set` no longer silently fall back to an *unencrypted* podman secret when systemd-creds encryption is unavailable or fails.

Previously, if `systemd-creds` wasn't usable (no TPM2/host-key/user-session) or `encrypt` failed, agentcage printed a warning and stored the raw value in the podman secret store (base64, **cleartext at rest**) — and on many hosts that was the *silent default*.

Now:
- If systemd-creds works → encrypt to `<state>/creds/<key>.cred` (unchanged, the good path).
- If it doesn't → **error out** with an actionable message, unless the operator explicitly opts in via `secrets.allow_plaintext: true` (or an explicit `podman:` source). Opting in stores the secret and prints an `UNENCRYPTED` warning.

New `SecretsConfig.allow_plaintext` field (default `false`).

## Why

Guarantees "no cleartext secrets at rest" by default on Linux — the cleartext path is now opt-in and loud, never the silent default.

## Tests

- New `TestSecretFailClosed`: refuses without opt-in (exit≠0, "refusing to store", no `secret_create`); stores with a warning when `allow_plaintext: true`.
- Full suite green (**1626** + new tests).

## Scope

Container + VM (host-podman path). The apple-container backend stores secrets differently (currently 0600 plaintext files) and gets **macOS Keychain / Secure-Enclave-backed storage in a separate follow-up** — that one has a headless-access design decision in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)