### PR TITLE
feat(secrets): pluggable SecretStore backends + secrets.backend knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pluggable secret-storage backends — `secrets.backend`.** Secret storage now goes through a `SecretStore` abstraction selectable via `secrets.backend`: `auto` (default — best encrypting backend for the platform), `systemd-creds` (Linux), `plaintext` (explicit opt-in), with `system-keychain` (macOS) landing in a follow-up. `auto` is fail-closed: it refuses cleartext unless `secrets.allow_plaintext: true`. The previous inline systemd-creds/plaintext branching in `cage create -s` / `secret set` is unified behind the abstraction (behavior-preserving on Linux).
+
 ### Changed
 
 - **Secrets are fail-closed on Linux — no silent cleartext fallback.** When systemd-creds encryption is unavailable or fails, `cage create -s` and `secret set` previously fell back to storing the value as an *unencrypted* podman secret. They now refuse and error out unless the operator explicitly opts in with `secrets.allow_plaintext: true` in cage.yaml (or uses an explicit `podman:` source). New `secrets.allow_plaintext` config field (default `false`); opting in prints an `UNENCRYPTED` warning. (macOS Keychain-backed storage for apple-container is a separate follow-up.)

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -109,38 +109,55 @@ def _write_apple_pending_secrets(name: str, pairs) -> None:
         os.close(fd)
 
 
-def _store_plaintext_secret_or_fail(podman, full_name: str, value: str,
-                                    cfg, key: str) -> None:
-    """Store *value* in the (unencrypted) podman secret store, or fail-closed.
+def _store_secret(podman, cfg, cage: str, key: str, value: str, *,
+                  source_scheme: str = "") -> None:
+    """Persist a secret at rest via the configured backend (fail-closed).
 
