### PR TITLE
feat(secrets): entropic secret-injection placeholders by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Secret-injection placeholders are now entropic by default.** `secret_injection` rules may omit `placeholder:` — agentcage generates `{{placeholder_<env_lowercase>_<16 hex chars>}}` (64 bits of entropy) and persists it into the cage's stored config the first time the rule is deployed (`cage create`, `cage update -c`, `cage edit`, `agentcage run`). The token is carried over by `env` name on subsequent updates, so it stays stable for long-running cage processes. Rationale: the proxy substitutes placeholders as literal strings, so a guessable placeholder like `{{GH_TOKEN}}` is an accidental-substitution hazard — outbound content that legitimately contains that text (template files, docs, CI config) would get the real secret injected into it. Explicit `placeholder:` values remain fully supported (some clients validate credential format before sending); `validate_config` now warns when an explicit placeholder uses the bare `{{ENV_NAME}}` convention. All bundled scaffolds generate entropic placeholders at render time, and `agentcage secret list` grew a `PLACEHOLDER` column so the generated token is discoverable. Existing cages are untouched — their stored placeholders keep working as-is.
+
 ## [0.22.22] - 2026-06-06
 
 ### Fixed

--- a/docs/explain/architecture.md
+++ b/docs/explain/architecture.md
@@ -42,7 +42,7 @@ Custom inspectors plug into the same chain with the same allow / flag / block co
 
 Secret injection keeps real secret values out of the cage entirely.
 
