### PR TITLE
feat(secret-injection): strict-by-default injection scope (Authorization header only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Secret injection is strict by default — `Authorization` header only.** The proxy now only substitutes a placeholder for its real secret value when the placeholder appears in the request's `Authorization` header. Placeholders left in the URL/query string, request body, other headers, or WebSocket frames pass through unchanged. This confines credentials to the standard auth channel and prevents accidental injection into bodies that may be logged or echoed.
+
+### Added
+
+- **`secret_injection[].inject_body` toggle (default `false`).** Set `inject_body: true` on a rule to opt back into the previous looser behavior, where placeholders are substituted in the request URL, all headers, the body, and WebSocket frames. Use this for APIs that carry the credential outside the `Authorization` header (e.g. a `?api_key=` query parameter or a JSON body field). Response redaction and literal-value blocking are unaffected by the toggle.
+
 ## [0.22.20] - 2026-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Secret injection is strict by default — `Authorization` header only.** The proxy now only substitutes a placeholder for its real secret value when the placeholder appears in the request's `Authorization` header. Placeholders left in the URL/query string, request body, other headers, or WebSocket frames pass through unchanged. This confines credentials to the standard auth channel and prevents accidental injection into bodies that may be logged or echoed.
+- **Secret injection is strict by default — credential-bearing headers only.** The proxy substitutes a placeholder for its real secret value only when the placeholder appears in a credential-bearing request header — one whose name contains `auth`, `key`, or `token` (case-insensitive). That single heuristic covers `Authorization`, `x-api-key` (Anthropic), `api-key` (Azure), `x-goog-api-key` (Google), `private-token` (GitLab), `x-subscription-token` (Brave), and virtually every other API's auth header without hard-coding vendor names. Placeholders left in the URL/query string, the request body, or a non-credential header pass through unchanged, confining credentials to the auth channel and keeping them out of bodies that may be logged or echoed. (The initial cut of this feature matched only `Authorization`, which broke header-key APIs such as Anthropic's `x-api-key`: requests went out carrying the literal placeholder and were rejected with `401 invalid x-api-key`.)
 
 ### Added
 