-    agentcage refuses to persist cleartext secrets unless the operator has
-    explicitly opted in via ``secrets.allow_plaintext: true``. Reached only
-    when systemd-creds encryption is unavailable or fails — the default is to
-    error out rather than silently write an unencrypted secret to disk.
+    Resolves the cage's ``secrets.backend`` (honoring an explicit per-rule
+    ``source:`` scheme) into a :class:`SecretStore` and stores the value.
+    Refuses to write cleartext unless the operator opted in via
+    ``secrets.allow_plaintext`` / ``backend: plaintext`` / a ``podman:``
+    source — in which case it stores and prints an UNENCRYPTED warning.
     """
-    if not cfg.secrets.allow_plaintext:
+    from agentcage.secret_store import (
+        PlaintextStore, SecretStoreError, resolve_store,
+    )
+    full = f"{cage}.{key}"
+    state_dir = state.deployment_dir(cage)
+    try:
+        store = resolve_store(cfg, podman=podman, source_scheme=source_scheme)
+    except SecretStoreError as e:
+        click.echo(f"error: refusing to store secret '{key}': {e}", err=True)
         click.echo(
-            f"error: refusing to store secret '{key}' as cleartext — "
-            f"systemd-creds encryption is unavailable on this host.",
-            err=True,
-        )
-        click.echo(
-            "  Fix: enable systemd-creds (systemd 250+ with a TPM2, host, or "
-            "per-user key), or — if you accept unencrypted at-rest storage — "
-            "set `secrets:\\n  allow_plaintext: true` in cage.yaml (or use a "
-            "'podman:' source for this rule).",
+            "  Fix: enable an encrypting backend (systemd-creds: systemd 250+ "
+            "with a TPM2/host/per-user key) or, to accept unencrypted at-rest "
+            "storage, set `secrets:\\n  allow_plaintext: true` in cage.yaml.",
             err=True,
         )
         sys.exit(1)
-    if podman.secret_exists(full_name):
-        podman.secret_remove(full_name)
-    podman.secret_create(full_name, value)
-    click.echo(
-        f"warning: secret '{full_name}' stored UNENCRYPTED in the podman "
-        f"store (secrets.allow_plaintext is set).",
-        err=True,
-    )
-    click.echo(f"Secret '{full_name}' set (unencrypted).")
+
+    try:
+        store.set(cage, key, value, state_dir=state_dir)
+    except (SecretStoreError, ValueError) as e:
+        # An encrypting backend failed at runtime (e.g. TPM2 contention).
+        if cfg.secrets.allow_plaintext and not isinstance(store, PlaintextStore):
+            click.echo(f"warning: {store.name} storage failed: {e}", err=True)
+            PlaintextStore(podman).set(cage, key, value, state_dir=state_dir)
+            store = PlaintextStore(podman)
+        else:
+            click.echo(f"error: failed to store secret '{key}': {e}", err=True)
+            sys.exit(1)
+
+    if isinstance(store, PlaintextStore):
+        click.echo(
+            f"warning: secret '{full}' stored UNENCRYPTED in the podman store.",
+            err=True,
+        )
+        click.echo(f"Secret '{full}' set (unencrypted).")
+    elif store.name == "systemd-creds":
+        click.echo(f"Secret '{key}' encrypted with systemd-creds.")
+    else:
+        click.echo(f"Secret '{full}' set ({store.name}).")
 
 
 def _apple_restart_if_running(name: str, cfg) -> None:
@@ -715,55 +732,19 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
         # For VM mode, secrets are set after the VM starts (in _deploy_cage).
         # For container mode, set them now on the host.
         if cfg.isolation == "container":
-            from agentcage.secret_resolver import detect_default_backend, encrypt_secret
             podman_secrets = Podman()
-            default_backend = detect_default_backend()
             for spec in secrets:
                 if "=" in spec:
                     key, val = spec.split("=", 1)
                 else:
                     key = spec
                     val = click.prompt(f"Value for {key}", hide_input=True)
-                # Route to systemd-creds if rule or default calls for it
                 rule = next((r for r in cfg.secret_injection if r.env == key), None)
                 source_scheme = ""
                 if rule and rule.source:
                     source_scheme = rule.source.partition(":")[0]
-                explicit_podman = source_scheme == "podman"
-                use_creds = (source_scheme == "systemd-creds"
-                             or (not source_scheme
-                                 and default_backend == "systemd-creds"))
-                full = f"{name}.{key}"
-                if use_creds:
-                    from agentcage.secret_resolver import resolve_scope
-                    try:
-                        scope = resolve_scope(cfg.secrets.scope)
-                        encrypt_secret(
-                            key, val, state.deployment_dir(name), scope=scope,
-                        )
-                        click.echo(
-                            f"Secret '{key}' encrypted with systemd-creds "
-                            f"({scope}-scope)."
-                        )
-                        continue
-                    except ValueError as e:
-                        click.echo(
-                            f"warning: systemd-creds encrypt failed: {e}",
-                            err=True,
-                        )
-                        _store_plaintext_secret_or_fail(
-                            podman_secrets, full, val, cfg, key)
-                        continue
-                if explicit_podman:
-                    # Operator explicitly chose the podman store.
-                    if podman_secrets.secret_exists(full):
-                        podman_secrets.secret_remove(full)
-                    podman_secrets.secret_create(full, val)
-                    click.echo(f"Secret '{full}' set.")
-                else:
-                    # No scheme + systemd-creds unavailable → cleartext.
-                    _store_plaintext_secret_or_fail(
-                        podman_secrets, full, val, cfg, key)
+                _store_secret(podman_secrets, cfg, name, key, val,
+                              source_scheme=source_scheme)
         else:
             # VM mode: store secrets for bridging after VM starts.
             # We need host podman for this — prompt to install if missing.
@@ -3345,48 +3326,13 @@ def secret_set(name: str, key: str):
         return
 
     podman = _podman_for_cage(name)
-    full_name = f"{name}.{key}"
 
-    # Determine storage backend
-    from agentcage.secret_resolver import detect_default_backend, encrypt_secret
-
-    cfg = state.load_deployment_config(name)
     rule = next((r for r in cfg.secret_injection if r.env == key), None)
     source_scheme = ""
     if rule and rule.source:
         source_scheme = rule.source.partition(":")[0]
 
-    backend = detect_default_backend()
-    explicit_podman = source_scheme == "podman"
-    use_creds = (source_scheme == "systemd-creds"
-                 or (not source_scheme and backend == "systemd-creds"))
-
-    if use_creds:
-        from agentcage.secret_resolver import resolve_scope
-        try:
-            scope = resolve_scope(cfg.secrets.scope)
-            encrypt_secret(key, value, state.deployment_dir(name), scope=scope)
-            # Remove any stale podman secret with the same name — the
-            # ExecStartPre in the quadlet will repopulate it from the
-            # encrypted blob at service start.
-            if podman.secret_exists(full_name):
-                podman.secret_remove(full_name)
-            click.echo(
-                f"Secret '{key}' encrypted with systemd-creds "
-                f"({scope}-scope)."
-            )
-        except ValueError as e:
-            click.echo(f"warning: systemd-creds encrypt failed: {e}", err=True)
-            _store_plaintext_secret_or_fail(podman, full_name, value, cfg, key)
-    elif explicit_podman:
-        # Operator explicitly chose the podman store.
-        if podman.secret_exists(full_name):
-            podman.secret_remove(full_name)
-        podman.secret_create(full_name, value)
-        click.echo(f"Secret '{full_name}' set.")
-    else:
-        # No scheme + systemd-creds unavailable → would be cleartext.
-        _store_plaintext_secret_or_fail(podman, full_name, value, cfg, key)
+    _store_secret(podman, cfg, name, key, value, source_scheme=source_scheme)
 
     # Auto-reload if cage is running
     if state.deployment_exists(name):

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -31,10 +31,14 @@ _VALID_SECRET_SCOPES = ("auto", "user", "system")
 
 @dataclass
 class SecretsConfig:
-    scope: str = "auto"  # "auto" | "user" | "system"
-    # When systemd-creds encryption is unavailable, agentcage refuses to
-    # store secrets as cleartext podman secrets (fail-closed). Set this to
-    # true to explicitly opt into the unencrypted podman secret store.
+    # At-rest storage backend: "auto" picks the best encrypting backend for
+    # the platform (Linux: systemd-creds). Explicit: "systemd-creds",
+    # "system-keychain" (macOS), "plaintext".
+    backend: str = "auto"
+    scope: str = "auto"  # "auto" | "user" | "system" (systemd-creds only)
+    # When no encrypting backend is available, agentcage refuses to store
+    # secrets as cleartext (fail-closed). Set this to true to explicitly opt
+    # into the unencrypted podman secret store under `backend: auto`.
     allow_plaintext: bool = False
 
 
@@ -507,7 +511,15 @@ def load_config(path: str) -> Config:
         raise ValueError(
             f"invalid secrets.scope: {scope!r}. Valid: {valid}"
         )
+    backend = str(secrets_raw.get("backend", "auto"))
+    from agentcage.secret_store import KNOWN_BACKENDS
+    if backend not in KNOWN_BACKENDS:
+        valid = ", ".join(sorted(KNOWN_BACKENDS))
+        raise ValueError(
+            f"invalid secrets.backend: {backend!r}. Valid: {valid}"
+        )
     cfg.secrets = SecretsConfig(
+        backend=backend,
         scope=scope,
         allow_plaintext=bool(secrets_raw.get("allow_plaintext", False)),
     )

--- a/src/agentcage/secret_store.py
+++ b/src/agentcage/secret_store.py
@@ -1,0 +1,178 @@
+"""Pluggable at-rest secret storage backends.
+
+Selected via the cage.yaml ``secrets.backend`` field:
+
+  ``auto``            — best available for the platform (Linux: systemd-creds;
+                        macOS: system-keychain — added in a follow-up).
+  ``systemd-creds``   — Linux: an encrypted ``.cred`` blob the systemd Quadlet
+                        decrypts at unit start (TPM2 / host / per-user key).
+  ``system-keychain`` — macOS: the System keychain (host-key, boot-unlocked,
+                        headless). Added in the macOS follow-up.
+  ``plaintext``       — the unencrypted podman secret store. Only reachable via
+                        an explicit opt-in (``backend: plaintext`` or
+                        ``secrets.allow_plaintext: true``).
+
+Every backend encrypts at rest EXCEPT ``plaintext``. The resolver is
+fail-closed: if no encrypting backend is available and the operator hasn't
+opted into plaintext, resolution raises rather than silently storing cleartext.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+class SecretStoreError(Exception):
+    """Raised when a backend is unavailable or an operation fails."""
+
+
+class SecretStore:
+    """A place to keep a cage's secrets encrypted at rest.
+
+    Subclasses implement the small management surface used by
+    ``secret set`` / ``secret rm`` / ``secret list`` and the deploy paths.
+    """
+
+    #: stable identifier used in cage.yaml ``secrets.backend``
+    name: str = "base"
+    #: True when the cage runtime decrypts the secret itself (e.g. the systemd
+    #: Quadlet via ``LoadCredentialEncrypted``); False when agentcage must
+    #: retrieve and deliver the value at deploy time.
+    runtime_decrypts: bool = False
+
+    def available(self) -> bool:
+        raise NotImplementedError
+
+    def set(self, cage: str, key: str, value: str, *,
+            state_dir: Path) -> None:
+        raise NotImplementedError
+
+    def delete(self, cage: str, key: str, *, state_dir: Path) -> None:
+        raise NotImplementedError
+
+    def get(self, cage: str, key: str, *, state_dir: Path) -> Optional[str]:
+        """Return the cleartext value, or None. Backends whose runtime
+        decrypts (systemd-creds) need not implement retrieval."""
+        raise SecretStoreError(
+            f"backend {self.name!r} does not support value retrieval"
+        )
+
+
+class SystemdCredsStore(SecretStore):
+    """Linux: encrypt to ``<state>/creds/<key>.cred`` (Quadlet decrypts)."""
+
+    name = "systemd-creds"
+    runtime_decrypts = True
+
+    def __init__(self, scope: str = "auto", podman=None) -> None:
+        self._scope = scope
+        self._podman = podman
+
+    def available(self) -> bool:
+        from agentcage.secret_resolver import detect_default_backend
+        return detect_default_backend() == "systemd-creds"
+
+    def set(self, cage: str, key: str, value: str, *, state_dir: Path) -> None:
+        from agentcage.secret_resolver import encrypt_secret, resolve_scope
+        scope = resolve_scope(self._scope)
+        encrypt_secret(key, value, state_dir, scope=scope)
+        # Drop any stale podman secret of the same name — the Quadlet's
+        # ExecStartPre repopulates it from the encrypted blob at start.
+        full = f"{cage}.{key}"
+        if self._podman is not None and self._podman.secret_exists(full):
+            self._podman.secret_remove(full)
+
+    def delete(self, cage: str, key: str, *, state_dir: Path) -> None:
+        cred = state_dir / "creds" / f"{key}.cred"
+        cred.unlink(missing_ok=True)
+        full = f"{cage}.{key}"
+        if self._podman is not None and self._podman.secret_exists(full):
+            self._podman.secret_remove(full)
+
+
+class PlaintextStore(SecretStore):
+    """Unencrypted podman secret store. Explicit opt-in only."""
+
+    name = "plaintext"
+    runtime_decrypts = True  # value already lives in the podman store
+
+    def __init__(self, podman) -> None:
+        self._podman = podman
+
+    def available(self) -> bool:
+        return self._podman is not None
+
+    def set(self, cage: str, key: str, value: str, *, state_dir: Path) -> None:
+        full = f"{cage}.{key}"
+        if self._podman.secret_exists(full):
+            self._podman.secret_remove(full)
+        self._podman.secret_create(full, value)
+
+    def delete(self, cage: str, key: str, *, state_dir: Path) -> None:
+        full = f"{cage}.{key}"
+        if self._podman.secret_exists(full):
+            self._podman.secret_remove(full)
+
+    def get(self, cage: str, key: str, *, state_dir: Path) -> Optional[str]:
+        full = f"{cage}.{key}"
+        if not self._podman.secret_exists(full):
+            return None
+        return self._podman.secret_read(full)
+
+
+# Backend names valid in cage.yaml ``secrets.backend``.
+KNOWN_BACKENDS = frozenset({
+    "auto", "systemd-creds", "system-keychain", "plaintext",
+})
+
+
+def resolve_store(cfg, *, podman=None, source_scheme: str = "") -> SecretStore:
+    """Pick the secret store for *cfg* (fail-closed).
+
+    Honors an explicit per-rule ``source:`` scheme first (``systemd-creds:`` /
+    ``podman:``), then ``cfg.secrets.backend``. ``auto`` resolves to the best
+    encrypting backend for the platform; if none is available it raises unless
+    ``secrets.allow_plaintext`` is set (then plaintext), so cleartext is never
+    a silent default.
+    """
+    import sys as _sys
+
+    sec = cfg.secrets
+    allow_plaintext = bool(getattr(sec, "allow_plaintext", False))
+
+    # Explicit per-rule scheme wins.
+    if source_scheme == "podman":
+        return PlaintextStore(podman)
+    if source_scheme == "systemd-creds":
+        return SystemdCredsStore(scope=sec.scope, podman=podman)
+
+    backend = getattr(sec, "backend", "auto") or "auto"
+
+    if backend == "systemd-creds":
+        store = SystemdCredsStore(scope=sec.scope, podman=podman)
+        if not store.available():
+            raise SecretStoreError(
+                "secrets.backend is 'systemd-creds' but systemd-creds "
+                "encryption is not usable on this host"
+            )
+        return store
+    if backend == "plaintext":
+        return PlaintextStore(podman)
+    if backend == "system-keychain":
+        raise SecretStoreError(
+            "secrets.backend 'system-keychain' is only available on macOS "
+            "(apple-container)"
+        )
+
+    # auto: prefer an encrypting backend; fail-closed otherwise.
+    if _sys.platform == "linux":
+        creds = SystemdCredsStore(scope=sec.scope, podman=podman)
+        if creds.available():
+            return creds
+    if allow_plaintext:
+        return PlaintextStore(podman)
+    raise SecretStoreError(
+        "no encrypting secret backend is available (systemd-creds unusable) "
+        "and secrets.allow_plaintext is not set"
+    )