-The cage gets a placeholder, e.g. `{{ANTHROPIC_API_KEY}}`. The agent uses the placeholder in headers, query strings, or bodies as if it were the real value. Before the inspector chain runs, the proxy checks two invariants:
+The cage gets a placeholder — a generated decoy token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}` (entropic so real outbound content never collides with it; see [Secret injection](../reference/secret-injection.md#placeholder-entropy)). The agent uses the placeholder in headers, query strings, or bodies as if it were the real value. Before the inspector chain runs, the proxy checks two invariants:
 
 1. **Literal value blocking.** If a real secret value appears in a request to a host outside that secret's `inject_to` list, the request is blocked. The cage should never know the real value, so its presence indicates the agent learned the secret outside the placeholder system.
 2. **Placeholder routing.** If a placeholder is heading to a domain not in that secret's `inject_to` list, the request is flagged but still goes through.

--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -10,7 +10,7 @@ Secrets listed in `secret_injection` are automatically excluded from the cage's 
 | Setting | Type | Required | Description |
 |---------|------|----------|-------------|
 | `env` | `string` | yes | Environment variable name holding the real secret (read by the proxy at startup). |
-| `placeholder` | `string` | yes | Token the cage sees and uses in requests (e.g. `"{{ANTHROPIC_API_KEY}}"`). |
+| `placeholder` | `string` | no | Token the cage sees and uses in requests. **Omit it** (recommended) and agentcage generates an entropic token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`, persisted into the cage's stored config at create/update/edit time. See [Placeholder entropy](#placeholder-entropy). |
 | `inject_to` | `list[string]` | no | Domains where placeholders are replaced with real values. If omitted, injection applies to all domains. |
 | `inject_body` | `bool` | no | When `false` (the default), placeholders are only substituted inside known credential-bearing request headers (the [auth-header allow-list](#injection-scope)). Set to `true` to also inject into the request URL (query string), every header, the request body, and WebSocket frames. See [Injection scope](#injection-scope). |
 | `inject_headers` | `list[string]` | no | Extra request headers — added to the built-in auth-header allow-list — to treat as credential-bearing under the strict default. Matched case-insensitively. Use for APIs whose auth header isn't a common convention. See [Injection scope](#injection-scope). |
@@ -31,27 +31,51 @@ The `source` field controls where agentcage loads the secret value from.
 | *(absent)* | | Set the secret via `agentcage secret set` or `--set-secret`. On Linux with systemd 250+, `agentcage secret set` encrypts with systemd-creds automatically. |
 
 ```yaml
-# 1Password via command backend
+# 1Password via command backend (placeholder omitted → auto-generated)
 secret_injection:
   - env: ANTHROPIC_API_KEY
-    placeholder: "{{ANTHROPIC_API_KEY}}"
     inject_to: ["api.anthropic.com"]
     source: "cmd:op read op://Private/anthropic/credential --no-newline"
 
 # Host environment variable (CI/CD)
 secret_injection:
   - env: OPENAI_API_KEY
-    placeholder: "{{OPENAI_API_KEY}}"
     inject_to: ["api.openai.com"]
     source: "env:OPENAI_API_KEY"
 
 # Explicit systemd-creds (auto-detected on Linux)
 secret_injection:
   - env: ANTHROPIC_API_KEY
-    placeholder: "{{ANTHROPIC_API_KEY}}"
     inject_to: ["api.anthropic.com"]
     source: "systemd-creds:"
 ```
+
+## Placeholder entropy
+
+When a rule omits `placeholder:`, agentcage generates
+`{{placeholder_<env_lowercase>_<16 hex chars>}}` (64 bits of entropy) and
+persists it into the cage's stored config the first time the rule is deployed
+(`cage create`, `cage update -c`, `cage edit`, or `agentcage run`). The token
+stays stable across updates — it is carried over by `env` name rather than
+regenerated, so long-running processes inside the cage keep working.
+
+Why entropy matters: the proxy substitutes the placeholder as a **literal
+string** wherever injection applies. A guessable placeholder like
+`{{GH_TOKEN}}` is an accidental-substitution hazard — if a file the agent
+sends outbound legitimately contains that text (a template file, docs, CI
+config), the real secret would be injected into it. A random suffix makes
+such collisions vanishingly unlikely. `agentcage cage create` warns when an
+explicit placeholder uses the bare `{{ENV_NAME}}` convention.
+
+Explicit `placeholder:` values remain fully supported — some clients validate
+credential format before sending (e.g. a `ghp_`-prefixed fake to pass a
+client-side check). To see the generated token for a cage, run
+`agentcage secret list <cage>` (placeholders are decoys, never sensitive).
+
+> **Note:** filling an omitted placeholder rewrites the stored `cage.yaml`
+> (under `~/.config/agentcage/cages/<name>/`), which normalizes the YAML and
+> drops comments in that file. Configs generated from scaffolds already carry
+> a generated placeholder, so they are stored untouched.
 
 > **Security note:** The `cmd:` backend runs shell commands with the privileges of the user running agentcage. This is the same trust boundary as Containerfile execution. If your `cage.yaml` comes from an untrusted source, review `source: "cmd:..."` entries before running `cage create`.
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -775,8 +775,12 @@ class AppleContainerBackend:
         # it on the wire. ``secret_envs`` kept (list of env names) for
         # backward compat with cages last started on 0.21.0 or earlier.
         secret_envs = [r.env for r in (config.secret_injection or [])]
+        # Skip rules whose placeholder hasn't been generated yet (the CLI
+        # fills omitted placeholders at declare time) — an empty placeholder
+        # must not become `-e ENV=` on the cage.
         secret_env_placeholders = {
-            r.env: r.placeholder for r in (config.secret_injection or [])
+            r.env: r.placeholder
+            for r in (config.secret_injection or []) if r.placeholder
         }
         # Protocol-relay credential env names — must reach the mitmproxy
         # process inside the cage (where the relay's _resolve_credential

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -711,6 +711,10 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
 
     # Save state
     state.save_deployment(name, config_path)
+    # Rules may omit `placeholder:` — persist generated entropic tokens
+    # into the stored config and reload so quadlets/proxy see them.
+    if state.fill_placeholders(name):
+        cfg = state.load_deployment_config(name)
     from agentcage.init import infer_scaffold_from_image
     metadata = {"agentcage_version": version("agentcage")}
     scaffold_name = infer_scaffold_from_image(cfg.container.image)
@@ -894,7 +898,12 @@ def cage_update(name: str | None, config_path: str | None,
             click.echo(f"error: cage '{name}' does not exist", err=True)
             sys.exit(1)
         _ensure_v022_cage(name)
+        # Capture the previous stored config before it's overwritten so
+        # already-generated placeholders carry over (stable across updates).
+        prev_raw = state.load_raw_config(name)
         state.save_deployment(name, config_path)
+        if state.fill_placeholders(name, prev_raw=prev_raw):
+            cfg = state.load_deployment_config(name)
         # Copy the Containerfile and its sibling build inputs into the state
         # dir so future updates can rebuild (Containerfiles may COPY files
         # and whole directory trees from the build context)
@@ -915,6 +924,7 @@ def cage_update(name: str | None, config_path: str | None,
         # base images (--pull), and restarts. To change config, edit it
         # explicitly via `cage edit` or supply a new config with
         # `cage update -c <file>`.
+        state.fill_placeholders(name)
         cfg = state.load_deployment_config(name)
         try:
             warnings = validate_config(cfg)
@@ -1627,6 +1637,14 @@ def cage_edit(name: str):
         click.echo(f"  Rejected edits saved to {rejected_path}", err=True)
         click.echo(f"  Original config at {config_path} is unchanged.", err=True)
         sys.exit(1)
+
+    # Fill omitted secret-injection placeholders before rendering so the
+    # diff below shows the generated token and validation sees the final
+    # config. Carry-over from the pre-edit config keeps already-generated
+    # placeholders stable when the user leaves `placeholder:` off a rule
+    # that already had one.
+    from agentcage.config import fill_raw_placeholders
+    fill_raw_placeholders(edited_raw, prev_raw=original_raw)
 
     # Re-render so we can validate via the real loader (writes to a tempfile
     # because load_config takes a path, not a dict).
@@ -3239,7 +3257,7 @@ def secret():
 
 
 def _render_secret_list(cfg, present_keys: set[str]) -> bool:
-    """Print the NAME/TYPE/STATUS table for a cage's secrets.
+    """Print the NAME/TYPE/STATUS/PLACEHOLDER table for a cage's secrets.
 
     Renders the *union* of declared (``cage.yaml``) and actually-stored
     secrets so a value set via ``secret set`` for a key with no matching
@@ -3251,12 +3269,15 @@ def _render_secret_list(cfg, present_keys: set[str]) -> bool:
     """
     expected = _expected_secrets(cfg)
     injection_names = {r.env for r in cfg.secret_injection}
+    # Placeholders are decoy tokens (never sensitive) — show them so a
+    # generated value is discoverable without opening the stored cage.yaml.
+    placeholders = {r.env: r.placeholder for r in cfg.secret_injection}
     # Declared secrets first (preserving config order), then any stored
     # keys that aren't declared anywhere.
     expected_set = set(expected)
     orphans = sorted(k for k in present_keys if k not in expected_set)
 
-    click.echo(f"{'NAME':<30} {'TYPE':<12} STATUS")
+    click.echo(f"{'NAME':<30} {'TYPE':<12} {'STATUS':<8} PLACEHOLDER")
     any_missing = False
     for key in expected:
         stype = "injection" if key in injection_names else "direct"
@@ -3265,7 +3286,10 @@ def _render_secret_list(cfg, present_keys: set[str]) -> bool:
         else:
             status = "MISSING"
             any_missing = True
-        click.echo(f"{key:<30} {stype:<12} {status}")
+        click.echo(
+            f"{key:<30} {stype:<12} {status:<8} "
+            f"{placeholders.get(key, '')}".rstrip()
+        )
     for key in orphans:
         # Stored at rest but not referenced by the config — staged at
         # start() but never injected/redacted. Surface it so it can be

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -42,9 +42,65 @@ class SecretsConfig:
     allow_plaintext: bool = False
 
 
+def generate_placeholder(env: str) -> str:
+    """Return an entropic placeholder token for *env*.
+
+    Format: ``{{placeholder_<env_lowercase>_<16 hex chars>}}`` (64 bits of
+    entropy). Guessable placeholders like ``{{GH_TOKEN}}`` are an accidental-
+    substitution hazard: any file the agent sends outbound that happens to
+    contain that literal text (template files, docs) would get the real
+    secret injected. The random suffix makes a collision with legitimate
+    content vanishingly unlikely. The token must stay inside ``{{...}}``
+    delimiters — the proxy matches placeholders as literal strings.
+    """
+    import secrets as _secrets
+    return "{{placeholder_%s_%s}}" % (env.lower(), _secrets.token_hex(8))
+
+
+def fill_raw_placeholders(raw: dict, prev_raw: dict | None = None) -> bool:
+    """Generate entropic placeholders for rules that omit ``placeholder:``.
+
+    Mutates *raw* (a parsed cage.yaml dict) in place; returns True if any
+    rule was filled. When *prev_raw* is given (``cage update -c`` / ``cage
+    edit``), a placeholder already persisted for the same env is carried
+    over so the token stays stable across updates — regenerating would
+    desynchronize processes still holding the old token in their env.
+
+    The filled dict is persisted into the stored cage.yaml (the single
+    source of truth) so every consumer — quadlet rendering, proxy config,
+    ``secret list`` — sees the same value.
+    """
+    def _rules(d: dict) -> list:
+        si = d.get("secret_injection") or []
+        rules = si.get("rules", []) if isinstance(si, dict) else si
+        return rules if isinstance(rules, list) else []
+
+    prev = {}
+    if prev_raw:
+        prev = {
+            e.get("env"): e.get("placeholder", "")
+            for e in _rules(prev_raw) if isinstance(e, dict)
+        }
+    changed = False
+    for entry in _rules(raw):
+        if not isinstance(entry, dict):
+            continue
+        env = entry.get("env", "")
+        if not env or entry.get("placeholder"):
+            continue
+        entry["placeholder"] = prev.get(env) or generate_placeholder(env)
+        changed = True
+    return changed
+
+
 @dataclass
 class SecretInjectionRule:
     env: str
+    # Empty means "not yet generated": rules may omit ``placeholder:`` in
+    # cage.yaml, and the CLI persists a generated token into the stored
+    # config at declare time (create/update/edit) — see
+    # config.fill_raw_placeholders. Consumers that render or inject
+    # placeholders skip rules whose placeholder is still empty.
     placeholder: str
     inject_to: list[str] = field(default_factory=list)
     source: str = ""
@@ -542,8 +598,11 @@ def load_config(path: str) -> Config:
 
     for entry in si_rules:
         env_name = entry.get("env", "")
-        placeholder = entry.get("placeholder", "")
-        if env_name and placeholder:
+        # placeholder is optional: an omitted/empty placeholder is filled
+        # with a generated entropic token when the rule is persisted to a
+        # cage's stored config (config.fill_raw_placeholders).
+        placeholder = entry.get("placeholder", "") or ""
+        if env_name:
             validate_env_name(env_name)
             source = entry.get("source", "")
             validate_source(source)
@@ -1184,6 +1243,19 @@ def validate_config(config: Config) -> list[str]:
             "connectivity (the proxy's filter:FORWARD policy is DROP "
             "and no ports are allowed through)"
         )
+
+    # Warn about guessable placeholders — the bare {{ENV_NAME}} convention
+    # is an accidental-substitution hazard (any outbound content containing
+    # the literal text gets the real secret injected). Explicit placeholders
+    # stay supported for APIs that validate credential format client-side.
+    for rule in config.secret_injection:
+        if rule.placeholder == "{{%s}}" % rule.env:
+            warnings.append(
+                f"secret_injection[{rule.env!r}]: placeholder "
+                f"'{rule.placeholder}' is guessable — omit `placeholder:` "
+                f"to auto-generate an entropic token, or pick a value "
+                f"unlikely to appear in outbound content"
+            )
 
     # Warn about passthrough implications
     if config.domains.passthrough:

--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -123,6 +123,16 @@ class SecretInjector:
         for entry in rules_list:
             env_name = entry.get("env", "")
             placeholder = entry.get("placeholder", "")
+            if not placeholder:
+                # A rule whose placeholder was never generated (the CLI
+                # fills omitted placeholders at declare time). An empty
+                # placeholder must never reach matching: `"" in text` is
+                # always True and `text.replace("", v)` corrupts content.
+                log.warning(
+                    "secret_injection: rule %s has no placeholder, "
+                    "skipping", env_name,
+                )
+                continue
             inject_to = [d.lower() for d in entry.get("inject_to", [])]
 
             real_value = os.environ.get(env_name, "")

--- a/src/agentcage/init.py
+++ b/src/agentcage/init.py
@@ -120,13 +120,26 @@ def scaffold_source(name: str) -> str:
     return "built-in"
 
 
+def _add_template_globals(env: SandboxedEnvironment) -> SandboxedEnvironment:
+    """Install helpers available to config templates.
+
+    ``placeholder("ENV")`` renders an entropic secret-injection placeholder
+    token at template-render time, so the generated cage.yaml carries a
+    concrete, unguessable value (and the stored config never needs a
+    comment-stripping rewrite to fill it in).
+    """
+    from agentcage.config import generate_placeholder
+    env.globals["placeholder"] = generate_placeholder
+    return env
+
+
 def _make_env() -> SandboxedEnvironment:
-    return SandboxedEnvironment(
+    return _add_template_globals(SandboxedEnvironment(
         loader=FileSystemLoader(str(_TEMPLATES_DIR)),
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,
-    )
+    ))
 
 
 def _scaffold_search_dirs() -> list[Path]:
@@ -183,12 +196,12 @@ def render_config(
 
     scaffold_file = scaffold_dir / "cage.yaml.j2"
     if scaffold_file.exists():
-        env = SandboxedEnvironment(
+        env = _add_template_globals(SandboxedEnvironment(
             loader=FileSystemLoader(str(scaffold_dir)),
             keep_trailing_newline=True,
             trim_blocks=True,
             lstrip_blocks=True,
-        )
+        ))
         tmpl = env.get_template("cage.yaml.j2")
     else:
         tmpl = env.get_template(f"presets/{scaffold}.yaml.j2")

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -349,8 +349,12 @@ def generate_quadlets(
         expanded_volumes.append(expanded)
     expanded_env = {k: os.path.expandvars(str(v)) for k, v in cc.env.items()}
 
-    # Build cage placeholder list: (env_name, placeholder_value)
-    cage_placeholders = [(r.env, r.placeholder) for r in config.secret_injection]
+    # Build cage placeholder list: (env_name, placeholder_value). Rules
+    # whose placeholder hasn't been generated yet (config.fill_raw_placeholders
+    # runs at declare time) are skipped rather than rendered as empty env.
+    cage_placeholders = [
+        (r.env, r.placeholder) for r in config.secret_injection if r.placeholder
+    ]
 
     # Proxy secrets: split by backend for quadlet generation.
     # A rule gets a decrypt ExecStartPre if:

--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -378,6 +378,11 @@ def execute(
 
     # Save deployment state
     state.save_deployment(cage_name, str(config_path))
+    # Scaffold templates render entropic placeholders at render time, but a
+    # user scaffold may still omit `placeholder:` — persist generated tokens
+    # and reload so quadlets/proxy see them.
+    if state.fill_placeholders(cage_name):
+        cfg = state.load_deployment_config(cage_name)
     meta = state.load_metadata(cage_name)
     meta["scaffold"] = scaffold
     meta["lifecycle"] = cfg.lifecycle

--- a/src/agentcage/scaffolds/arch/cage.yaml.j2
+++ b/src/agentcage/scaffolds/arch/cage.yaml.j2
@@ -72,7 +72,7 @@ container:
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
 #  - env: GITHUB_TOKEN
-#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
 #    inject_to:
 #      - github.com
 

--- a/src/agentcage/scaffolds/busybox/cage.yaml.j2
+++ b/src/agentcage/scaffolds/busybox/cage.yaml.j2
@@ -56,7 +56,7 @@ container:
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
 #  - env: GITHUB_TOKEN
-#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
 #    inject_to:
 #      - github.com
 

--- a/src/agentcage/scaffolds/claude-code/README.md
+++ b/src/agentcage/scaffolds/claude-code/README.md
@@ -66,7 +66,7 @@ claude setup-token                                  # on the host — mints a to
 agentcage secret set myagent CLAUDE_CODE_OAUTH_TOKEN # paste the token
 ```
 
-Then uncomment the `CLAUDE_CODE_OAUTH_TOKEN` block under `secret_injection` in `cage.yaml`, and remove the `ANTHROPIC_API_KEY` rule (Claude Code prefers the API key when both are set). Claude Code sends the placeholder `{{CLAUDE_CODE_OAUTH_TOKEN}}` as a bearer token, and the proxy swaps it for the real value en route to `anthropic.com` — the real token never enters the cage.
+Then uncomment the `CLAUDE_CODE_OAUTH_TOKEN` block under `secret_injection` in `cage.yaml`, and remove the `ANTHROPIC_API_KEY` rule (Claude Code prefers the API key when both are set). Claude Code sends the generated placeholder token (run `agentcage secret list <cage>` to see it) as a bearer token, and the proxy swaps it for the real value en route to `anthropic.com` — the real token never enters the cage.
 
 This is the best option for persistent and headless cages: the token is long-lived, so there is no per-session refresh that could collide with your host login.
 
@@ -77,7 +77,7 @@ agentcage secret set myagent ANTHROPIC_API_KEY
 agentcage cage create -c cage.yaml
 ```
 
-The scaffold uses `secret_injection` for the API key. Claude Code sends the placeholder `{{ANTHROPIC_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Claude Code sends a generated placeholder token (e.g. `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
 
 #### 3. Start a session
 

--- a/src/agentcage/scaffolds/claude-code/cage.yaml.j2
+++ b/src/agentcage/scaffolds/claude-code/cage.yaml.j2
@@ -82,10 +82,12 @@ container:
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.
+# Placeholders are generated decoy tokens, unique per cage — entropy keeps
+# real outbound content from ever colliding with one.
 # Create each secret:  agentcage secret set {{ name }} ANTHROPIC_API_KEY
 secret_injection:
   - env: ANTHROPIC_API_KEY
-    placeholder: "{%raw%}{{ANTHROPIC_API_KEY}}{%endraw%}"
+    placeholder: "{{ placeholder('ANTHROPIC_API_KEY') }}"
     inject_to:
       - anthropic.com
 
@@ -97,13 +99,13 @@ secret_injection:
   # If you enable this, remove the ANTHROPIC_API_KEY rule above — Claude Code
   # prefers the API key when both are set.
   #- env: CLAUDE_CODE_OAUTH_TOKEN
-  #  placeholder: "{%raw%}{{CLAUDE_CODE_OAUTH_TOKEN}}{%endraw%}"
+  #  placeholder: "{{ placeholder('CLAUDE_CODE_OAUTH_TOKEN') }}"
   #  inject_to:
   #    - anthropic.com
 
   # Uncomment for GitHub push via HTTPS:
   #- env: GITHUB_TOKEN
-  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
   #  inject_to:
   #    - github.com
 

--- a/src/agentcage/scaffolds/codex/README.md
+++ b/src/agentcage/scaffolds/codex/README.md
@@ -53,7 +53,7 @@ This builds the proxy and DNS images, generates systemd quadlet files, and start
 agentcage secret set myagent OPENAI_API_KEY
 ```
 
-The scaffold uses `secret_injection` for the API key. Codex sends the placeholder `{{OPENAI_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Codex sends a generated placeholder token (e.g. `{{placeholder_openai_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
 
 #### 4. Start a session
 

--- a/src/agentcage/scaffolds/codex/cage.yaml.j2
+++ b/src/agentcage/scaffolds/codex/cage.yaml.j2
@@ -62,16 +62,18 @@ container:
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.
+# Placeholders are generated decoy tokens, unique per cage — entropy keeps
+# real outbound content from ever colliding with one.
 # Create each secret:  agentcage secret set {{ name }} OPENAI_API_KEY
 secret_injection:
   - env: OPENAI_API_KEY
-    placeholder: "{%raw%}{{OPENAI_API_KEY}}{%endraw%}"
+    placeholder: "{{ placeholder('OPENAI_API_KEY') }}"
     inject_to:
       - openai.com
 
   # Uncomment for GitHub push via HTTPS:
   #- env: GITHUB_TOKEN
-  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
   #  inject_to:
   #    - github.com
 

--- a/src/agentcage/scaffolds/debian/cage.yaml.j2
+++ b/src/agentcage/scaffolds/debian/cage.yaml.j2
@@ -72,7 +72,7 @@ container:
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
 #  - env: GITHUB_TOKEN
-#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
 #    inject_to:
 #      - github.com
 

--- a/src/agentcage/scaffolds/openclaw/README.md
+++ b/src/agentcage/scaffolds/openclaw/README.md
@@ -43,7 +43,7 @@ agentcage secret set myapp OPENCLAW_GATEWAY_PASSWORD
 
 If you add `BRAVE_API_KEY`, uncomment the Brave entries in the `secret_injection` section and add `search.brave.com` to the domain allowlist in `cage.yaml`.
 
-> **Secret injection:** The config uses `secret_injection` for API keys (Anthropic, Brave). The cage container never sees the real value -- it gets a placeholder like `{{ANTHROPIC_API_KEY}}`, and the proxy swaps it for the real value when forwarding to the correct domain. The gateway password (`OPENCLAW_GATEWAY_PASSWORD`) stays in `podman_secrets` since it is used internally by the cage process, not in proxied HTTP requests. See [Secret injection](../../docs/reference/secret-injection.md) for details.
+> **Secret injection:** The config uses `secret_injection` for API keys (Anthropic, Brave). The cage container never sees the real value -- it gets a generated placeholder token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`, and the proxy swaps it for the real value when forwarding to the correct domain. The gateway password (`OPENCLAW_GATEWAY_PASSWORD`) stays in `podman_secrets` since it is used internally by the cage process, not in proxied HTTP requests. See [Secret injection](../../docs/reference/secret-injection.md) for details.
 
 ### 4. Connect and pair your browser
 

--- a/src/agentcage/scaffolds/openclaw/cage.yaml.j2
+++ b/src/agentcage/scaffolds/openclaw/cage.yaml.j2
@@ -83,33 +83,35 @@ container:
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.
+# Placeholders are generated decoy tokens, unique per cage — entropy keeps
+# real outbound content from ever colliding with one.
 # Create each secret:  agentcage secret set {{ name }} ANTHROPIC_API_KEY
 secret_injection:
   # Core AI provider
   - env: ANTHROPIC_API_KEY
-    placeholder: "{%raw%}{{ANTHROPIC_API_KEY}}{%endraw%}"
+    placeholder: "{{ placeholder('ANTHROPIC_API_KEY') }}"
     inject_to:
       - anthropic.com
 
   # Uncomment providers as needed:
   #- env: OPENAI_API_KEY
-  #  placeholder: "{%raw%}{{OPENAI_API_KEY}}{%endraw%}"
+  #  placeholder: "{{ placeholder('OPENAI_API_KEY') }}"
   #  inject_to:
   #    - openai.com
   #- env: OPENROUTER_API_KEY
-  #  placeholder: "{%raw%}{{OPENROUTER_API_KEY}}{%endraw%}"
+  #  placeholder: "{{ placeholder('OPENROUTER_API_KEY') }}"
   #  inject_to:
   #    - openrouter.ai
 
   # Web search
   #- env: BRAVE_API_KEY
-  #  placeholder: "{%raw%}{{BRAVE_API_KEY}}{%endraw%}"
+  #  placeholder: "{{ placeholder('BRAVE_API_KEY') }}"
   #  inject_to:
   #    - search.brave.com
 
   # Web scraping
   #- env: FIRECRAWL_API_KEY
-  #  placeholder: "{%raw%}{{FIRECRAWL_API_KEY}}{%endraw%}"
+  #  placeholder: "{{ placeholder('FIRECRAWL_API_KEY') }}"
   #  inject_to:
   #    - firecrawl.dev
 

--- a/src/agentcage/scaffolds/pi/README.md
+++ b/src/agentcage/scaffolds/pi/README.md
@@ -61,7 +61,7 @@ agentcage secret set myagent ANTHROPIC_API_KEY
 agentcage cage create -c cage.yaml
 ```
 
-The scaffold uses `secret_injection` for the API key. Pi sends the placeholder `{{ANTHROPIC_API_KEY}}` in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Pi sends a generated placeholder token (e.g. `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
 
 **API key (OpenAI):**
 

--- a/src/agentcage/scaffolds/pi/cage.yaml.j2
+++ b/src/agentcage/scaffolds/pi/cage.yaml.j2
@@ -74,22 +74,24 @@ container:
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.
+# Placeholders are generated decoy tokens, unique per cage — entropy keeps
+# real outbound content from ever colliding with one.
 # Create each secret:  agentcage secret set {{ name }} ANTHROPIC_API_KEY
 secret_injection:
   - env: ANTHROPIC_API_KEY
-    placeholder: "{%raw%}{{ANTHROPIC_API_KEY}}{%endraw%}"
+    placeholder: "{{ placeholder('ANTHROPIC_API_KEY') }}"
     inject_to:
       - anthropic.com
 
   # Uncomment if you want Pi to talk to OpenAI models:
   #- env: OPENAI_API_KEY
-  #  placeholder: "{%raw%}{{OPENAI_API_KEY}}{%endraw%}"
+  #  placeholder: "{{ placeholder('OPENAI_API_KEY') }}"
   #  inject_to:
   #    - openai.com
 
   # Uncomment for GitHub push via HTTPS:
   #- env: GITHUB_TOKEN
-  #  placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+  #  placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
   #  inject_to:
   #    - github.com
 

--- a/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
+++ b/src/agentcage/scaffolds/ubuntu/cage.yaml.j2
@@ -80,7 +80,7 @@ container:
 # Uncomment for GitHub push over HTTPS or any other host you want to inject to.
 #secret_injection:
 #  - env: GITHUB_TOKEN
-#    placeholder: "{%raw%}{{GITHUB_TOKEN}}{%endraw%}"
+#    placeholder: "{{ placeholder('GITHUB_TOKEN') }}"
 #    inject_to:
 #      - github.com
 

--- a/src/agentcage/state.py
+++ b/src/agentcage/state.py
@@ -84,6 +84,24 @@ def save_raw_config(name: str, raw: dict) -> None:
         yaml.safe_dump(raw, f, default_flow_style=False, sort_keys=False)
 
 
+def fill_placeholders(name: str, prev_raw: dict | None = None) -> bool:
+    """Fill omitted secret-injection placeholders in a stored cage.yaml.
+
+    Persists a generated entropic token for every rule that omits
+    ``placeholder:`` (see :func:`agentcage.config.fill_raw_placeholders`).
+    Returns True if the stored config was rewritten — callers must then
+    reload their Config so downstream rendering sees the filled values.
+    Note: rewriting goes through yaml.safe_dump and drops YAML comments;
+    this only happens when at least one rule actually omits a placeholder.
+    """
+    from agentcage.config import fill_raw_placeholders
+    raw = load_raw_config(name)
+    if fill_raw_placeholders(raw, prev_raw):
+        save_raw_config(name, raw)
+        return True
+    return False
+
+
 # Keys from cage.yaml that the proxy addon actually reads
 _PROXY_KEYS = frozenset({
     "domains", "secrets", "max_request_body", "entropy", "content_type",

--- a/src/agentcage/templates/init-config.yaml.j2
+++ b/src/agentcage/templates/init-config.yaml.j2
@@ -74,10 +74,12 @@ domains:
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.
+# Placeholders are generated decoy tokens, unique per cage — entropy keeps
+# real outbound content from ever colliding with one.
 # Create each secret first:  agentcage secret set {{ name }} MY_API_KEY
 # secret_injection:
 #   - env: MY_API_KEY
-#     placeholder: "{%raw%}{{MY_API_KEY}}{%endraw%}"
+#     placeholder: "{{ placeholder('MY_API_KEY') }}"
 #     inject_to:
 #       - api.example.com
 

--- a/tests/e2e/configs/secrets.yaml
+++ b/tests/e2e/configs/secrets.yaml
@@ -17,6 +17,12 @@ domains:
   allow:
     - httpbin.org
 secret_injection:
+  # No `placeholder:` — exercises declare-time generation: cage create must
+  # persist an entropic {{placeholder_my_auto_key_<16hex>}} token into the
+  # stored config and expose it as the cage's MY_AUTO_KEY env var (phase 3.2b).
+  - env: MY_AUTO_KEY
+    inject_to:
+      - httpbin.org
   - env: MY_API_KEY
     placeholder: "{{MY_API_KEY}}"
     inject_to:

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -15,7 +15,8 @@ register_cage "$CAGE"
 echo "Creating secrets cage..."
 export E2E_PORT_SECRETS="$SECRET_PORT"
 create_cage "$CONFIGS/secrets.yaml" \
-  --set-secret MY_API_KEY=test-secret-value-12345 >/dev/null
+  --set-secret MY_API_KEY=test-secret-value-12345 \
+  --set-secret MY_AUTO_KEY=auto-secret-value-67890 >/dev/null
 start_mock "$CAGE" httpbin.org
 if ! wait_ready "$BASE" 120; then
   e2e_fail "3.0" "Setup" "secrets cage not ready"
@@ -48,6 +49,17 @@ if [ "$OUTPUT" = "{{MY_API_KEY}}" ]; then
   e2e_pass "3.2" "Placeholder in cage env"
 else
   e2e_fail "3.2" "Placeholder in cage env" "got '$OUTPUT', expected '{{MY_API_KEY}}'"
+fi
+
+# 3.2b: Entropic placeholder generated for a rule declared without `placeholder:`
+# (cage create persists {{placeholder_my_auto_key_<16hex>}} into the stored
+# config and the cage env carries it).
+e2e_timer_start
+OUTPUT=$(podman exec "${CAGE}-cage" printenv MY_AUTO_KEY 2>&1) || true
+if echo "$OUTPUT" | grep -Eq '^\{\{placeholder_my_auto_key_[0-9a-f]{16}\}\}$'; then
+  e2e_pass "3.2b" "Entropic placeholder in cage env"
+else
+  e2e_fail "3.2b" "Entropic placeholder in cage env" "got '$OUTPUT', expected {{placeholder_my_auto_key_<16hex>}}"
 fi
 
 # 3.3: Injection on outbound — send placeholder, then poll audit for injection record.

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -248,14 +248,17 @@ else
     "/app/node_modules/openclaw symlink missing or target package.json unreadable"
 fi
 
-# 8.8a: cage env has literal placeholder (not the real sentinel)
+# 8.8a: cage env has a literal entropic placeholder (not the real sentinel).
+# The scaffold generates {{placeholder_anthropic_api_key_<16hex>}} at render
+# time, so the exact token differs per cage — assert the format, not a fixed
+# literal.
 e2e_timer_start
-if podman exec "${CAGE}-cage" env 2>/dev/null | grep -q 'ANTHROPIC_API_KEY={{ANTHROPIC_API_KEY}}'; then
-  e2e_pass "8.8a" "cage env has literal placeholder"
+actual=$(podman exec "${CAGE}-cage" printenv ANTHROPIC_API_KEY 2>/dev/null || echo 'not set')
+if echo "$actual" | grep -Eq '^\{\{placeholder_anthropic_api_key_[0-9a-f]{16}\}\}$'; then
+  e2e_pass "8.8a" "cage env has literal entropic placeholder"
 else
-  actual=$(podman exec "${CAGE}-cage" env 2>/dev/null | grep '^ANTHROPIC_API_KEY=' || echo 'not set')
-  e2e_fail "8.8a" "cage env has literal placeholder" \
-    "expected ANTHROPIC_API_KEY={{ANTHROPIC_API_KEY}}, got: $actual"
+  e2e_fail "8.8a" "cage env has literal entropic placeholder" \
+    "expected {{placeholder_anthropic_api_key_<16hex>}}, got: $actual"
 fi
 
 # 8.8b: proxy records an injection attempt on the injected domain.
@@ -267,11 +270,12 @@ fi
 # we care about: "proxy stopped attempting injection on configured
 # domains."
 e2e_timer_start
-# Trigger a fresh flow to httpbin.org with the placeholder.
+# Trigger a fresh flow to httpbin.org with the placeholder. The cage env
+# already holds the generated token — expand $ANTHROPIC_API_KEY in-cage.
 agentcage cage exec "$CAGE" -- sh -c \
   'curl --retry 3 --retry-delay 5 -sS -o /dev/null -x "$HTTPS_PROXY" \
     --max-time 15 \
-    -H "Authorization: Bearer {{ANTHROPIC_API_KEY}}" \
+    -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
     https://httpbin.org/headers' >/dev/null 2>&1 || true
 # The audit log lags the wire by ~1s; poll with a modest deadline.
 FOUND=false
@@ -297,7 +301,7 @@ e2e_timer_start
 agentcage cage exec "$CAGE" -- sh -c \
   'curl --retry 3 --retry-delay 5 -sS -o /dev/null -x "$HTTPS_PROXY" \
     --max-time 15 \
-    -H "Authorization: Bearer {{ANTHROPIC_API_KEY}}" \
+    -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
     https://postman-echo.com/headers' >/dev/null 2>&1 || true
 LEAKED=false
 for _ in $(seq 1 10); do

--- a/tests/test_placeholder_entropy.py
+++ b/tests/test_placeholder_entropy.py
@@ -1,0 +1,355 @@
+"""Entropic secret-injection placeholders.
+
+Covers generation (config.generate_placeholder), declare-time filling of
+omitted placeholders (config.fill_raw_placeholders / state.fill_placeholders),
+parser acceptance of placeholder-less rules, the guessable-placeholder
+warning, empty-placeholder guards in quadlet rendering and the proxy
+injector, scaffold render-time generation, and the `secret list`
+PLACEHOLDER column.
+"""
+
+import platform
+import re
+import textwrap
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from agentcage.config import (
+    fill_raw_placeholders,
+    generate_placeholder,
+    load_config,
+    validate_config,
+)
+
+TOKEN_RE = re.compile(r"^\{\{placeholder_[a-z0-9_]+_[0-9a-f]{16}\}\}$")
+
+
+class TestGeneratePlaceholder:
+
+    def test_format(self):
+        tok = generate_placeholder("GH_TOKEN")
+        assert TOKEN_RE.match(tok)
+        assert tok.startswith("{{placeholder_gh_token_")
+
+    def test_unique_per_call(self):
+        assert generate_placeholder("KEY") != generate_placeholder("KEY")
+
+
+class TestFillRawPlaceholders:
+
+    def test_fills_omitted(self):
+        raw = {"secret_injection": [{"env": "GH_TOKEN"}]}
+        assert fill_raw_placeholders(raw) is True
+        assert TOKEN_RE.match(raw["secret_injection"][0]["placeholder"])
+
+    def test_preserves_explicit(self):
+        raw = {"secret_injection": [
+            {"env": "GH_TOKEN", "placeholder": "ghp_fake000"},
+        ]}
+        assert fill_raw_placeholders(raw) is False
+        assert raw["secret_injection"][0]["placeholder"] == "ghp_fake000"
+
+    def test_carry_over_from_prev(self):
+        prev = {"secret_injection": [
+            {"env": "GH_TOKEN", "placeholder": "{{placeholder_gh_token_aaaaaaaaaaaaaaaa}}"},
+        ]}
+        raw = {"secret_injection": [{"env": "GH_TOKEN"}, {"env": "NEW_KEY"}]}
+        assert fill_raw_placeholders(raw, prev_raw=prev) is True
+        rules = raw["secret_injection"]
+        assert rules[0]["placeholder"] == "{{placeholder_gh_token_aaaaaaaaaaaaaaaa}}"
+        assert TOKEN_RE.match(rules[1]["placeholder"])
+        assert rules[1]["placeholder"] != rules[0]["placeholder"]
+
+    def test_rules_dict_form(self):
+        raw = {"secret_injection": {"rules": [{"env": "K"}], "redact_to": []}}
+        assert fill_raw_placeholders(raw) is True
+        assert TOKEN_RE.match(raw["secret_injection"]["rules"][0]["placeholder"])
+
+    def test_no_rules_is_noop(self):
+        raw = {"name": "x"}
+        assert fill_raw_placeholders(raw) is False
+
+    def test_malformed_entries_skipped(self):
+        raw = {"secret_injection": ["not-a-dict", {"placeholder": "x"}, None]}
+        assert fill_raw_placeholders(raw) is False
+
+
+class TestParserAcceptsOmittedPlaceholder:
+
+    def _load(self, tmp_path, body: str):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent(body))
+        return load_config(str(p))
+
+    def test_rule_kept_with_empty_placeholder(self, tmp_path):
+        cfg = self._load(tmp_path, """\
+            name: test
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+        """)
+        assert len(cfg.secret_injection) == 1
+        assert cfg.secret_injection[0].env == "MY_KEY"
+        assert cfg.secret_injection[0].placeholder == ""
+
+    def test_placeholderless_rule_still_strips_cage_env(self, tmp_path):
+        """An injected secret must never reach the cage env/podman_secrets,
+        placeholder or not."""
+        cfg = self._load(tmp_path, """\
+            name: test
+            container:
+              image: localhost/test:latest
+              podman_secrets: [MY_KEY]
+              env:
+                MY_KEY: "${MY_KEY}"
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+        """)
+        assert "MY_KEY" not in cfg.container.podman_secrets
+        assert "MY_KEY" not in cfg.container.env
+
+    def test_guessable_placeholder_warns(self, tmp_path):
+        cfg = self._load(tmp_path, """\
+            name: test
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: GH_TOKEN
+                placeholder: "{{GH_TOKEN}}"
+        """)
+        warnings = validate_config(cfg)
+        assert any("guessable" in w for w in warnings)
+
+    def test_entropic_placeholder_does_not_warn(self, tmp_path):
+        cfg = self._load(tmp_path, """\
+            name: test
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: GH_TOKEN
+                placeholder: "{{placeholder_gh_token_0123456789abcdef}}"
+        """)
+        warnings = validate_config(cfg)
+        assert not any("guessable" in w for w in warnings)
+
+
+class TestStateFillPlaceholders:
+
+    def _seed(self, state, name, body: str):
+        d = state.deployment_dir(name)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "cage.yaml").write_text(textwrap.dedent(body))
+
+    def test_fill_persists_to_stored_config(self, patch_state_dirs):
+        state = patch_state_dirs
+        self._seed(state, "c1", """\
+            name: c1
+            container:
+              image: localhost/test:latest
+            secret_injection:
+              - env: MY_KEY
+        """)
+        assert state.fill_placeholders("c1") is True
+        raw = state.load_raw_config("c1")
+        assert TOKEN_RE.match(raw["secret_injection"][0]["placeholder"])
+        # Idempotent: second call must not rewrite
+        assert state.fill_placeholders("c1") is False
+
+    def test_fill_carry_over_stable_across_update(self, patch_state_dirs):
+        state = patch_state_dirs
+        self._seed(state, "c2", """\
+            name: c2
+            container:
+              image: localhost/test:latest
+            secret_injection:
+              - env: MY_KEY
+        """)
+        state.fill_placeholders("c2")
+        first = state.load_raw_config("c2")["secret_injection"][0]["placeholder"]
+        # Simulate `cage update -c`: stored config replaced by a user file
+        # that still omits the placeholder.
+        prev_raw = state.load_raw_config("c2")
+        self._seed(state, "c2", """\
+            name: c2
+            container:
+              image: localhost/test:latest
+            secret_injection:
+              - env: MY_KEY
+        """)
+        assert state.fill_placeholders("c2", prev_raw=prev_raw) is True
+        second = state.load_raw_config("c2")["secret_injection"][0]["placeholder"]
+        assert second == first
+
+
+class TestQuadletEmptyPlaceholderGuard:
+
+    def _cfg(self, tmp_path, placeholder_line: str = ""):
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent(f"""\
+            name: guardtest
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+            {placeholder_line}
+        """))
+        return load_config(str(p))
+
+    def test_empty_placeholder_not_rendered(self, tmp_path, patch_state_dirs):
+        from agentcage.quadlets import generate_quadlets
+        cfg = self._cfg(tmp_path)
+        units = generate_quadlets(
+            cfg, str(tmp_path / "proxy-config.yaml"), str(tmp_path), "guardtest",
+        )
+        cage_unit = units["guardtest-cage.container"]
+        assert 'Environment="MY_KEY="' not in cage_unit
+        assert 'Environment="MY_KEY=' not in cage_unit
+
+    def test_filled_placeholder_rendered(self, tmp_path, patch_state_dirs):
+        from agentcage.quadlets import generate_quadlets
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: guardtest
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+        """))
+        cfg = load_config(str(p))
+        units = generate_quadlets(
+            cfg, str(tmp_path / "proxy-config.yaml"), str(tmp_path), "guardtest",
+        )
+        cage_unit = units["guardtest-cage.container"]
+        assert (
+            'Environment="MY_KEY={{placeholder_my_key_0123456789abcdef}}"'
+            in cage_unit
+        )
+
+
+class TestInjectorEmptyPlaceholderGuard:
+
+    def test_empty_placeholder_rule_skipped(self, monkeypatch):
+        """`"" in text` is always True and `text.replace("", v)` corrupts
+        content — an empty placeholder must never become an active rule."""
+        monkeypatch.setenv("MY_KEY", "real-value")
+        from agentcage.data.proxy.secret_injector import SecretInjector
+        inj = SecretInjector()
+        inj.configure([{"env": "MY_KEY", "placeholder": ""}])
+        assert inj.rules == []
+
+    def test_normal_rule_kept(self, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "real-value")
+        from agentcage.data.proxy.secret_injector import SecretInjector
+        inj = SecretInjector()
+        inj.configure([
+            {"env": "MY_KEY",
+             "placeholder": "{{placeholder_my_key_0123456789abcdef}}"},
+        ])
+        assert len(inj.rules) == 1
+
+
+class TestScaffoldRenderTimeGeneration:
+
+    @pytest.mark.parametrize("scaffold,env", [
+        ("claude-code", "ANTHROPIC_API_KEY"),
+        ("codex", "OPENAI_API_KEY"),
+        ("pi", "ANTHROPIC_API_KEY"),
+        ("openclaw", "ANTHROPIC_API_KEY"),
+    ])
+    def test_active_rules_render_entropic_tokens(self, scaffold, env):
+        from agentcage.init import render_config
+        parsed = yaml.safe_load(render_config("t", scaffold=scaffold))
+        rules = {r["env"]: r for r in parsed.get("secret_injection", [])}
+        assert env in rules
+        assert TOKEN_RE.match(rules[env]["placeholder"])
+
+    def test_tokens_unique_per_render(self):
+        from agentcage.init import render_config
+        a = yaml.safe_load(render_config("t", scaffold="claude-code"))
+        b = yaml.safe_load(render_config("t", scaffold="claude-code"))
+        pa = a["secret_injection"][0]["placeholder"]
+        pb = b["secret_injection"][0]["placeholder"]
+        assert pa != pb
+
+
+@pytest.mark.skipif(
+    platform.system() != "Linux",
+    reason="Linux/container cage create flow; runs on the Linux CI",
+)
+class TestCageCreateFillsPlaceholders:
+    """End-to-end through the CLI: `cage create` must persist a generated
+    placeholder into the stored cage.yaml and hand a *filled* Config to
+    build_and_deploy (real state module, mocked podman/systemd/deploy)."""
+
+    @patch("agentcage.cli._build_and_deploy")
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli._check_secrets", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.systemd")
+    @patch("agentcage.cli.Podman")
+    def test_create_persists_and_deploys_filled_placeholder(
+        self, MockPodman, mock_systemd, mock_backend, _check_secrets,
+        _check_ports, mock_build_deploy, tmp_path, patch_state_dirs,
+        monkeypatch,
+    ):
+        from click.testing import CliRunner
+        import agentcage.cli as cli_mod
+        from agentcage.cli import main
+
+        monkeypatch.setattr(
+            cli_mod, "_ensure_backend_ready",
+            lambda cfg, **kw: cli_mod.get_backend(cfg),
+        )
+        state = patch_state_dirs
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: fill-e2e
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+        """))
+        result = CliRunner().invoke(main, ["cage", "create", "-c", str(p)])
+        assert result.exit_code == 0, result.output
+
+        # Stored config carries the generated token…
+        raw = state.load_raw_config("fill-e2e")
+        stored = raw["secret_injection"][0]["placeholder"]
+        assert TOKEN_RE.match(stored)
+        # …and build_and_deploy received the *reloaded* (filled) Config.
+        deployed_cfg = mock_build_deploy.call_args.args[0]
+        assert deployed_cfg.secret_injection[0].placeholder == stored
+        # The user's original file is never mutated.
+        assert "placeholder" not in p.read_text()
+
+
+class TestSecretListPlaceholderColumn:
+
+    def test_placeholder_shown(self, tmp_path, capsys):
+        from agentcage.cli import _render_secret_list
+        p = tmp_path / "cage.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: listtest
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+            secret_injection:
+              - env: MY_KEY
+                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+        """))
+        cfg = load_config(str(p))
+        _render_secret_list(cfg, {"MY_KEY"})
+        out = capsys.readouterr().out
+        assert "PLACEHOLDER" in out
+        assert "{{placeholder_my_key_0123456789abcdef}}" in out

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -1,5 +1,6 @@
 """Tests for scaffold listing, rendering, and metadata loading."""
 