-- **`secret_injection[].inject_body` toggle (default `false`).** Set `inject_body: true` on a rule to opt back into the previous looser behavior, where placeholders are substituted in the request URL, all headers, the body, and WebSocket frames. Use this for APIs that carry the credential outside the `Authorization` header (e.g. a `?api_key=` query parameter or a JSON body field). Response redaction and literal-value blocking are unaffected by the toggle.
+- **`secret_injection[].inject_headers` (list, default empty).** Extra request headers to treat as credential-bearing under the strict default — for auth headers whose name has none of the `auth`/`key`/`token` keywords (e.g. Honeycomb's `inject_headers: ["X-Honeycomb-Team"]`). Matched case-insensitively; the keyword heuristic still applies to your other headers.
+- **`secret_injection[].inject_body` toggle (default `false`).** Set `inject_body: true` on a rule to also substitute placeholders in the request URL, every header, the body, and WebSocket frames. Use this for APIs that carry the credential outside a header (e.g. a `?api_key=` query parameter or a JSON body field). Response redaction and literal-value blocking are unaffected by the toggle.
 
 ## [0.22.20] - 2026-05-30
 

--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -12,7 +12,8 @@ Secrets listed in `secret_injection` are automatically excluded from the cage's 
 | `env` | `string` | yes | Environment variable name holding the real secret (read by the proxy at startup). |
 | `placeholder` | `string` | yes | Token the cage sees and uses in requests (e.g. `"{{ANTHROPIC_API_KEY}}"`). |
 | `inject_to` | `list[string]` | no | Domains where placeholders are replaced with real values. If omitted, injection applies to all domains. |
-| `inject_body` | `bool` | no | When `false` (the default), placeholders are only substituted inside the HTTP `Authorization` request header. Set to `true` to also inject into the request URL (query string) and request body, and into WebSocket frames. See [Injection scope](#injection-scope). |
+| `inject_body` | `bool` | no | When `false` (the default), placeholders are only substituted inside known credential-bearing request headers (the [auth-header allow-list](#injection-scope)). Set to `true` to also inject into the request URL (query string), every header, the request body, and WebSocket frames. See [Injection scope](#injection-scope). |
+| `inject_headers` | `list[string]` | no | Extra request headers — added to the built-in auth-header allow-list — to treat as credential-bearing under the strict default. Matched case-insensitively. Use for APIs whose auth header isn't a common convention. See [Injection scope](#injection-scope). |
 | `source` | `string` | no | Where to load the secret from. See [Secret backends](#secret-backends). If omitted, set it via `agentcage secret set`. |
 | `transform` | `string` | no | Convert the underlying secret into a derived value at request time (e.g. mint a short-lived OAuth access token). See [Transforms](#transforms). |
 | `transform_config` | `mapping` | no | Per-transform options. Required keys depend on the transform. |
@@ -75,11 +76,35 @@ When `inject_to` is omitted, the real value is injected for all outbound request
 
 ## Injection scope
 
-By default secret injection is **strict**: the proxy only swaps a placeholder for its real value when the placeholder appears in the request's `Authorization` header. Placeholders left anywhere else — the URL/query string, the request body, or any other header — pass through unchanged. This keeps credentials confined to the standard auth channel and avoids accidentally writing secrets into request bodies that might be logged or echoed.
+By default secret injection is **strict**: the proxy only swaps a placeholder for its real value when the placeholder appears in a **credential-bearing request header** (the auth channel). Placeholders left anywhere else — the URL/query string, the request body, or a non-credential header — pass through unchanged. This keeps credentials confined to the auth channel and avoids accidentally writing secrets into request bodies that might be logged or echoed.
 
-Set `inject_body: true` on a rule to opt into the looser behavior, where placeholders are substituted in the URL, all request headers, the request body, and WebSocket frames. Use this only for APIs that genuinely carry the credential outside the `Authorization` header (for example a `?api_key=` query parameter or a JSON body field).
+A request header is treated as credential-bearing when its name **contains `auth`, `key`, or `token`** (case-insensitive). This single heuristic covers the documented auth header of virtually every API without hard-coding vendor names — for example `Authorization`, `x-api-key` (**Anthropic**), `api-key` (Azure, Pinecone), `apikey` (Supabase), `x-goog-api-key` (Google), `private-token` (GitLab), `x-auth-key` (Cloudflare), `x-subscription-token` (Brave), `dd-api-key` (Datadog), `circle-token` (CircleCI), `x-figma-token`, `fastly-key`, `x-shopify-access-token`, and so on all match.
 
-Response redaction and literal-value blocking are unaffected by this toggle — real secret values are always redacted from responses and always blocked when found leaking outbound, regardless of `inject_body`.
+> Anthropic's API authenticates with `x-api-key` (not `Authorization`). It matches on `key`, so `secret_injection` works against `api.anthropic.com` out of the box.
+
+If your API uses a credential header whose name has **none** of those keywords (e.g. Honeycomb's `X-Honeycomb-Team`), add it explicitly with `inject_headers` (matched case-insensitively; the keyword default still applies to your other headers):
+
+```yaml
+secret_injection:
+  - env: HONEYCOMB_API_KEY
+    placeholder: "{{HONEYCOMB_API_KEY}}"
+    inject_to: ["api.honeycomb.io"]
+    inject_headers: ["X-Honeycomb-Team"]
+```
+
+If the API carries the credential **outside any header** — a `?api_key=` query parameter (SerpAPI), `?auth=` / `?access_token=` (Firebase), or a JSON body field (Plaid) — header injection can't reach it (the keyword heuristic applies to header *names* only, not the URL or body). Set `inject_body: true` to substitute placeholders in the URL, every header, the request body, and WebSocket frames:
+
+```yaml
+secret_injection:
+  - env: SERPAPI_KEY
+    placeholder: "{{SERPAPI_KEY}}"
+    inject_to: ["serpapi.com"]
+    inject_body: true   # key travels as ?api_key=
+```
+
+> **Security note:** `inject_body: true` is looser by design — a placeholder anywhere in the body is replaced, including bodies that may be logged or echoed downstream. Prefer the header-based default (with `inject_headers` if needed) whenever the API supports a header credential.
+
+Response redaction and literal-value blocking are unaffected by these toggles — real secret values are always redacted from responses and always blocked when found leaking outbound, regardless of `inject_body` / `inject_headers`.
 
 ## Literal value blocking
 

--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -12,6 +12,7 @@ Secrets listed in `secret_injection` are automatically excluded from the cage's 
 | `env` | `string` | yes | Environment variable name holding the real secret (read by the proxy at startup). |
 | `placeholder` | `string` | yes | Token the cage sees and uses in requests (e.g. `"{{ANTHROPIC_API_KEY}}"`). |
 | `inject_to` | `list[string]` | no | Domains where placeholders are replaced with real values. If omitted, injection applies to all domains. |
+| `inject_body` | `bool` | no | When `false` (the default), placeholders are only substituted inside the HTTP `Authorization` request header. Set to `true` to also inject into the request URL (query string) and request body, and into WebSocket frames. See [Injection scope](#injection-scope). |
 | `source` | `string` | no | Where to load the secret from. See [Secret backends](#secret-backends). If omitted, set it via `agentcage secret set`. |
 | `transform` | `string` | no | Convert the underlying secret into a derived value at request time (e.g. mint a short-lived OAuth access token). See [Transforms](#transforms). |
 | `transform_config` | `mapping` | no | Per-transform options. Required keys depend on the transform. |
@@ -71,6 +72,14 @@ Existing values in the old backend are not migrated automatically; once the cage
 When `inject_to` is set for a rule, the proxy only injects the real value for requests to matching domains (subdomains are matched automatically). If the cage sends a placeholder to any other domain, the request is **flagged**.
 
 When `inject_to` is omitted, the real value is injected for all outbound requests and redacted from all inbound responses.
+
+## Injection scope
+
+By default secret injection is **strict**: the proxy only swaps a placeholder for its real value when the placeholder appears in the request's `Authorization` header. Placeholders left anywhere else — the URL/query string, the request body, or any other header — pass through unchanged. This keeps credentials confined to the standard auth channel and avoids accidentally writing secrets into request bodies that might be logged or echoed.
+
+Set `inject_body: true` on a rule to opt into the looser behavior, where placeholders are substituted in the URL, all request headers, the request body, and WebSocket frames. Use this only for APIs that genuinely carry the credential outside the `Authorization` header (for example a `?api_key=` query parameter or a JSON body field).
+
+Response redaction and literal-value blocking are unaffected by this toggle — real secret values are always redacted from responses and always blocked when found leaking outbound, regardless of `inject_body`.
 
 ## Literal value blocking
 

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -50,10 +50,16 @@ class SecretInjectionRule:
     source: str = ""
     transform: str = ""
     transform_config: dict = field(default_factory=dict)
-    # Strict by default: only substitute placeholders found in the HTTP
-    # Authorization header. Set ``inject_body: true`` to also inject into
-    # the request URL and body (the legacy, looser behavior).
+    # Strict by default: only substitute placeholders found in a
+    # credential-bearing request header — one whose name contains "auth",
+    # "key", or "token" (Authorization, x-api-key, *-token, …). Set
+    # ``inject_body: true`` to also inject into the request URL and body
+    # (the legacy, looser behavior).
     inject_body: bool = False
+    # Extra request headers to treat as credential-bearing under the strict
+    # default — for auth headers whose name doesn't match the keyword
+    # heuristic (e.g. ``x-honeycomb-team``). Matched case-insensitively.
+    inject_headers: list[str] = field(default_factory=list)
 
 
 def validate_transform(name: str) -> None:
@@ -553,6 +559,9 @@ def load_config(path: str) -> Config:
                 transform=transform,
                 transform_config=transform_config,
                 inject_body=bool(entry.get("inject_body", False)),
+                inject_headers=[
+                    str(h).strip() for h in (entry.get("inject_headers") or [])
+                ],
             ))
 
     # Remove injected secrets from podman_secrets and env — they are handled

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -50,6 +50,10 @@ class SecretInjectionRule:
     source: str = ""
     transform: str = ""
     transform_config: dict = field(default_factory=dict)
+    # Strict by default: only substitute placeholders found in the HTTP
+    # Authorization header. Set ``inject_body: true`` to also inject into
+    # the request URL and body (the legacy, looser behavior).
+    inject_body: bool = False
 
 
 def validate_transform(name: str) -> None:
@@ -548,6 +552,7 @@ def load_config(path: str) -> Config:
                 source=source,
                 transform=transform,
                 transform_config=transform_config,
+                inject_body=bool(entry.get("inject_body", False)),
             ))
 
     # Remove injected secrets from podman_secrets and env — they are handled

--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -47,6 +47,9 @@ class InjectionRule:
     # block can detect raw key bytes leaking into outbound traffic.
     transform: str = ""
     transform_fn: Optional[Callable[[], str]] = None
+    # Strict by default: only inject into the HTTP Authorization header.
+    # When True, also inject into the request URL and body (legacy behavior).
+    inject_body: bool = False
 
 
 class SecretInjector:
@@ -102,6 +105,8 @@ class SecretInjector:
                 )
                 continue
 
+            inject_body = bool(entry.get("inject_body", False))
+
             transform_name = entry.get("transform", "") or ""
             transform_fn: Optional[Callable[[], str]] = None
             if transform_name:
@@ -126,6 +131,7 @@ class SecretInjector:
                     inject_to=inject_to,
                     transform=transform_name,
                     transform_fn=transform_fn,
+                    inject_body=inject_body,
                 )
             )
 
@@ -272,19 +278,36 @@ class SecretInjector:
             ph_bytes = ph.encode()
             value_bytes = value.encode()
 
-            flow.request.url = flow.request.url.replace(ph, value)
+            injected = False
 
-            for k in list(flow.request.headers.keys()):
-                v = flow.request.headers[k]
-                if ph in v:
-                    flow.request.headers[k] = v.replace(ph, value)
+            if rule.inject_body:
+                # Legacy/loose mode: inject into URL, all headers, and body.
+                if ph in flow.request.url:
+                    flow.request.url = flow.request.url.replace(ph, value)
+                    injected = True
 
-            if flow.request.content and ph_bytes in flow.request.content:
-                flow.request.content = flow.request.content.replace(
-                    ph_bytes, value_bytes
-                )
+                for k in list(flow.request.headers.keys()):
+                    v = flow.request.headers[k]
+                    if ph in v:
+                        flow.request.headers[k] = v.replace(ph, value)
+                        injected = True
 
-            names.append(rule.name)
+                if flow.request.content and ph_bytes in flow.request.content:
+                    flow.request.content = flow.request.content.replace(
+                        ph_bytes, value_bytes
+                    )
+                    injected = True
+            else:
+                # Strict mode (default): only inject into the HTTP
+                # Authorization header. Placeholders anywhere else (URL,
+                # body, other headers) are left untouched.
+                auth = flow.request.headers.get("Authorization")
+                if auth is not None and ph in auth:
+                    flow.request.headers["Authorization"] = auth.replace(ph, value)
+                    injected = True
+
+            if injected:
+                names.append(rule.name)
         return names
 
     def _redact_request(self, flow: http.HTTPFlow) -> list[str]:
@@ -517,6 +540,11 @@ class SecretInjector:
 
         names: list[str] = []
         for rule in self.rules:
+            # Strict mode only injects into the HTTP Authorization header,
+            # which has no equivalent in raw WebSocket frames — leave the
+            # placeholder in place unless the rule opted into body injection.
+            if not rule.inject_body:
+                continue
             ph_bytes = rule.placeholder.encode()
             if ph_bytes not in content:
                 continue

--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -33,6 +33,34 @@ _SECRETS_DIR = Path(
     os.environ.get("AGENTCAGE_SECRETS_DIR", "/home/acproxy/secrets")
 )
 
+# Strict (default) injection confines secret substitution to the "auth
+# channel": a placeholder is swapped for its real value only when it appears
+# in a *credential-bearing request header*, never in the URL/query string,
+# the request body, or a WebSocket frame (those keep the placeholder unless
+# the rule sets ``inject_body: true``). Keeping secrets out of bodies is the
+# PR #251 goal — bodies get logged and echoed downstream; the auth header
+# does not.
+#
+# Rather than enumerate specific vendor header names, we recognize a header
+# as credential-bearing when its name contains one of these keyword stems
+# (case-insensitive substring match). Almost every API's auth header does:
+#   authorization, x-api-key, api-key, apikey, x-goog-api-key, private-token,
+#   x-auth-token, x-auth-key, x-subscription-token, ocp-apim-subscription-key,
+#   dd-api-key, circle-token, x-algolia-api-key, fastly-key, x-figma-token,
+#   x-postmark-server-token, x-shopify-access-token, … all match.
+# (Surveyed against ~70 popular APIs; the only credential header found that
+# lacks any of these stems is Honeycomb's ``x-honeycomb-team`` — add headers
+# like that per-rule via ``inject_headers``.)
+#
+# This is safe because the match only ever has an effect when a rule's unique
+# ``{{PLACEHOLDER}}`` literally appears in the header — the cage only puts the
+# placeholder where its HTTP client sends the credential — so a broad match
+# can't inject a secret somewhere the agent didn't already place it. APIs that
+# carry the key in the URL query string (Google ``?key=``, SerpAPI
+# ``?api_key=``, Firebase ``?auth=``) or the request body (Plaid) are outside
+# the header channel and need ``inject_body: true``.
+AUTH_HEADER_KEYWORDS: tuple[str, ...] = ("auth", "key", "token")
+
 
 @dataclass
 class InjectionRule:
@@ -47,9 +75,25 @@ class InjectionRule:
     # block can detect raw key bytes leaking into outbound traffic.
     transform: str = ""
     transform_fn: Optional[Callable[[], str]] = None
-    # Strict by default: only inject into the HTTP Authorization header.
-    # When True, also inject into the request URL and body (legacy behavior).
+    # Strict by default: only inject into credential-bearing headers — those
+    # whose name matches the ``AUTH_HEADER_KEYWORDS`` heuristic or is listed in
+    # ``inject_headers``. When True, also inject into the request URL, every
+    # header, the body, and WebSocket frames (the legacy, looser behavior).
     inject_body: bool = False
+    # Extra request headers this rule treats as credential-bearing under the
+    # strict default — for auth headers whose name doesn't match the keyword
+    # heuristic (e.g. ``x-honeycomb-team``). Matched case-insensitively.
+    inject_headers: list[str] = field(default_factory=list)
+
+    def is_auth_header(self, name: str) -> bool:
+        """Whether ``name`` is a credential-bearing header this rule injects
+        into under the strict default. True when the (case-insensitive) header
+        name contains one of ``AUTH_HEADER_KEYWORDS`` or exactly matches an
+        ``inject_headers`` entry."""
+        n = name.lower()
+        if any(kw in n for kw in AUTH_HEADER_KEYWORDS):
+            return True
+        return any(n == extra.lower() for extra in self.inject_headers)
 
 
 class SecretInjector:
@@ -106,6 +150,9 @@ class SecretInjector:
                 continue
 
             inject_body = bool(entry.get("inject_body", False))
+            inject_headers = [
+                str(h).strip() for h in (entry.get("inject_headers") or [])
+            ]
 
             transform_name = entry.get("transform", "") or ""
             transform_fn: Optional[Callable[[], str]] = None
@@ -132,6 +179,7 @@ class SecretInjector:
                     transform=transform_name,
                     transform_fn=transform_fn,
                     inject_body=inject_body,
+                    inject_headers=inject_headers,
                 )
             )
 
@@ -298,13 +346,19 @@ class SecretInjector:
                     )
                     injected = True
             else:
-                # Strict mode (default): only inject into the HTTP
-                # Authorization header. Placeholders anywhere else (URL,
-                # body, other headers) are left untouched.
-                auth = flow.request.headers.get("Authorization")
-                if auth is not None and ph in auth:
-                    flow.request.headers["Authorization"] = auth.replace(ph, value)
-                    injected = True
+                # Strict mode (default): only inject into credential-bearing
+                # headers — those whose name contains "auth", "key", or
+                # "token" (Authorization, x-api-key, *-token, …), plus any
+                # explicit ``inject_headers``. Placeholders anywhere else —
+                # the URL, the body, or a non-credential header — are left
+                # untouched.
+                for k in list(flow.request.headers.keys()):
+                    if not rule.is_auth_header(k):
+                        continue
+                    v = flow.request.headers[k]
+                    if ph in v:
+                        flow.request.headers[k] = v.replace(ph, value)
+                        injected = True
 
             if injected:
                 names.append(rule.name)
@@ -540,9 +594,10 @@ class SecretInjector:
 
         names: list[str] = []
         for rule in self.rules:
-            # Strict mode only injects into the HTTP Authorization header,
-            # which has no equivalent in raw WebSocket frames — leave the
-            # placeholder in place unless the rule opted into body injection.
+            # Strict mode only injects into credential-bearing request
+            # headers, which have no equivalent in a raw WebSocket frame —
+            # leave the placeholder in place unless the rule opted into body
+            # injection (inject_body).
             if not rule.inject_body:
                 continue
             ph_bytes = rule.placeholder.encode()

