### PR TITLE
feat(secrets): `secret rotate-placeholders` — retire/migrate injection placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agentcage secret rotate-placeholders <cage> [KEY ...]`** — mint fresh entropic placeholders for all (or only the named) `secret_injection` rules. Use it to retire a compromised placeholder or migrate a legacy static/guessable one (`{{GH_TOKEN}}`) to an entropic token. The new tokens are persisted to the stored `cage.yaml` and a running cage is restarted so the old placeholders stop injecting and the cage process picks up the new ones (a placeholder change can't apply zero-restart the way a value change can — the token is baked into the cage process's environment at start). Rotation fixes the live cage, not a `cage.yaml` tracked elsewhere: since an explicit non-empty `placeholder:` always wins, drop the `placeholder:` line from a source config you `cage update -c` from so agentcage owns and preserves the generated token.
+
 ## [0.23.0] - 2026-06-12
 
 ### Added

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -256,6 +256,7 @@ Manage cage-scoped secrets.
 | `secret list NAME` | List secrets for a cage (with status if cage exists) |
 | `secret set NAME KEY [--declare] [--placeholder P] [--inject-to D]` | Set a secret (prompts for value or reads stdin). Applies live to a running cage — no restart. `--declare` adds a `secret_injection` rule for a brand-new KEY (entropic placeholder; `--inject-to` scopes it) |
 | `secret rm NAME KEY` | Remove a secret |
+| `secret rotate-placeholders NAME [KEY...]` | Mint fresh entropic placeholders for all (or named) `secret_injection` rules — retire a compromised placeholder or migrate a legacy static one. Restarts a running cage to apply |
 | `secret migrate NAME` | Migrate a cage's secrets to a different storage backend |
 
 Aliases: `ls` → `list`.

--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -77,6 +77,29 @@ client-side check). To see the generated token for a cage, run
 > drops comments in that file. Configs generated from scaffolds already carry
 > a generated placeholder, so they are stored untouched.
 
+### Rotating a placeholder
+
+To retire a placeholder — because it leaked, or to migrate a legacy
+static/guessable one like `{{GH_TOKEN}}` to an entropic token — run:
+
+```bash
+agentcage secret rotate-placeholders <cage>            # all injection rules
+agentcage secret rotate-placeholders <cage> GH_TOKEN   # just this one
+```
+
+This mints a fresh `{{placeholder_<env>_<16hex>}}` for each targeted rule,
+persists it to the stored `cage.yaml`, and restarts a running cage so the old
+placeholder stops injecting and the cage process picks up the new one. (A
+placeholder change can't apply zero-restart the way a *value* change can — the
+token is baked into the cage process's environment at start.) A stopped cage
+is just updated in place; the next start picks it up.
+
+> **Note:** rotation fixes the **live cage**, not a `cage.yaml` you track
+> elsewhere. Because an explicit, non-empty `placeholder:` always wins, the
+> next `cage update -c` from a source file that still pins the old token
+> reintroduces it. For a durable migration, also delete the `placeholder:`
+> line from your source config so agentcage generates and preserves the token.
+
 ## How placeholders and values reach the containers
 
 Placeholders are delivered to the cage via a derived env-file —

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -3618,6 +3618,90 @@ def secret_rm(name: str, key: str):
     _apply_secret_live_or_restart(name, key, "")
 
 
+def _injection_rules(raw: dict) -> list:
+    """Return the secret_injection rule list from a raw cage.yaml dict.
+
+    Handles both the bare-list and ``{rules: [...]}`` mapping forms (and
+    returns the live list so callers can mutate it in place). Mirrors the
+    helper in :func:`agentcage.config.fill_raw_placeholders`.
+    """
+    si = raw.get("secret_injection") or []
+    rules = si.get("rules", []) if isinstance(si, dict) else si
+    return rules if isinstance(rules, list) else []
+
+
+@secret.command("rotate-placeholders")
+@click.argument("name")
+@click.argument("keys", nargs=-1)
+def secret_rotate_placeholders(name: str, keys: tuple[str, ...]):
+    """Mint fresh entropic placeholders for a cage's injection rules.
+
+    Rotates every secret_injection rule's placeholder, or only the named
+    KEYS. Use this to retire a compromised placeholder or migrate a legacy
+    static/guessable one (e.g. ``{{GH_TOKEN}}``) to an entropic token. The
+    new tokens are persisted to the stored cage.yaml; a running cage is
+    restarted so the old placeholders stop injecting and the cage process
+    picks up the new ones.
+
+    Note: this fixes the live cage, not a cage.yaml you track elsewhere. If
+    your source config pins an explicit placeholder, the next ``cage update
+    -c`` reintroduces it — drop the ``placeholder:`` line from your source
+    so agentcage owns (and preserves) the generated token instead.
+    """
+    if not state.deployment_exists(name):
+        click.echo(f"error: cage '{name}' does not exist", err=True)
+        sys.exit(1)
+    _ensure_v022_cage(name)
+
+    raw = state.load_raw_config(name)
+    rules = [r for r in _injection_rules(raw) if isinstance(r, dict) and r.get("env")]
+    by_env = {r["env"]: r for r in rules}
+
+    if keys:
+        missing = [k for k in keys if k not in by_env]
+        if missing:
+            click.echo(
+                f"error: no secret_injection rule for: {', '.join(missing)}",
+                err=True,
+            )
+            sys.exit(1)
+        targets = [by_env[k] for k in keys]
+    else:
+        targets = rules
+        if not targets:
+            click.echo(f"Cage '{name}' has no secret_injection rules to rotate.")
+            return
+
+    from agentcage.config import generate_placeholder
+    rotations = []
+    for rule in targets:
+        old = rule.get("placeholder", "")
+        new = generate_placeholder(rule["env"])
+        rule["placeholder"] = new
+        rotations.append((rule["env"], old, new))
+    state.save_raw_config(name, raw)
+
+    click.echo(f"Rotated {len(rotations)} placeholder(s) for '{name}':")
+    for env, old, new in rotations:
+        click.echo(f"  {env}  {old or '(unset)'}  →  {new}")
+
+    cfg = state.load_deployment_config(name)
+    if _is_apple_container(cfg):
+        _apple_restart_if_running(name, cfg)
+        return
+    backend = get_backend(cfg)
+    if backend.is_running(cfg.name, "cage"):
+        click.echo(
+            f"Restarting cage '{cfg.name}' to apply — the old "
+            f"placeholder(s) stop injecting now."
+        )
+        _restart_cage(cfg.name, cfg)
+    else:
+        click.echo(
+            "Cage is not running — the new placeholders apply on next start."
+        )
+
+
 # ── domain group ─────────────────────────────────────────
 
 

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -229,6 +229,27 @@ else
     "no new secrets_injected entry within 60s (before=$COUNT_BEFORE after=$COUNT_AFTER)"
 fi
 
+# 3.4f: rotate-placeholders mints a fresh entropic token and applies it.
+# MY_AUTO_KEY already carries a generated placeholder (3.2b); rotation must
+# replace it with a *different* entropic token, visible in the cage env
+# (the rotate restarts the running cage so PID 1 picks it up).
+e2e_timer_start
+OLD_PH=$(agentcage cage exec "$CAGE" -- printenv MY_AUTO_KEY 2>/dev/null | tr -d '\r') || true
+agentcage secret rotate-placeholders "$CAGE" MY_AUTO_KEY >/dev/null 2>&1 || true
+if wait_ready "$BASE" 60; then
+  NEW_PH=$(agentcage cage exec "$CAGE" -- printenv MY_AUTO_KEY 2>/dev/null | tr -d '\r') || true
+  if echo "$NEW_PH" | grep -Eq '^\{\{placeholder_my_auto_key_[0-9a-f]{16}\}\}$' \
+     && [ "$NEW_PH" != "$OLD_PH" ]; then
+    e2e_pass "3.4f" "rotate-placeholders mints+applies a fresh token"
+  else
+    e2e_fail "3.4f" "rotate-placeholders mints+applies a fresh token" \
+      "old='$OLD_PH' new='$NEW_PH'"
+  fi
+else
+  e2e_fail "3.4f" "rotate-placeholders mints+applies a fresh token" \
+    "cage did not come back after rotate"
+fi
+
 # 3.5: Remove secret
 e2e_timer_start
 agentcage secret rm "$CAGE" MY_API_KEY >/dev/null 2>&1 || true

--- a/tests/test_rotate_placeholders.py
+++ b/tests/test_rotate_placeholders.py
@@ -1,0 +1,173 @@
+"""`agentcage secret rotate-placeholders`.
+
+Covers minting fresh entropic tokens for all or named injection rules,
+persistence to the stored cage.yaml, restart-if-running vs persist-if-
+stopped, the named-key/empty-cage error and no-op paths, and that a
+rotated guessable placeholder clears the validate_config lint warning.
+"""
+
+import re
+import textwrap
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agentcage.cli import main
+
+TOKEN_RE = re.compile(r"^\{\{placeholder_[a-z0-9_]+_[0-9a-f]{16}\}\}$")
+
+
+def _seed(state, name, body: str):
+    d = state.deployment_dir(name)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "cage.yaml").write_text(textwrap.dedent(body))
+    meta = state.load_metadata(name)
+    meta["agentcage_version"] = "0.22.22"
+    state.save_metadata(name, meta)
+
+
+_TWO_RULES = """\
+    name: c1
+    container:
+      image: localhost/test:latest
+    dns_servers: ["1.1.1.1"]
+    secret_injection:
+      - env: ANTHROPIC_API_KEY
+        placeholder: "{{ANTHROPIC_API_KEY}}"
+        inject_to: [anthropic.com]
+      - env: GITHUB_TOKEN
+        placeholder: "{{GITHUB_TOKEN}}"
+        inject_to: [github.com]
+"""
+
+
+def _rules(state, name):
+    raw = state.load_raw_config(name)
+    return {r["env"]: r["placeholder"] for r in raw["secret_injection"]}
+
+
+class TestRotatePlaceholders:
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_rotate_all_persists_and_restarts(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        state = patch_state_dirs
+        _seed(state, "c1", _TWO_RULES)
+        mock_backend.return_value.is_running.return_value = True
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1"],
+        )
+        assert result.exit_code == 0, result.output
+        rules = _rules(state, "c1")
+        assert TOKEN_RE.match(rules["ANTHROPIC_API_KEY"])
+        assert TOKEN_RE.match(rules["GITHUB_TOKEN"])
+        # Distinct tokens, both rotated away from the guessable originals.
+        assert rules["ANTHROPIC_API_KEY"] != rules["GITHUB_TOKEN"]
+        mock_restart.assert_called_once()
+        assert "Rotated 2 placeholder" in result.output
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_rotate_named_key_only(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        state = patch_state_dirs
+        _seed(state, "c1", _TWO_RULES)
+        mock_backend.return_value.is_running.return_value = True
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1", "GITHUB_TOKEN"],
+        )
+        assert result.exit_code == 0, result.output
+        rules = _rules(state, "c1")
+        assert TOKEN_RE.match(rules["GITHUB_TOKEN"])
+        # The untargeted rule is left exactly as it was.
+        assert rules["ANTHROPIC_API_KEY"] == "{{ANTHROPIC_API_KEY}}"
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_stopped_cage_persists_without_restart(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        state = patch_state_dirs
+        _seed(state, "c1", _TWO_RULES)
+        mock_backend.return_value.is_running.return_value = False
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert TOKEN_RE.match(_rules(state, "c1")["ANTHROPIC_API_KEY"])
+        mock_restart.assert_not_called()
+        assert "apply on next start" in result.output
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_unknown_key_errors_and_changes_nothing(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        state = patch_state_dirs
+        _seed(state, "c1", _TWO_RULES)
+        mock_backend.return_value.is_running.return_value = True
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1", "NOPE"],
+        )
+        assert result.exit_code == 1
+        assert "no secret_injection rule for: NOPE" in result.output
+        # Nothing rotated, nothing restarted.
+        assert _rules(state, "c1")["ANTHROPIC_API_KEY"] == "{{ANTHROPIC_API_KEY}}"
+        mock_restart.assert_not_called()
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_cage_with_no_rules_is_noop(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        state = patch_state_dirs
+        _seed(state, "c1", """\
+            name: c1
+            container:
+              image: localhost/test:latest
+            dns_servers: ["1.1.1.1"]
+        """)
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "no secret_injection rules to rotate" in result.output
+        mock_restart.assert_not_called()
+
+    def test_nonexistent_cage_errors(self, patch_state_dirs):
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "ghost"],
+        )
+        assert result.exit_code == 1
+        assert "does not exist" in result.output
+
+    @patch("agentcage.cli._restart_cage")
+    @patch("agentcage.cli.get_backend")
+    def test_rotation_clears_guessable_lint_warning(
+        self, mock_backend, mock_restart, patch_state_dirs,
+    ):
+        """The migration payoff: a guessable {{ENV}} placeholder trips the
+        validate_config warning; after rotation the stored config validates
+        clean."""
+        from agentcage.config import load_config, validate_config
+        state = patch_state_dirs
+        _seed(state, "c1", _TWO_RULES)
+        mock_backend.return_value.is_running.return_value = False
+
+        before = validate_config(load_config(str(state.stored_config_path("c1"))))
+        assert any("guessable" in w for w in before)
+
+        result = CliRunner().invoke(
+            main, ["secret", "rotate-placeholders", "c1"],
+        )
+        assert result.exit_code == 0, result.output
+        after = validate_config(load_config(str(state.stored_config_path("c1"))))
+        assert not any("guessable" in w for w in after)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.22.22"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Adds `agentcage secret rotate-placeholders <cage> [KEY ...]`: mint fresh entropic placeholders for all (or only the named) `secret_injection` rules, persist them to the stored `cage.yaml`, and restart a running cage so the old placeholders stop injecting and the cage process picks up the new ones.

Closes the migration/rotation gap discussed in #262: before this, the only way to replace a guessable/legacy placeholder (`{{GH_TOKEN}}`) or retire a compromised one was a hand `cage edit` (and blanking the line didn't work — carry-over resurrected the old value by env name).

## Why a restart (not zero-restart)

A secret *value* change applies live (PR #260) because the placeholder the cage process holds is constant — only the value the proxy swaps in changes. A *placeholder* change is different: the token is baked into the cage process's environment at container start (via the `EnvironmentFile=` channel from #259), so the running process must be recreated to pick up the new one. Stopped cages just persist; the next start derives everything.

## Resolution semantics unchanged

This deliberately does **not** touch placeholder resolution — an explicit, non-empty `placeholder:` still wins; omitted/empty still generates-and-preserves. Rotation is the explicit, opt-in gesture. The help text and docs call out the one gotcha: rotation fixes the live cage, not a `cage.yaml` you track elsewhere, so drop the `placeholder:` line from a source you `cage update -c` from to avoid reintroducing the old token.

## Operator UX

```console
$ agentcage secret rotate-placeholders mycage
Rotated 2 placeholder(s) for 'mycage':
  ANTHROPIC_API_KEY  {{ANTHROPIC_API_KEY}}  →  {{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}
  GITHUB_TOKEN       {{GITHUB_TOKEN}}        →  {{placeholder_github_token_1b77c0de44a2f019}}
Restarting cage 'mycage' to apply — the old placeholder(s) stop injecting now.
```

## Testing

- `tests/test_rotate_placeholders.py` (7): rotate-all vs named-key, running restarts / stopped persists, unknown-key and nonexistent-cage errors, no-rules no-op, and a guessable→entropic round-trip that clears the `validate_config` lint warning.
- Full suite: **1765 passed** locally (8 `test_egress_image` deselected — environmental, no rootless container build on this host).
- e2e phase 3 gained **3.4f** (rotate mints a fresh entropic token and applies it via restart); phase 3 is **21/21** on podman 5.x rootless.
- Manual operator runs: migrated a guessable `{{MY_API_KEY}}` on a running cage → entropic token live in the cage env, **injected on the wire** (fresh `secrets_injected` audit entries), sibling rule untouched; verified the stopped-cage persist path and rotate-all too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)