### PR TITLE
fix(scaffold): rm -rf the openclaw self-ref path before symlinking (openclaw 2026.6+ base)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **openclaw scaffold: restore the `/app/node_modules/openclaw` self-reference symlink on openclaw 2026.6+ base images.** The scaffold links `/app` (package name `openclaw`) under `node_modules` so a bundled extension's `import "openclaw/..."` resolves to the running openclaw root. openclaw 2026.6 now ships a *real* (hoisted, often older — e.g. `2026.5.28` under a `2026.6.1` root) `/app/node_modules/openclaw` directory, which `ln -sfn` cannot overwrite, so the symlink was silently never created and `import "openclaw"` resolved to the stale nested copy. The scaffold now `rm -rf`s the path before linking, so the symlink always points at the single running version. Fixes the E2E Phase 8.7 regression (red on `master` since the base image rebuilt).
+
 ## [0.22.21] - 2026-06-04
 
 ### Changed

--- a/src/agentcage/scaffolds/openclaw/Containerfile
+++ b/src/agentcage/scaffolds/openclaw/Containerfile
@@ -51,7 +51,15 @@ RUN if [ -d /app/extensions/matrix ] && [ -f /app/extensions/matrix/package.json
 # import walks up and resolves via /app/package.json's exports map.
 # Safe on older bases: they don't have the bundled extension tree, the
 # symlink just goes unused.
+#
+# `rm -rf` first: openclaw 2026.6+ ships a REAL /app/node_modules/openclaw
+# (a hoisted, often *older* nested copy of the package — e.g. 2026.5.28
+# under a 2026.6.1 root). `ln -sfn` cannot replace an existing directory, so
+# without removing it the symlink is never created and `import "openclaw"`
+# resolves to that stale nested copy instead of the running root. Remove it
+# so the symlink always points at /app (the single running version).
 RUN mkdir -p /app/node_modules \
+ && rm -rf /app/node_modules/openclaw \
  && ln -sfn /app /app/node_modules/openclaw
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary

Fixes the **E2E Phase 8.7** failure that has been red on `master` (and therefore on every open PR) since the openclaw `:latest` base image rebuilt on 2026-06-03. **Pre-existing and unrelated to any in-flight code change** — it's pure base-image drift.

## Root cause

The openclaw scaffold links `/app` (package name `openclaw`) under `node_modules` so a bundled extension's `import "openclaw/..."` resolves to the running openclaw root via `/app/package.json`'s exports map:

```dockerfile
RUN mkdir -p /app/node_modules && ln -sfn /app /app/node_modules/openclaw
```

openclaw **2026.6** now ships a **real** `/app/node_modules/openclaw` directory — a hoisted, *older* nested copy of the package (observed: `2026.5.28` under a `2026.6.1` root). `ln -sfn` **cannot overwrite an existing directory**, so the symlink is silently never created. Phase 8.7 (`test -L /app/node_modules/openclaw`) then fails, and `import "openclaw"` resolves to the stale nested `2026.5.28` instead of the running `2026.6.1`.

## Fix

`rm -rf` the path before linking, so the symlink always points at `/app` (the single running version):

```dockerfile
RUN mkdir -p /app/node_modules \
 && rm -rf /app/node_modules/openclaw \
 && ln -sfn /app /app/node_modules/openclaw
```

## Verification

Against `ghcr.io/openclaw/openclaw:latest` (2026.6.1):
- symlink created, `test -L` + `test -s .../package.json` both pass (8.7's exact conditions);
- `openclaw --version` → `OpenClaw 2026.6.1` (runtime loads fine; removing the stale nested copy and pointing `import "openclaw"` at the running root is strictly more correct than a dual-version tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)