--- a/tests/e2e/configs/secrets.yaml
+++ b/tests/e2e/configs/secrets.yaml
@@ -21,3 +21,10 @@ secret_injection:
     placeholder: "{{MY_API_KEY}}"
     inject_to:
       - httpbin.org
+    # Phase 3.3 drives injection by POSTing the placeholder in the request
+    # BODY (the in-cage agent's /check-secret forwards the body to
+    # httpbin.org/post, with no Authorization header). Injection is strict
+    # by default — Authorization header only — so opt this rule into body
+    # injection to exercise (and keep covering) the loose path on the wire.
+    # The strict default's Authorization-header path is covered by phase 8.
+    inject_body: true

--- a/tests/e2e/configs/secrets.yaml
+++ b/tests/e2e/configs/secrets.yaml
@@ -23,8 +23,9 @@ secret_injection:
       - httpbin.org
     # Phase 3.3 drives injection by POSTing the placeholder in the request
     # BODY (the in-cage agent's /check-secret forwards the body to
-    # httpbin.org/post, with no Authorization header). Injection is strict
-    # by default — Authorization header only — so opt this rule into body
-    # injection to exercise (and keep covering) the loose path on the wire.
-    # The strict default's Authorization-header path is covered by phase 8.
+    # httpbin.org/post, with no auth header). Injection is strict by default
+    # — only known credential-bearing headers (Authorization, x-api-key, …)
+    # are injected — so opt this rule into body injection to exercise (and
+    # keep covering) the loose path on the wire. The strict default's
+    # auth-header path is covered by phase 8 (Authorization: Bearer).
     inject_body: true

--- a/tests/test_addon_capture_redaction.py
+++ b/tests/test_addon_capture_redaction.py
@@ -216,6 +216,9 @@ def test_capture_jsonl_does_not_contain_real_secret_after_inject(tmp_path):
         placeholder="{{ANTHROPIC_API_KEY}}",
         real_value=_FAKE_REAL,
         inject_to=["anthropic.com"],
+        # Placeholder is in the body, so the inject step needs the opt-in
+        # body-injection path; strict (default) mode would leave it alone.
+        inject_body=True,
     )
     addon = _build_addon_with_capture(tmp_path, rules=[rule])
 
@@ -243,6 +246,38 @@ def test_capture_jsonl_does_not_contain_real_secret_after_inject(tmp_path):
     assert "{{ANTHROPIC_API_KEY}}" in entry["outbound"]["request"]["body"]
     assert _FAKE_REAL not in entry["inbound"]["request"]["body"]
     assert _FAKE_REAL not in entry["outbound"]["request"]["body"]
+
+
+def test_strict_default_leaves_body_placeholder_uninjected(tmp_path):
+    """Strict mode (the default): a placeholder that lives only in the
+    request body is never swapped for the real value — it never reaches
+    the wire, so it cannot leak into capture.jsonl either. Opting into
+    body injection is what test_capture_jsonl_does_not_contain_real_secret
+    _after_inject covers."""
+    rule = InjectionRule(
+        name="ANTHROPIC_API_KEY",
+        placeholder="{{ANTHROPIC_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["anthropic.com"],
+        # inject_body defaults to False — strict mode.
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    flow = _make_flow(
+        body='{"model": "claude", "x-api-key": "{{ANTHROPIC_API_KEY}}"}',
+    )
+    addon.request(flow)
+    # The real value never went on the wire: body still holds the placeholder.
+    assert _FAKE_REAL.encode() not in flow.request.content
+    assert b"{{ANTHROPIC_API_KEY}}" in flow.request.content
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert _FAKE_REAL not in cap_text
+    entry = json.loads(cap_text.splitlines()[0])
+    assert "{{ANTHROPIC_API_KEY}}" in entry["outbound"]["request"]["body"]
 
 
 def test_capture_jsonl_does_not_contain_real_secret_in_headers(tmp_path):
@@ -296,6 +331,9 @@ def test_redact_request_round_trip_through_addon_response(tmp_path):
         placeholder="{{ANTHROPIC_API_KEY}}",
         real_value=_FAKE_REAL,
         inject_to=["anthropic.com"],
+        # Exercises injection into BOTH the Authorization header and the
+        # body, so the rule opts into body injection.
+        inject_body=True,
     )
     addon = _build_addon_with_capture(tmp_path, rules=[rule])
 

--- a/tests/test_addon_capture_redaction.py
+++ b/tests/test_addon_capture_redaction.py
@@ -320,6 +320,89 @@ def test_capture_jsonl_does_not_contain_real_secret_in_headers(tmp_path):
     assert outbound_auth == "Bearer {{ANTHROPIC_API_KEY}}"
 
 