--- a/tests/test_secret_store.py
+++ b/tests/test_secret_store.py
@@ -1,0 +1,91 @@
+"""Tests for the pluggable SecretStore backend resolver."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentcage.config import SecretsConfig
+from agentcage.secret_store import (
+    PlaintextStore,
+    SecretStoreError,
+    SystemdCredsStore,
+    resolve_store,
+)
+
+
+class _Cfg:
+    def __init__(self, **kw):
+        self.secrets = SecretsConfig(**kw)
+
+
+def _backend(monkeypatch, value):
+    monkeypatch.setattr(
+        "agentcage.secret_resolver.detect_default_backend", lambda: value,
+    )
+
+
+def test_explicit_systemd_creds_available(monkeypatch):
+    _backend(monkeypatch, "systemd-creds")
+    store = resolve_store(_Cfg(backend="systemd-creds"), podman=MagicMock())
+    assert isinstance(store, SystemdCredsStore)
+
+
+def test_explicit_systemd_creds_unavailable_raises(monkeypatch):
+    _backend(monkeypatch, "podman")
+    with pytest.raises(SecretStoreError):
+        resolve_store(_Cfg(backend="systemd-creds"), podman=MagicMock())
+
+
+def test_explicit_plaintext(monkeypatch):
+    _backend(monkeypatch, "podman")
+    store = resolve_store(_Cfg(backend="plaintext"), podman=MagicMock())
+    assert isinstance(store, PlaintextStore)
+
+
+def test_system_keychain_on_linux_raises(monkeypatch):
+    _backend(monkeypatch, "systemd-creds")
+    with pytest.raises(SecretStoreError):
+        resolve_store(_Cfg(backend="system-keychain"), podman=MagicMock())
+
+
+def test_auto_prefers_systemd_creds(monkeypatch):
+    _backend(monkeypatch, "systemd-creds")
+    store = resolve_store(_Cfg(backend="auto"), podman=MagicMock())
+    assert isinstance(store, SystemdCredsStore)
+
+
+def test_auto_fail_closed_without_encrypting_backend(monkeypatch):
+    _backend(monkeypatch, "podman")
+    with pytest.raises(SecretStoreError):
+        resolve_store(_Cfg(backend="auto", allow_plaintext=False), podman=MagicMock())
+
+
+def test_auto_allows_plaintext_when_opted_in(monkeypatch):
+    _backend(monkeypatch, "podman")
+    store = resolve_store(
+        _Cfg(backend="auto", allow_plaintext=True), podman=MagicMock(),
+    )
+    assert isinstance(store, PlaintextStore)
+
+
+def test_source_scheme_overrides_backend(monkeypatch):
+    _backend(monkeypatch, "systemd-creds")
+    # An explicit podman: source wins over the configured systemd-creds backend.
+    store = resolve_store(
+        _Cfg(backend="systemd-creds"), podman=MagicMock(), source_scheme="podman",
+    )
+    assert isinstance(store, PlaintextStore)
+
+
+def test_config_rejects_invalid_backend(tmp_path):
+    from agentcage.config import load_config
+    p = tmp_path / "cage.yaml"
+    p.write_text(
+        "name: t\n"
+        "container:\n  image: x:latest\n"
+        "secrets:\n  backend: bogus\n"
+    )
+    with pytest.raises(ValueError, match="invalid secrets.backend"):
+        load_config(str(p))


### PR DESCRIPTION
## What

Phase A of pluggable secret storage (you asked for selectable backends). Introduces a **`SecretStore` abstraction** with backends chosen via `secrets.backend`:

```yaml
secrets:
  backend: auto      # auto | systemd-creds | system-keychain | plaintext
  allow_plaintext: false
```

- `auto` (default) → best encrypting backend for the platform (Linux: `systemd-creds`), **fail-closed** (refuses cleartext unless `allow_plaintext: true`).
- An explicit per-rule `source:` (`systemd-creds:` / `podman:`) still wins.
- `system-keychain` (macOS) is reserved here and lands in the **next PR** (the headless System-keychain backend, validated by spike on the M1).

The previous inline systemd-creds/plaintext branching in `cage create -s` and `secret set` is unified behind one `_store_secret` helper using the abstraction — **behavior-preserving on Linux**.

## Why

Foundation for "let the user decide" + a clean home for the macOS backend. Keeps the fail-closed guarantee from #245.

## Tests

- New `test_secret_store.py` (9): explicit/auto resolution, fail-closed, plaintext opt-in, source-scheme override, system-keychain-on-linux raises, invalid-backend config rejected.
- Full suite **1637** passing.

## Scope

Linux behavior-preserving + the new knob. macOS `system-keychain` backend + apple transient-stage/wipe is the follow-up PR (Mac-e2e'd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)