### PR TITLE
fix(apple-container): auto-start apiserver + gate create/update/start on backend prerequisites

### DIFF
--- a/src/agentcage/backend.py
+++ b/src/agentcage/backend.py
@@ -15,6 +15,18 @@ class Backend(Protocol):
         """Return list of unmet prerequisite descriptions (empty = all OK)."""
         ...
 
+    def ensure_ready(self, *, quiet: bool = False) -> None:
+        """Best-effort bring-up of recoverable substrate before build/start.
+
+        Idempotent and non-fatal: backends that can auto-start their
+        substrate (e.g. apple-container's apiserver, which does not survive
+        a reboot) do so here so a downed daemon doesn't masquerade as a
+        missing image. Anything that *can't* be auto-recovered (wrong OS,
+        missing CLI) is left for ``check_prerequisites`` to report. Backends
+        with nothing to recover implement this as a no-op.
+        """
+        ...
+
     def build_artifacts(
         self, config: Config, deploy_name: str, *, quiet: bool = False,
         no_cache: bool = False, pull: bool = False,

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -857,6 +857,30 @@ class AppleContainerBackend:
         if not quiet:
             click.echo(f"Installed apple-container unit metadata to {dest}/")
 
+    def ensure_ready(self, *, quiet: bool = False) -> None:
+        """Start the `container` apiserver if it isn't already running.
+
+        The apiserver does not survive a reboot — it must be re-started each
+        boot with `container system start`. While it's down every `container`
+        subcommand fails (an XPC connection error), so a downed daemon used
+        to surface as "wrapped image not found" from the image probe in
+        start(). Bring it up here, mirroring the Lima backend which
+        auto-starts its VM in start() rather than making the user do it by
+        hand. Best-effort and idempotent: if it still won't come up,
+        check_prerequisites() reports it uniformly with the other unmet
+        prerequisites.
+        """
+        try:
+            if ac_cli.system_running():
+                return
+            if not quiet:
+                click.echo("Apple container apiserver not running — starting it…")
+            ac_cli.run(["system", "start", "--enable-kernel-install"], check=False)
+        except FileNotFoundError:
+            # `container` CLI not installed — check_prerequisites() reports
+            # this with an install hint; nothing to recover here.
+            pass
+
     def start(self, name: str, *, quiet: bool = False) -> None:
         """Start the cage's two sibling microVMs (egress + cage).
 
@@ -877,27 +901,20 @@ class AppleContainerBackend:
             )
         meta = json.loads(unit_path.read_text())
 
-        # The apiserver does not survive a reboot — `container system start`
-        # must be re-run each boot. When it is down, every `container`
-        # subcommand fails (an XPC connection error), so image_inspect()
-        # below would return None and we'd blame a missing image ("was
-        # build_artifacts() called?") when the real fix is starting the
-        # daemon. Bring it up ourselves, mirroring the Lima backend which
-        # auto-starts its VM in start() (vm.py) rather than making the user
-        # do it by hand. Only error if it still won't come up.
+        # Defensive backstop for direct/programmatic callers: the CLI gates
+        # build+start on ensure_ready() already, but start() may also be
+        # invoked outside that path (backup/restore). ensure_ready() is
+        # idempotent and best-effort; if the apiserver is still down after
+        # it, fail with an actionable message rather than the misleading
+        # "wrapped image not found" the image probe below would produce.
+        self.ensure_ready(quiet=quiet)
         if not ac_cli.system_running():
-            if not quiet:
-                click.echo("Apple container apiserver not running — starting it…")
-            ac_cli.run(
-                ["system", "start", "--enable-kernel-install"], check=False,
+            raise RuntimeError(
+                "Apple container apiserver is not running and could not be "
+                "started automatically — run "
+                "'container system start --enable-kernel-install' manually "
+                f"and retry (`agentcage cage start {name}`)"
             )
-            if not ac_cli.system_running():
-                raise RuntimeError(
-                    "Apple container apiserver is not running and could not be "
-                    "started automatically — run "
-                    "'container system start --enable-kernel-install' manually "
-                    f"and retry (`agentcage cage start {name}`)"
-                )
 
         wrapper_image = ac_wrapper.wrapped_image_name(name)
         if not ac_cli.image_inspect(wrapper_image):

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -877,6 +877,28 @@ class AppleContainerBackend:
             )
         meta = json.loads(unit_path.read_text())
 
+        # The apiserver does not survive a reboot — `container system start`
+        # must be re-run each boot. When it is down, every `container`
+        # subcommand fails (an XPC connection error), so image_inspect()
+        # below would return None and we'd blame a missing image ("was
+        # build_artifacts() called?") when the real fix is starting the
+        # daemon. Bring it up ourselves, mirroring the Lima backend which
+        # auto-starts its VM in start() (vm.py) rather than making the user
+        # do it by hand. Only error if it still won't come up.
+        if not ac_cli.system_running():
+            if not quiet:
+                click.echo("Apple container apiserver not running — starting it…")
+            ac_cli.run(
+                ["system", "start", "--enable-kernel-install"], check=False,
+            )
+            if not ac_cli.system_running():
+                raise RuntimeError(
+                    "Apple container apiserver is not running and could not be "
+                    "started automatically — run "
+                    "'container system start --enable-kernel-install' manually "
+                    f"and retry (`agentcage cage start {name}`)"
+                )
+
         wrapper_image = ac_wrapper.wrapped_image_name(name)
         if not ac_cli.image_inspect(wrapper_image):
             raise RuntimeError(

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -46,6 +46,12 @@ class ContainerBackend:
             issues.append("Podman is not available")
         return issues
 
+    def ensure_ready(self, *, quiet: bool = False) -> None:
+        # Nothing to auto-recover: rootless podman's systemd socket
+        # activation brings the service up on demand when the quadlets
+        # start. A missing podman is reported by check_prerequisites().
+        return
+
     def build_artifacts(
         self, config: Config, deploy_name: str, *, quiet: bool = False,
         no_cache: bool = False, pull: bool = False,  # noqa: ARG002

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -175,6 +175,13 @@ class VmBackend:
     def check_prerequisites(self, config: Config) -> list[str]:
         return lima_prerequisites.check_prerequisites()
 
+    def ensure_ready(self, *, quiet: bool = False) -> None:
+        # The Lima VM (this backend's substrate) is created and started
+        # on demand inside start(); there's nothing to bring up ahead of
+        # it here. A missing limactl/QEMU is reported by
+        # check_prerequisites().
+        return
+
     def build_artifacts(
         self, config: Config, deploy_name: str, *, quiet: bool = False,
         no_cache: bool = False, pull: bool = False,  # noqa: ARG002

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -66,6 +66,33 @@ def _is_apple_container(cfg) -> bool:
     return getattr(cfg, "isolation", None) == "apple-container"
 
 
+def _ensure_backend_ready(cfg, *, quiet: bool = False):
+    """Resolve the backend, auto-recover its substrate, and gate on prereqs.
+
+    Brings up anything recoverable (``ensure_ready`` — e.g. apple-container's
+    apiserver, which dies on reboot) *before* checking prerequisites, so a
+    daemon we can restart ourselves never trips the gate. Whatever is still
+    unmet (wrong OS, missing CLI, a daemon that refused to start) is reported
+    uniformly and aborts the command — the diagnostics already lived in each
+    backend's ``check_prerequisites`` but nothing on the build/start path ran
+    them, so a downed apiserver surfaced as a misleading "image not found".
+    Returns the backend so callers can reuse it.
+    """
+    backend = get_backend(cfg)
+    backend.ensure_ready(quiet=quiet)
+    issues = backend.check_prerequisites(cfg)
+    if issues:
+        click.echo(
+            f"error: prerequisites for the '{getattr(cfg, 'isolation', '?')}' "
+            "backend are not met:",
+            err=True,
+        )
+        for issue in issues:
+            click.echo(f"  - {issue}", err=True)
+        sys.exit(1)
+    return backend
+
+
 def _apple_secret_names(cfg, name: str) -> set[str]:
     """Names of secrets stored for an apple-container cage via its backend
     (macOS keychain, or the legacy pending_secrets.json under plaintext)."""
@@ -778,6 +805,11 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
     from agentcage.quadlets import collect_used_octets
     used_octets = collect_used_octets()
 
+    # Auto-recover the backend substrate (apple-container's apiserver dies on
+    # reboot) and gate on prerequisites before building — build_artifacts
+    # would otherwise fail with a confusing image error if the daemon is down.
+    _ensure_backend_ready(cfg)
+
     try:
         _build_and_deploy(cfg, config_host_path, name, podman, used_octets=used_octets,
                            no_cache=no_cache, pull=pull)
@@ -989,6 +1021,9 @@ def cage_update(name: str | None, config_path: str | None,
     from agentcage.quadlets import collect_used_octets as _collect_update
     _existing_meta = state.load_metadata(name) or {}
     _existing_octet = _existing_meta.get("network_octet")
+    # Bring up the backend substrate (apple-container's apiserver dies on
+    # reboot) and gate on prerequisites before the rebuild/restart.
+    _ensure_backend_ready(cfg)
     _build_and_deploy(
         cfg,
         config_host_path,
@@ -1723,7 +1758,7 @@ def cage_start(name: str):
         state.save_proxy_config(name)
         state.save_dns_allowlist(name)
 
-    backend = get_backend(cfg)
+    backend = _ensure_backend_ready(cfg)
     backend.start(name)
     click.echo(f"Started cage '{name}'")
 

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -78,6 +78,49 @@ def test_prereqs_apiserver_stopped_distinct_from_missing():
     assert any("apiserver is not running" in s for s in issues)
 
 
+def test_start_auto_starts_apiserver_when_down(tmp_path, monkeypatch):
+    """The apiserver doesn't survive a reboot. Rather than make the user
+    run `container system start` by hand, start() brings it up itself
+    (mirroring the Lima backend's VM auto-start) and then proceeds."""
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+        },
+    )
+    # Down on the first probe, up after `system start` runs.
+    states = iter([False, True, True, True, True])
+    monkeypatch.setattr(ac_cli, "system_running", lambda: next(states))
+
+    backend.start("demo", quiet=True)
+
+    assert ["system", "start", "--enable-kernel-install"] in captured
+
+
+def test_start_errors_when_apiserver_wont_start(tmp_path, monkeypatch):
+    """If the daemon stays down even after we try to start it, raise an
+    actionable error — never the misleading 'wrapped image not found'."""
+    backend = AppleContainerBackend()
+    monkeypatch.setattr(backend, "unit_dir", lambda: tmp_path)
+    (tmp_path / "pi01.json").write_text(json.dumps({"autostart": False}))
+
+    with patch.object(ac_cli, "system_running", return_value=False), \
+         patch.object(ac_cli, "run") as run, \
+         patch.object(ac_cli, "image_inspect") as image_inspect:
+        with pytest.raises(RuntimeError) as excinfo:
+            backend.start("pi01", quiet=True)
+
+    assert "apiserver is not running" in str(excinfo.value)
+    assert "container system start" in str(excinfo.value)
+    # We attempted the auto-start before giving up.
+    assert ["system", "start", "--enable-kernel-install"] in [
+        c.args[0] for c in run.call_args_list
+    ]
+    # Bailed before ever probing images.
+    image_inspect.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # config validation
 # ---------------------------------------------------------------------------
