### PR TITLE
fix(secrets): surface orphan stored secrets in `secret list`

### DIFF
--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -64,6 +64,8 @@ To switch a cage between secret backends (e.g. legacy Podman store → systemd-c
 
 Existing values in the old backend are not migrated automatically; once the cage is updated and new secrets are set, the old store entries are unused and can be removed with `podman secret rm` or left in place (they are inert).
 
+> **Orphan secrets:** `agentcage secret set <cage> <key>` stores a value even when no `secret_injection` rule, `podman_secret`, or relay credential references `<key>`. Such a value is staged at start but never injected or redacted. `agentcage secret list` shows these with type `orphan` so you can either add a matching rule or remove the value with `agentcage secret rm`.
+
 ## Domain restrictions
 
 When `inject_to` is set for a rule, the proxy only injects the real value for requests to matching domains (subdomains are matched automatically). If the cage sends a placeholder to any other domain, the request is **flagged**.

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -3203,6 +3203,42 @@ def secret():
     """Manage cage-scoped secrets."""
 
 
+def _render_secret_list(cfg, present_keys: set[str]) -> bool:
+    """Print the NAME/TYPE/STATUS table for a cage's secrets.
+
+    Renders the *union* of declared (``cage.yaml``) and actually-stored
+    secrets so a value set via ``secret set`` for a key with no matching
+    ``secret_injection`` rule (or ``podman_secret`` / relay credential) is
+    still surfaced — as type ``orphan`` — rather than silently hidden.
+    Declared-but-absent secrets show ``MISSING``.
+
+    Returns True if any declared secret is missing (callers exit non-zero).
+    """
+    expected = _expected_secrets(cfg)
+    injection_names = {r.env for r in cfg.secret_injection}
+    # Declared secrets first (preserving config order), then any stored
+    # keys that aren't declared anywhere.
+    expected_set = set(expected)
+    orphans = sorted(k for k in present_keys if k not in expected_set)
+
+    click.echo(f"{'NAME':<30} {'TYPE':<12} STATUS")
+    any_missing = False
+    for key in expected:
+        stype = "injection" if key in injection_names else "direct"
+        if key in present_keys:
+            status = "ok"
+        else:
+            status = "MISSING"
+            any_missing = True
+        click.echo(f"{key:<30} {stype:<12} {status}")
+    for key in orphans:
+        # Stored at rest but not referenced by the config — staged at
+        # start() but never injected/redacted. Surface it so it can be
+        # audited or removed with `secret rm`.
+        click.echo(f"{key:<30} {'orphan':<12} ok")
+    return any_missing
+
+
 @secret.command("list")
 @click.argument("name")
 def secret_list(name: str):
@@ -3215,58 +3251,17 @@ def secret_list(name: str):
     if _is_apple_container(cfg):
         # Keys live in the cage's secret backend (keychain / pending_secrets).
         present_keys = _apple_secret_names(cfg, name)
-        expected = _expected_secrets(cfg)
-        injection_names = {r.env for r in cfg.secret_injection}
-        click.echo(f"{'NAME':<30} {'TYPE':<12} STATUS")
-        any_missing = False
-        for key in expected:
-            stype = "injection" if key in injection_names else "direct"
-            if key in present_keys:
-                status = "ok"
-            else:
-                status = "MISSING"
-                any_missing = True
-            click.echo(f"{key:<30} {stype:<12} {status}")
-        if any_missing:
+        if _render_secret_list(cfg, present_keys):
             sys.exit(1)
         return
     podman = _podman_for_cage(name)
     secrets = podman.secret_list(prefix=f"{name}.")
-
-    # If cage state exists, cross-reference with expected secrets
-    if state.deployment_exists(name):
-        cfg = state.load_deployment_config(name)
-        expected = _expected_secrets(cfg)
-
-        # Determine which type each secret is
-        injection_names = {r.env for r in cfg.secret_injection}
-        present_keys = {
-            s.get("Name", "").removeprefix(f"{name}.")
-            for s in secrets
-        }
-
-        click.echo(f"{'NAME':<30} {'TYPE':<12} STATUS")
-        any_missing = False
-        for key in expected:
-            stype = "injection" if key in injection_names else "direct"
-            if key in present_keys:
-                status = "ok"
-            else:
-                status = "MISSING"
-                any_missing = True
-            click.echo(f"{key:<30} {stype:<12} {status}")
-
-        if any_missing:
-            sys.exit(1)
-    else:
-        if not secrets:
-            click.echo(f"No secrets found for '{name}'.")
-            return
-        click.echo(f"{'NAME':<30}")
-        for s in secrets:
-            sname = s.get("Name", "")
-            key = sname.removeprefix(f"{name}.")
-            click.echo(f"{key:<30}")
+    present_keys = {
+        s.get("Name", "").removeprefix(f"{name}.")
+        for s in secrets
+    }
+    if _render_secret_list(cfg, present_keys):
+        sys.exit(1)
 
 
 @secret.command("set")

--- a/tests/test_secret_cli.py
+++ b/tests/test_secret_cli.py
@@ -160,6 +160,30 @@ class TestSecretList:
 
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
+    def test_list_shows_orphan_stored_but_undeclared(self, mock_state, MockPodman):
+        # A secret set for a key with no injection rule / podman_secret is
+        # still stored at rest; it must be surfaced (type 'orphan') rather
+        # than silently hidden by the expected-only filter.
+        podman = MockPodman.return_value
+        podman.secret_list.return_value = [
+            {"Name": "myapp.API_KEY"},
+            {"Name": "myapp.STRAY"},
+        ]
+        mock_state.deployment_exists.return_value = True
+        cfg = _mock_container_config()
+        cfg.secret_injection = [MagicMock(env="API_KEY")]
+        cfg.container.podman_secrets = []
+        mock_state.load_deployment_config.return_value = cfg
+
+        result = _runner().invoke(main, ["secret", "list", "myapp"])
+        assert result.exit_code == 0
+        assert "API_KEY" in result.output
+        assert "injection" in result.output
+        assert "STRAY" in result.output
+        assert "orphan" in result.output
+
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
     def test_list_empty(self, mock_state, MockPodman):
         podman = MockPodman.return_value
         podman.secret_list.return_value = []


### PR DESCRIPTION
## Problem

`agentcage secret list` only iterated over `expected_secrets(cfg)` — the names declared in `cage.yaml` (via `secret_injection`, `container.podman_secrets`, or protocol-relay credential sources). It then checked each declared name for presence in the store.

As a result, a value set with `agentcage secret set <cage> <key>` for a key that has **no matching injection rule** (nor `podman_secret` / relay credential) was:

- **stored at rest** (macOS keychain / podman store) by `_store_secret`, and
- **staged at start** (apple-container `_stage_secrets`),

but **never displayed** by `secret list`. The secret silently became an undiscoverable orphan — confusing for auditing and cleanup, and inconsistent with `secret set`/`secret rm`, which happily operate on undeclared keys.

## Fix

Render the **union** of declared and actually-stored keys:

- Declared keys keep their `injection` / `direct` type and `ok` / `MISSING` status (unchanged behavior, including the non-zero exit on any `MISSING`).
- Stored-but-undeclared keys now show as type **`orphan`** (status `ok`) so they can be audited or removed with `secret rm`.

The table rendering is factored into a shared `_render_secret_list(cfg, present_keys)` used by both the apple-container and podman code paths. This also drops a dead `else` branch in the podman path (the command already exits early when the deployment doesn't exist, so the old "no state" branch was unreachable).

## Example

```
$ agentcage secret set mycage STRAY        # no secret_injection rule for STRAY
$ agentcage secret list mycage
NAME                           TYPE         STATUS
ANTHROPIC_API_KEY              injection    ok
STRAY                          orphan       ok      # <- previously hidden
```

## Notes on behavior (related investigation)

Secrets are read once at egress startup; `_stage_secrets` runs only in `start()` and the staged cleartext is wiped after the proxy loads it. `secret set` already auto-restarts a running apple-container cage so the new value takes effect. This PR does not change that path — it only fixes the **listing** so stored values are never silently hidden.

## Tests

- New `test_list_shows_orphan_stored_but_undeclared` regression test.
- Existing `TestSecretList` cases pass unchanged.
- Docs note added to `docs/reference/secret-injection.md`.

> CI note: the 4 pre-existing failures in `TestSecretSet`/`TestSecretRm` on a Linux dev box are environmental (they probe the host for `systemd-creds`) and fail identically on `master`; they are unrelated to this change and untouched by it.