+def test_strict_default_injects_anthropic_x_api_key_header(tmp_path):
+    """End-to-end regression guard (PR #251): Anthropic sends its key in the
+    ``x-api-key`` header, not ``Authorization``. Under the STRICT DEFAULT
+    (no inject_body), the addon must still swap the placeholder for the real
+    value on the wire — otherwise the literal placeholder reaches Anthropic
+    and the request 401s with 'invalid x-api-key'. The capture file must also
+    still show only the placeholder."""
+    rule = InjectionRule(
+        name="ANTHROPIC_API_KEY",
+        placeholder="{{ANTHROPIC_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["anthropic.com"],
+        # No inject_body — this is the strict default path.
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    flow = _make_flow(
+        headers={"x-api-key": "{{ANTHROPIC_API_KEY}}"},
+        body=b"",
+    )
+    addon.request(flow)
+    # On the wire upstream: the real key, so Anthropic accepts it.
+    assert flow.request.headers["x-api-key"] == _FAKE_REAL
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert _FAKE_REAL not in cap_text, (
+        f"real-key bytes leaked via x-api-key into capture.jsonl: "
+        f"{cap_text[:500]!r}..."
+    )
+    entry = json.loads(cap_text.splitlines()[0])
+    outbound_key = next(
+        v for k, v in entry["outbound"]["request"]["headers"]
+        if k.lower() == "x-api-key"
+    )
+    assert outbound_key == "{{ANTHROPIC_API_KEY}}"
+
+
+def test_strict_inject_headers_keywordless_header_no_capture_leak(tmp_path):
+    """The ``inject_headers`` path is the second newly-injectable surface:
+    a credential header whose name has no auth/key/token keyword (Honeycomb's
+    ``X-Honeycomb-Team``). Pin the capture-no-leak invariant for it too —
+    inject puts the real value on the wire, redact_request scrubs it back, and
+    capture.jsonl shows only the placeholder. (Guards against a future
+    name-aware redaction refactor silently leaking inject_headers-only
+    credentials, since redaction is currently header-name-agnostic.)"""
+    rule = InjectionRule(
+        name="HONEYCOMB_API_KEY",
+        placeholder="{{HONEYCOMB_API_KEY}}",
+        real_value=_FAKE_REAL,
+        inject_to=["honeycomb.io"],
+        inject_headers=["X-Honeycomb-Team"],  # no keyword; no inject_body
+    )
+    addon = _build_addon_with_capture(tmp_path, rules=[rule])
+
+    flow = _make_flow(
+        url="https://api.honeycomb.io/1/events/ds",
+        host="api.honeycomb.io",
+        headers={"X-Honeycomb-Team": "{{HONEYCOMB_API_KEY}}"},
+        body=b"",
+    )
+    addon.request(flow)
+    # On the wire upstream: the real key, so Honeycomb accepts it.
+    assert flow.request.headers["X-Honeycomb-Team"] == _FAKE_REAL
+
+    _attach_response(flow)
+    addon.response(flow)
+
+    cap_text = (tmp_path / "capture.jsonl").read_text()
+    assert _FAKE_REAL not in cap_text, (
+        f"real-key bytes leaked via inject_headers into capture.jsonl: "
+        f"{cap_text[:500]!r}..."
+    )
+    entry = json.loads(cap_text.splitlines()[0])
+    outbound = next(
+        v for k, v in entry["outbound"]["request"]["headers"]
+        if k.lower() == "x-honeycomb-team"
+    )
+    assert outbound == "{{HONEYCOMB_API_KEY}}"
+
+
 def test_redact_request_round_trip_through_addon_response(tmp_path):
     """Full pipeline cross-check: after addon.request() the flow has
     the real value (inject was meant to put it on the wire), and after

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,6 +85,28 @@ class TestLoadConfigFull:
         assert rule.env == "INJECTED_KEY"
         assert rule.placeholder == "{{INJECTED_KEY}}"
         assert rule.inject_to == ["api.example.com"]
+        # Strict by default — body injection is opt-in.
+        assert rule.inject_body is False
+
+    def test_secret_injection_inject_body_toggle(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: KEY1
+                placeholder: "{{KEY1}}"
+                inject_to: ["api.example.com"]
+                inject_body: true
+              - env: KEY2
+                placeholder: "{{KEY2}}"
+                inject_to: ["api.example.com"]
+        """))
+        cfg = load_config(str(p))
+        rules = {r.env: r for r in cfg.secret_injection}
+        assert rules["KEY1"].inject_body is True
+        assert rules["KEY2"].inject_body is False
 
     def test_injected_secret_removed_from_podman_secrets(self, full_yaml):
         cfg = load_config(full_yaml)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,50 @@ class TestLoadConfigFull:
         assert rule.inject_to == ["api.example.com"]
         # Strict by default — body injection is opt-in.
         assert rule.inject_body is False
+        # No extra auth headers by default — the built-in allow-list applies.
+        assert rule.inject_headers == []
+
+    def test_secret_injection_inject_headers(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: KEY1
+                placeholder: "{{KEY1}}"
+                inject_to: ["api.example.com"]
+                inject_headers: ["X-Acme-Token", "X-Acme-Secondary"]
+              - env: KEY2
+                placeholder: "{{KEY2}}"
+                inject_to: ["api.example.com"]
+        """))
+        cfg = load_config(str(p))
+        rules = {r.env: r for r in cfg.secret_injection}
+        assert rules["KEY1"].inject_headers == ["X-Acme-Token", "X-Acme-Secondary"]
+        assert rules["KEY2"].inject_headers == []
+
+    def test_secret_injection_inject_headers_null_and_trimmed(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: KEY1
+                placeholder: "{{KEY1}}"
+                inject_headers:
+              - env: KEY2
+                placeholder: "{{KEY2}}"
+                inject_headers: ["  X-Padded-Token  "]
+        """))
+        cfg = load_config(str(p))
+        rules = {r.env: r for r in cfg.secret_injection}
+        # `inject_headers:` (null) coerces to [].
+        assert rules["KEY1"].inject_headers == []
+        # Stray whitespace is stripped at load time (HTTP field-names can't
+        # contain whitespace) so it still matches the real header name.
+        assert rules["KEY2"].inject_headers == ["X-Padded-Token"]
 
     def test_secret_injection_inject_body_toggle(self, tmp_path):
         p = tmp_path / "config.yaml"

--- a/tests/test_secret_injector.py
+++ b/tests/test_secret_injector.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from secret_injector import SecretInjector, InjectionRule
+from secret_injector import SecretInjector, InjectionRule, AUTH_HEADER_KEYWORDS
 
 
 # ── Helpers ──────────────────────────────────────────────