+import re
 import textwrap
 from pathlib import Path
 
@@ -160,11 +161,15 @@ class TestCodingAgentScaffolds:
     def test_claude_code_oauth_token_rule_present_but_inactive(self):
         """The CLAUDE_CODE_OAUTH_TOKEN injection rule ships commented out —
         present as guidance, but not active (an active rule would make
-        `cage create` demand the secret). The placeholder must render
-        literally, not be expanded by Jinja."""
+        `cage create` demand the secret). The placeholder renders as a
+        concrete entropic token even inside the comment, so uncommenting
+        the rule yields a ready-to-use config."""
         cfg_text = render_config("test-cc", scaffold="claude-code")
         assert "#- env: CLAUDE_CODE_OAUTH_TOKEN" in cfg_text
-        assert "{{CLAUDE_CODE_OAUTH_TOKEN}}" in cfg_text
+        assert re.search(
+            r"\{\{placeholder_claude_code_oauth_token_[0-9a-f]{16}\}\}",
+            cfg_text,
+        )
         parsed = yaml.safe_load(cfg_text)
         active = [s["env"] for s in parsed.get("secret_injection", [])]
         assert active == ["ANTHROPIC_API_KEY"]


### PR DESCRIPTION
## Summary

`secret_injection` placeholders are now **entropic by default**: rules may omit `placeholder:`, and agentcage generates `{{placeholder_<env_lowercase>_<16 hex chars>}}` (64 bits of entropy), persisting it into the cage's stored config at declare time.

**Why.** The proxy substitutes placeholders as literal strings wherever injection applies. A guessable placeholder like `{{GH_TOKEN}}` is an accidental-substitution hazard: outbound content that legitimately contains that text — template files, docs, CI config — would get the real secret injected into it. A random suffix makes such collisions vanishingly unlikely.

## What changed

- **Schema:** `placeholder:` is optional. `config.generate_placeholder()` mints the token; `config.fill_raw_placeholders()` / `state.fill_placeholders()` persist it into the stored cage.yaml — the single source of truth for quadlets, proxy config, and `secret list`.
- **Declare-time fill:** wired into `cage create`, `cage update -c` (with carry-over of previously generated tokens by `env` name, so they stay **stable across updates**), `cage update` (no `-c`), `cage edit` (the diff shows the generated token), and `agentcage run`.
- **Scaffolds:** all bundled templates render entropic tokens at render time via a sandboxed Jinja `placeholder()` helper — scaffold-generated configs are stored verbatim (no comment-stripping rewrite). Commented-out example rules render a concrete token too, so uncommenting them just works.
- **Guards:** empty placeholders are skipped in quadlet rendering, the apple-container env map, and the proxy injector. The injector guard is load-bearing: an empty placeholder must never reach matching (`"" in text` is always `True`, and `text.replace("", v)` corrupts content).
- **Lint:** `validate_config` warns when an explicit placeholder uses the bare `{{ENV_NAME}}` convention.
- **UX:** `agentcage secret list` grew a `PLACEHOLDER` column (placeholders are decoys, never sensitive).
- Docs (`secret-injection.md` "Placeholder entropy" section, architecture), scaffold READMEs, CHANGELOG.

## Compatibility

Explicit `placeholder:` values remain fully supported (some clients validate credential format client-side before sending). Existing cages are untouched — stored placeholders keep working as-is. The user's original cage.yaml is never mutated; only the stored copy under `~/.config/agentcage/cages/<name>/` is filled.

## Testing

- `tests/test_placeholder_entropy.py` (26 tests): generation format/uniqueness, fill + carry-over semantics, parser acceptance, guessable-placeholder warning, quadlet/injector empty-placeholder guards, scaffold render-time generation for all four agent scaffolds, `secret list` column, and a CLI-level `cage create` test asserting the stored config and the deployed Config both carry the same generated token.
- Full suite: **1700 passed**; the only diff vs master's baseline in my sandbox is the updated scaffold assertion (master baseline failures are environmental: no podman/DNS).
- e2e: phase 3 gained `MY_AUTO_KEY` — a rule declared **without** `placeholder:` — asserting the cage env carries `{{placeholder_my_auto_key_<16hex>}}` (3.2b); the explicit-placeholder path (3.2) still covered. Phase 8 now reads the generated token from the cage env instead of assuming the `{{ANTHROPIC_API_KEY}}` literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