@@ -595,6 +638,8 @@ def _setup_start_test(tmp_path, monkeypatch, *, unit_meta):
     monkeypatch.setattr(
         backend, "public_certs_dir", lambda _n: public_certs_dir,
     )
+    # start() guards on the apiserver being up before probing images.
+    monkeypatch.setattr(ac_cli, "system_running", lambda: True)
     monkeypatch.setattr(
         ac_cli, "image_inspect", lambda _img: {"config": {}},
     )

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -121,6 +121,68 @@ def test_start_errors_when_apiserver_wont_start(tmp_path, monkeypatch):
     image_inspect.assert_not_called()
 
 
+def test_ensure_ready_starts_apiserver_when_down():
+    """ensure_ready() is the recoverable-substrate step the CLI runs before
+    build/start: a downed apiserver gets `container system start`."""
+    backend = AppleContainerBackend()
+    states = iter([False, True])  # down, then up after start
+    with patch.object(ac_cli, "system_running", side_effect=lambda: next(states)), \
+         patch.object(ac_cli, "run") as run:
+        backend.ensure_ready(quiet=True)
+    assert ["system", "start", "--enable-kernel-install"] in [
+        c.args[0] for c in run.call_args_list
+    ]
+
+
+def test_ensure_ready_noop_when_apiserver_already_running():
+    """If the daemon is already up, ensure_ready() must not touch it."""
+    backend = AppleContainerBackend()
+    with patch.object(ac_cli, "system_running", return_value=True), \
+         patch.object(ac_cli, "run") as run:
+        backend.ensure_ready(quiet=True)
+    run.assert_not_called()
+
+
+def test_ensure_ready_swallows_missing_cli():
+    """When the `container` CLI isn't installed, ensure_ready() has nothing
+    to recover and must not raise — check_prerequisites() reports the
+    missing CLI with an install hint instead."""
+    backend = AppleContainerBackend()
+    with patch.object(ac_cli, "system_running", return_value=False), \
+         patch.object(ac_cli, "run", side_effect=FileNotFoundError):
+        backend.ensure_ready(quiet=True)  # no exception
+
+
+def test_ensure_backend_ready_gate_recovers_then_passes():
+    """The CLI gate auto-recovers the substrate, then proceeds when no
+    prerequisites are unmet — returning the backend for reuse."""
+    from agentcage import cli
+    backend = MagicMock()
+    backend.check_prerequisites.return_value = []
+    cfg = Config(name="t", isolation="apple-container")
+    with patch.object(cli, "get_backend", return_value=backend):
+        result = cli._ensure_backend_ready(cfg)
+    backend.ensure_ready.assert_called_once()
+    assert result is backend
+
+
+def test_ensure_backend_ready_gate_aborts_on_unmet_prereqs():
+    """Whatever ensure_ready() couldn't fix (reported by check_prerequisites)
+    aborts the command with a non-zero exit and the issue text — this is the
+    path that turns a downed-and-unstartable apiserver into an actionable
+    message instead of the misleading 'image not found'."""
+    from agentcage import cli
+    backend = MagicMock()
+    backend.check_prerequisites.return_value = [
+        "Apple container apiserver is not running — run 'container system start'",
+    ]
+    cfg = Config(name="t", isolation="apple-container")
+    with patch.object(cli, "get_backend", return_value=backend):
+        with pytest.raises(SystemExit) as excinfo:
+            cli._ensure_backend_ready(cfg)
+    assert excinfo.value.code == 1
+
+
 # ---------------------------------------------------------------------------
 # config validation
 # ---------------------------------------------------------------------------