@@ -90,24 +90,164 @@ class TestInjectRequest:
         assert flow.request.url == "https://api.anthropic.com/v1?key=real-secret"
         assert names == ["KEY"]
 
-    def test_strict_default_only_injects_auth_header(self):
-        """By default, only the Authorization header is injected."""
+    def test_strict_default_injects_credential_headers(self):
+        """By default, injection is confined to credential-bearing headers —
+        Authorization AND x-api-key (Anthropic) and friends — but never the
+        URL, the body, or a header with no auth/key/token in its name."""
         inj = _injector_with_rules([
             InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
         ])
         flow = _make_flow(
             url="https://api.anthropic.com/v1?key={{KEY}}",
             host="api.anthropic.com",
-            headers={"Authorization": "Bearer {{KEY}}", "X-Api-Key": "{{KEY}}"},
+            headers={
+                "Authorization": "Bearer {{KEY}}",
+                "X-Api-Key": "{{KEY}}",        # Anthropic's auth header
+                "X-Custom-Trace": "{{KEY}}",   # no auth/key/token → not a credential header
+            },
             content="body with {{KEY}} here",
         )
         names = inj.inject_request(flow)
+        # Both recognized auth headers get the real value...
         assert flow.request.headers["Authorization"] == "Bearer real-secret"
-        # URL, body, and non-auth headers keep the placeholder.
+        assert flow.request.headers["X-Api-Key"] == "real-secret"
+        # ...while the URL, body, and non-credential headers keep the placeholder.
+        # (Note: the *query param* `?key=` is not a header, so it is untouched
+        # even though "key" is a keyword — the heuristic only applies to headers.)
         assert flow.request.url == "https://api.anthropic.com/v1?key={{KEY}}"
-        assert flow.request.headers["X-Api-Key"] == "{{KEY}}"
+        assert flow.request.headers["X-Custom-Trace"] == "{{KEY}}"
         assert flow.request.content == b"body with {{KEY}} here"
         assert names == ["KEY"]
+
+    def test_strict_injects_x_api_key_regression(self):
+        """Regression guard (PR #251): Anthropic authenticates with the
+        ``x-api-key`` header, not ``Authorization``. The first strict
+        implementation injected only into ``Authorization``, so the literal
+        ``{{ANTHROPIC_API_KEY}}`` placeholder went upstream and the API
+        replied ``401 invalid x-api-key``. Strict mode must inject into
+        ``x-api-key`` (matched by the "key" keyword)."""
+        inj = _injector_with_rules([
+            InjectionRule("ANTHROPIC_API_KEY", "{{ANTHROPIC_API_KEY}}",
+                          "sk-ant-real", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(headers={"x-api-key": "{{ANTHROPIC_API_KEY}}"})
+        names = inj.inject_request(flow)
+        assert flow.request.headers["x-api-key"] == "sk-ant-real"
+        assert names == ["ANTHROPIC_API_KEY"]
+
+    # Real-world credential headers that all match the auth/key/token
+    # heuristic — surveyed across popular APIs. (Honeycomb's
+    # ``x-honeycomb-team`` is intentionally absent: it has no keyword and is
+    # covered by ``inject_headers`` instead — see test below.)
+    @pytest.mark.parametrize("header", [
+        "Authorization",            # OpenAI, GitHub, Stripe, … (auth)
+        "x-api-key",                # Anthropic, AWS API Gateway (key)
+        "api-key",                  # Azure OpenAI, Pinecone, Qdrant (key)
+        "apikey",                   # Supabase (key)
+        "x-goog-api-key",           # Google Gemini / Cloud (key)
+        "PRIVATE-TOKEN",            # GitLab (token)
+        "X-Auth-Token",             # OpenStack (auth, token)
+        "X-Auth-Key",               # Cloudflare legacy (auth, key)
+        "X-Subscription-Token",     # Brave Search (token)
+        "Ocp-Apim-Subscription-Key",  # Azure APIM / Bing (key)
+        "DD-API-KEY",               # Datadog (key)
+        "Circle-Token",             # CircleCI (token)
+        "X-Algolia-API-Key",        # Algolia (key)
+        "X-Figma-Token",            # Figma (token)
+        "Fastly-Key",               # Fastly (key)
+        "X-Postmark-Server-Token",  # Postmark (token)
+        "X-Shopify-Access-Token",   # Shopify Admin (token)
+    ])
+    def test_strict_injects_real_world_credential_headers(self, header):
+        """The keyword heuristic injects into the documented auth header of
+        popular APIs without naming any of them in code."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(headers={header: "{{KEY}}"})
+        names = inj.inject_request(flow)
+        assert flow.request.headers[header] == "real-secret"
+        assert names == ["KEY"]
+
+    @pytest.mark.parametrize("header,matches", [
+        ("X-Brand-New-Token", True),     # token
+        ("My-Secret-Key", True),         # key
+        ("X-Custom-Auth", True),         # auth
+        ("AUTHORIZATION", True),         # case-insensitive
+        ("x-honeycomb-team", False),     # no keyword
+        ("X-Trace-Id", False),
+        ("Content-Type", False),
+        ("X-Request-Id", False),
+    ])
+    def test_strict_keyword_heuristic(self, header, matches):
+        """The heuristic injects into any header whose name contains
+        auth/key/token (case-insensitive), and leaves all others alone — no
+        vendor-specific names involved."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(headers={header: "{{KEY}}"})
+        names = inj.inject_request(flow)
+        if matches:
+            assert flow.request.headers[header] == "real-secret"
+            assert names == ["KEY"]
+        else:
+            assert flow.request.headers[header] == "{{KEY}}"
+            assert names == []
+
+    @pytest.mark.parametrize("keyword", AUTH_HEADER_KEYWORDS)
+    def test_each_keyword_triggers_injection(self, keyword):
+        """Every keyword stem on its own marks a header as credential-bearing."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        header = f"X-Custom-{keyword}"
+        flow = _make_flow(headers={header: "{{KEY}}"})
+        names = inj.inject_request(flow)
+        assert flow.request.headers[header] == "real-secret"
+        assert names == ["KEY"]
+
+    def test_inject_headers_covers_keywordless_header(self):
+        """A credential header whose name has no auth/key/token keyword (e.g.
+        Honeycomb's ``x-honeycomb-team``) is injected only when listed in the
+        rule's ``inject_headers`` — and the keyword defaults still apply."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["example.com"],
+                          inject_headers=["X-Honeycomb-Team"]),
+        ])
+        flow = _make_flow(
+            url="https://api.example.com/v1",
+            host="api.example.com",
+            headers={
+                "X-Honeycomb-Team": "{{KEY}}",      # opted-in, no keyword
+                "Authorization": "Bearer {{KEY}}",  # keyword default still applies
+            },
+        )
+        names = inj.inject_request(flow)
+        assert flow.request.headers["X-Honeycomb-Team"] == "real-secret"
+        assert flow.request.headers["Authorization"] == "Bearer real-secret"
+        assert names == ["KEY"]
+
+    def test_strict_credential_header_to_unauthorized_domain(self):
+        """The broadened header match must still defer to ``inject_to``: a
+        placeholder in a credential header heading to an unauthorized domain
+        is left in place (not injected) and is flagged by the policy check."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            url="https://evil.com/exfil",
+            host="evil.com",
+            headers={"x-api-key": "{{KEY}}"},
+        )
+        names = inj.inject_request(flow)
+        assert flow.request.headers["x-api-key"] == "{{KEY}}"
+        assert names == []
+        result = inj.check_injection_policy(flow)
+        assert result is not None
+        assert result.action == "flag"
+        assert "evil.com" in result.reason
 
     def test_strict_default_no_auth_header_is_noop(self):
         """Strict mode with no Authorization header injects nothing."""
@@ -322,6 +462,31 @@ class TestConfigure:
         assert inj.rules[0].real_value == "my-real-secret"
         assert inj.rules[0].placeholder == "{{TEST_KEY}}"
         assert inj.rules[0].inject_to == ["example.com"]
+
+    def test_loads_inject_headers(self, monkeypatch):
+        monkeypatch.setenv("TEST_KEY", "secret")
+        inj = SecretInjector()
+        inj.configure([
+            {"env": "TEST_KEY", "placeholder": "{{TEST_KEY}}",
+             "inject_headers": ["X-Honeycomb-Team"]},
+        ])
+        rule = inj.rules[0]
+        assert rule.inject_headers == ["X-Honeycomb-Team"]
+        # The keyword-less custom header is recognized (case-insensitively)...
+        assert rule.is_auth_header("x-honeycomb-team")
+        # ...and the keyword heuristic still applies on top of it.
+        assert rule.is_auth_header("Authorization")
+        assert rule.is_auth_header("x-api-key")
+
+    def test_default_rule_has_no_extra_inject_headers(self, monkeypatch):
+        monkeypatch.setenv("TEST_KEY", "secret")
+        inj = SecretInjector()
+        inj.configure([{"env": "TEST_KEY", "placeholder": "{{TEST_KEY}}"}])
+        rule = inj.rules[0]
+        assert rule.inject_headers == []
+        # With no extras, only the keyword heuristic decides.
+        assert rule.is_auth_header("x-api-key")
+        assert not rule.is_auth_header("x-honeycomb-team")
 
     def test_skips_missing_env_var(self, monkeypatch):
         monkeypatch.delenv("MISSING_KEY", raising=False)
@@ -787,8 +952,8 @@ class TestConfigFormat:
 
 class TestInjectWsContent:
     def test_replaces_placeholder_for_authorized_domain(self):
-        # WebSocket frames have no Authorization header, so injection only
-        # happens when the rule opts into body injection.
+        # WebSocket frames carry no headers (the auth channel), so injection
+        # only happens when the rule opts into body injection.
         inj = _injector_with_rules([
             InjectionRule("KEY", "{{KEY}}", "real-secret",
                           inject_to=["anthropic.com"], inject_body=True),

--- a/tests/test_secret_injector.py
+++ b/tests/test_secret_injector.py
@@ -57,8 +57,10 @@ def _injector_with_rules(rules):
 
 class TestInjectRequest:
     def test_replaces_placeholder_in_body(self):
+        # Body injection only happens when inject_body=True.
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(content="body with {{KEY}} here")
         names = inj.inject_request(flow)
@@ -75,8 +77,10 @@ class TestInjectRequest:
         assert names == ["KEY"]
 
     def test_replaces_placeholder_in_url(self):
+        # URL injection only happens when inject_body=True.
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(
             url="https://api.anthropic.com/v1?key={{KEY}}",
@@ -85,6 +89,38 @@ class TestInjectRequest:
         names = inj.inject_request(flow)
         assert flow.request.url == "https://api.anthropic.com/v1?key=real-secret"
         assert names == ["KEY"]
+
+    def test_strict_default_only_injects_auth_header(self):
+        """By default, only the Authorization header is injected."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            url="https://api.anthropic.com/v1?key={{KEY}}",
+            host="api.anthropic.com",
+            headers={"Authorization": "Bearer {{KEY}}", "X-Api-Key": "{{KEY}}"},
+            content="body with {{KEY}} here",
+        )
+        names = inj.inject_request(flow)
+        assert flow.request.headers["Authorization"] == "Bearer real-secret"
+        # URL, body, and non-auth headers keep the placeholder.
+        assert flow.request.url == "https://api.anthropic.com/v1?key={{KEY}}"
+        assert flow.request.headers["X-Api-Key"] == "{{KEY}}"
+        assert flow.request.content == b"body with {{KEY}} here"
+        assert names == ["KEY"]
+
+    def test_strict_default_no_auth_header_is_noop(self):
+        """Strict mode with no Authorization header injects nothing."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        flow = _make_flow(
+            host="api.anthropic.com",
+            content="body with {{KEY}} here",
+        )
+        names = inj.inject_request(flow)
+        assert flow.request.content == b"body with {{KEY}} here"
+        assert names == []
 
     def test_flags_placeholder_to_unauthorized_domain(self):
         inj = _injector_with_rules([
@@ -105,7 +141,8 @@ class TestInjectRequest:
     def test_inject_skips_unauthorized_domain(self):
         """Placeholder should be left in place for unauthorized domains."""
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(
             url="https://evil.com/exfil",
@@ -119,8 +156,10 @@ class TestInjectRequest:
     def test_inject_mixed_rules(self):
         """Authorized rule gets injected, unauthorized rule's placeholder stays."""
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
-            InjectionRule("EMAIL", "{{EMAIL}}", "user@example.com", inject_to=["other.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
+            InjectionRule("EMAIL", "{{EMAIL}}", "user@example.com",
+                          inject_to=["other.com"], inject_body=True),
         ])
         flow = _make_flow(
             url="https://api.anthropic.com/v1/messages",
@@ -162,7 +201,8 @@ class TestInjectRequest:
 
     def test_subdomain_matches_inject_to(self):
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(
             url="https://api.anthropic.com/v1",
@@ -191,8 +231,10 @@ class TestInjectRequest:
 
     def test_multiple_rules(self):
         inj = _injector_with_rules([
-            InjectionRule("KEY1", "{{KEY1}}", "secret-1", inject_to=["anthropic.com"]),
-            InjectionRule("KEY2", "{{KEY2}}", "secret-2", inject_to=["anthropic.com"]),
+            InjectionRule("KEY1", "{{KEY1}}", "secret-1",
+                          inject_to=["anthropic.com"], inject_body=True),
+            InjectionRule("KEY2", "{{KEY2}}", "secret-2",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(content="a={{KEY1}}&b={{KEY2}}")
         names = inj.inject_request(flow)
@@ -487,7 +529,8 @@ class TestRedactRequest:
     def test_non_redact_domain_still_injects(self):
         """Normal inject_to behavior unchanged for non-redact_to domains."""
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         inj.redact_to = ["matrix.example.com"]
         flow = _make_flow(content="body with {{KEY}} here")
@@ -608,7 +651,7 @@ class TestRedactRequestPostUpstream:
         """
         inj = _injector_with_rules([
             InjectionRule("KEY", "{{KEY}}", "sk-real-secret",
-                          inject_to=["anthropic.com"]),
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         flow = _make_flow(
             url="https://api.anthropic.com/v1?k={{KEY}}",
@@ -658,6 +701,9 @@ class TestRedactRequestPostUpstream:
                 "{{ANTHROPIC_API_KEY}}",
                 "sk-ant-api03-FAKE-TEST-VALUE-FOR-REDACTION-1234567890",
                 inject_to=["anthropic.com"],
+                # This case puts the placeholder in the URL/body, so it
+                # needs the opt-in body-injection path to inject+redact.
+                inject_body=True,
             ),
         ])
 
@@ -741,12 +787,24 @@ class TestConfigFormat:
 
 class TestInjectWsContent:
     def test_replaces_placeholder_for_authorized_domain(self):
+        # WebSocket frames have no Authorization header, so injection only
+        # happens when the rule opts into body injection.
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         content, names = inj.inject_ws_content(b"token={{KEY}}", "api.anthropic.com")
         assert content == b"token=real-secret"
         assert names == ["KEY"]
+
+    def test_strict_default_leaves_ws_placeholder(self):
+        """Without inject_body, WebSocket placeholders are left untouched."""
+        inj = _injector_with_rules([
+            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+        ])
+        content, names = inj.inject_ws_content(b"token={{KEY}}", "api.anthropic.com")
+        assert content == b"token={{KEY}}"
+        assert names == []
 
     def test_skips_unauthorized_domain(self):
         inj = _injector_with_rules([
@@ -780,8 +838,10 @@ class TestInjectWsContent:
 
     def test_multiple_rules(self):
         inj = _injector_with_rules([
-            InjectionRule("K1", "{{K1}}", "secret-1", inject_to=["anthropic.com"]),
-            InjectionRule("K2", "{{K2}}", "secret-2", inject_to=["anthropic.com"]),
+            InjectionRule("K1", "{{K1}}", "secret-1",
+                          inject_to=["anthropic.com"], inject_body=True),
+            InjectionRule("K2", "{{K2}}", "secret-2",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         content, names = inj.inject_ws_content(b"a={{K1}}&b={{K2}}", "api.anthropic.com")
         assert content == b"a=secret-1&b=secret-2"
@@ -789,7 +849,8 @@ class TestInjectWsContent:
 
     def test_subdomain_matching(self):
         inj = _injector_with_rules([
-            InjectionRule("KEY", "{{KEY}}", "real-secret", inject_to=["anthropic.com"]),
+            InjectionRule("KEY", "{{KEY}}", "real-secret",
+                          inject_to=["anthropic.com"], inject_body=True),
         ])
         content, names = inj.inject_ws_content(b"{{KEY}}", "deep.sub.anthropic.com")
         assert content == b"real-secret"
@@ -1154,6 +1215,7 @@ class TestTransformRules:
             inject_to=["googleapis.com"],
             transform="google-jwt-bearer",
             transform_fn=lambda: "ya29.ws-token",
+            inject_body=True,
         )
         inj = _injector_with_rules([rule])
         content, names = inj.inject_ws_content(


### PR DESCRIPTION
## Summary

Tightens the egress proxy's secret-injection scope to **strict by default**: a placeholder is swapped for its real value only when it appears in the request's `Authorization` header. Placeholders left in the URL/query string, request body, other headers, or WebSocket frames now pass through unchanged.

This confines credentials to the standard auth channel and prevents accidentally writing real secrets into request bodies that might be logged, echoed, or captured downstream.

## New `inject_body` toggle (default `false`)

A per-rule opt-in that restores the previous looser behavior — substituting in the URL, all headers, the request body, and WebSocket frames:

```yaml
secret_injection:
  - env: ANTHROPIC_API_KEY
    placeholder: "{{ANTHROPIC_API_KEY}}"
    inject_to: ["api.anthropic.com"]
    # default: only the Authorization header is injected

  - env: SOME_QUERY_KEY
    placeholder: "{{SOME_QUERY_KEY}}"
    inject_to: ["api.example.com"]
    inject_body: true   # API carries the key in ?api_key= or the body
```

Use it only for APIs that genuinely carry the credential outside the `Authorization` header. **Response redaction and literal-value blocking are unaffected** — real values are always redacted from responses and always blocked when found leaking outbound, regardless of this toggle.

## Wiring

The toggle flows end-to-end with no new plumbing:
- `config.SecretInjectionRule.inject_body` parsed from `cage.yaml`
- passed through `proxy-config.yaml` verbatim by `state.save_proxy_config` (`secret_injection` is a passthrough section)
- read by the proxy's `SecretInjector` (`InjectionRule.inject_body`), gating the request-injection and WebSocket-injection paths

## Tests

- Strict-default unit coverage: auth-header-only injection, no-Authorization-header → no-op, and URL/body/other-headers/WS placeholders left untouched.
- Existing body/URL/WebSocket cases updated to opt in via `inject_body=True` (preserving their coverage of the loose path).
- Addon-level integration test asserting a body-only placeholder under the strict default never reaches the wire or `capture.jsonl`.

Docs (`docs/reference/secret-injection.md`) and `CHANGELOG.md` updated.

> Note: pre-existing `test_config` failures on macOS dev machines (the apple-container `read_only` parity warning) are environmental and unrelated to this change — they pass on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)