--- a/tests/test_apple_container_cli.py
+++ b/tests/test_apple_container_cli.py
@@ -17,7 +17,25 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _bypass_backend_gate(monkeypatch):
+    """Neutralize the create/update/start prerequisite gate for these tests.
+
+    ``_ensure_backend_ready`` is unit-tested on its own (see
+    test_apple_container.py); here we only want it to resolve the test's
+    (mocked) backend without enforcing ``check_prerequisites`` on a
+    MagicMock. ``get_backend`` is looked up lazily so the per-test
+    ``@patch`` mock is the one returned.
+    """
+    import agentcage.cli as _cli
+    monkeypatch.setattr(
+        _cli, "_ensure_backend_ready",
+        lambda cfg, **kw: _cli.get_backend(cfg),
+    )
 
 from agentcage.cli import main
 

--- a/tests/test_apple_container_egress_ports.py
+++ b/tests/test_apple_container_egress_ports.py
@@ -130,6 +130,7 @@ def _start_with_meta(tmp_path, meta_extra: dict) -> list[str]:
          patch.object(AppleContainerBackend, "_wait_supervisor_ready"), \
          patch.object(AppleContainerBackend, "_container_ip", return_value="10.0.0.2"), \
          patch("agentcage.backends.apple_container.ac_cli.run", side_effect=fake_run), \
+         patch("agentcage.backends.apple_container.ac_cli.system_running", return_value=True), \
          patch("agentcage.backends.apple_container.ac_cli.inspect", return_value=None), \
          patch("agentcage.backends.apple_container.ac_cli.image_inspect", return_value={"ok": 1}), \
          patch("agentcage.backends.apple_container.ac_wrapper.wrapped_image_name",

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -7,9 +7,29 @@ import textwrap
 from unittest.mock import MagicMock, patch, call, ANY
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from agentcage.cli import main, _stage_build_context
+
+
+@pytest.fixture(autouse=True)
+def _bypass_backend_gate(monkeypatch):
+    """Neutralize the create/update/start prerequisite gate for these tests.
+
+    ``_ensure_backend_ready`` (auto-start the substrate + enforce
+    ``check_prerequisites``) is a cross-cutting glue step unit-tested on its
+    own (see test_apple_container.py). Here we only want it to resolve the
+    test's (mocked) backend without running enforcement on a MagicMock —
+    otherwise ``check_prerequisites`` returns a truthy Mock and trips the
+    gate. Resolve ``get_backend`` lazily so the per-test ``@patch`` mock is
+    the one returned.
+    """
+    import agentcage.cli as _cli
+    monkeypatch.setattr(
+        _cli, "_ensure_backend_ready",
+        lambda cfg, **kw: _cli.get_backend(cfg),
+    )
 
 
 def _runner():


### PR DESCRIPTION
## Problem

After a reboot, `agentcage cage start <name>` on the apple-container backend failed with a misleading error:

```
RuntimeError: wrapped image 'localhost/agentcage-apple-pi01:latest' not found — was build_artifacts() called?
```

The image was actually present. Apple's `container` **apiserver does not survive a reboot** — it must be re-started each boot (`container system start`). While it's down, every `container` subcommand fails with an XPC connection error, so `image_inspect()` returned `None` and `start()` wrongly blamed a missing image.

The kicker: the diagnostics for this *already existed* in each backend's `check_prerequisites()` (apple-container even distinguishes "apiserver stopped" from "not installed"), but **nothing on the build/start path ever called them** — only `agentcage doctor` did.

## Fix

Two layers:

**1. `Backend.ensure_ready()`** — best-effort, idempotent bring-up of recoverable substrate before build/start:
- **apple-container**: starts the apiserver if it's down (mirrors the Lima backend, which auto-starts its VM in `start()` rather than making the user do it by hand). Running it *before* `build_artifacts()` means `cage create`/`update` are covered too, not just `start`.
- **container / vm**: no-ops (rootless podman socket-activates; the Lima VM is brought up inside `start()`).

**2. CLI gate `_ensure_backend_ready()`** — `ensure_ready()` then `check_prerequisites()`; anything still unmet (wrong OS, missing CLI, a daemon that refused to start) aborts the command with the issues listed. Wired into `cage create`, `update`, and `start`. Because `ensure_ready()` runs first, a daemon we can restart ourselves never trips the gate.

`start()` keeps a defensive `ensure_ready()` + recheck for direct/programmatic callers (backup/restore), raising the actionable apiserver error rather than the bogus image one.

## Why this shape

The three backends previously diverged on a downed substrate: Lima auto-starts its VM, podman relies on systemd socket activation, and apple-container did nothing (surfacing the misleading image error). This unifies them — auto-recover what's recoverable, then report uniformly via the prerequisite checks that already existed.

## Tests

- `ensure_ready()` units: down→`system start`, no-op when already up, swallows missing-CLI (`check_prerequisites` reports that instead).
- Gate units: recover-then-pass (returns backend), abort-on-unmet-prereqs (`SystemExit(1)`).
- `start()`: auto-starts when down; raises actionable error when it won't start; never falls through to the image probe.
- CLI command tests neutralize the cross-cutting gate via an autouse fixture (resolving the mocked backend without enforcing prereqs on a `MagicMock`), so they keep exercising command mechanics; the gate is covered by the direct tests above.

Verified the full suite shows **zero net new failures** vs. the base (the pre-existing failures are macOS-environmental and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)