### PR TITLE
feat(secrets): `agentcage:secret:<ENV>:<128-bit hex>` placeholder format + shape validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Secret-injection placeholders now use the `agentcage:secret:<ENV>:<32 hex>` format** (e.g. `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`) instead of the `{{placeholder_<env>_<16 hex>}}` brace form. The suffix is now 128 bits of entropy (was 64), and the `agentcage:secret:` prefix makes a placeholder self-identifying. `validate_config` (run by `cage create`/`update`/`edit`) now **warns when any `secret_injection` placeholder is not in the `agentcage:secret:*` form** — including the old brace form and arbitrary custom values — and points at `agentcage secret rotate-placeholders` to mint a conforming token. This is a warning, not a hard error: existing cages keep working unchanged (their stored placeholders are still matched verbatim), and explicit placeholders are still accepted for clients that validate credential format before sending. Newly generated placeholders (omitted `placeholder:`, scaffolds, `rotate-placeholders`, `secret set --declare`) all use the new format.
+
 ### Added
 
 - **`agentcage secret rotate-placeholders <cage> [KEY ...]`** — mint fresh entropic placeholders for all (or only the named) `secret_injection` rules. Use it to retire a compromised placeholder or migrate a legacy static/guessable one (`{{GH_TOKEN}}`) to an entropic token. The new tokens are persisted to the stored `cage.yaml` and a running cage is restarted so the old placeholders stop injecting and the cage process picks up the new ones (a placeholder change can't apply zero-restart the way a value change can — the token is baked into the cage process's environment at start). Rotation fixes the live cage, not a `cage.yaml` tracked elsewhere: since an explicit non-empty `placeholder:` always wins, drop the `placeholder:` line from a source config you `cage update -c` from so agentcage owns and preserves the generated token.

--- a/docs/explain/architecture.md
+++ b/docs/explain/architecture.md
@@ -42,7 +42,7 @@ Custom inspectors plug into the same chain with the same allow / flag / block co
 
 Secret injection keeps real secret values out of the cage entirely.
 
-The cage gets a placeholder — a generated decoy token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}` (entropic so real outbound content never collides with it; see [Secret injection](../reference/secret-injection.md#placeholder-entropy)). The agent uses the placeholder in headers, query strings, or bodies as if it were the real value. Before the inspector chain runs, the proxy checks two invariants:
+The cage gets a placeholder — a generated decoy token like `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a` (entropic so real outbound content never collides with it; see [Secret injection](../reference/secret-injection.md#placeholder-entropy)). The agent uses the placeholder in headers, query strings, or bodies as if it were the real value. Before the inspector chain runs, the proxy checks two invariants:
 
 1. **Literal value blocking.** If a real secret value appears in a request to a host outside that secret's `inject_to` list, the request is blocked. The cage should never know the real value, so its presence indicates the agent learned the secret outside the placeholder system.
 2. **Placeholder routing.** If a placeholder is heading to a domain not in that secret's `inject_to` list, the request is flagged but still goes through.

--- a/docs/reference/secret-injection.md
+++ b/docs/reference/secret-injection.md
@@ -10,7 +10,7 @@ Secrets listed in `secret_injection` are automatically excluded from the cage's 
 | Setting | Type | Required | Description |
 |---------|------|----------|-------------|
 | `env` | `string` | yes | Environment variable name holding the real secret (read by the proxy at startup). |
-| `placeholder` | `string` | no | Token the cage sees and uses in requests. **Omit it** (recommended) and agentcage generates an entropic token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`, persisted into the cage's stored config at create/update/edit time. See [Placeholder entropy](#placeholder-entropy). |
+| `placeholder` | `string` | no | Token the cage sees and uses in requests. **Omit it** (recommended) and agentcage generates an entropic token like `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`, persisted into the cage's stored config at create/update/edit time. See [Placeholder entropy](#placeholder-entropy). |
 | `inject_to` | `list[string]` | no | Domains where placeholders are replaced with real values. If omitted, injection applies to all domains. |
 | `inject_body` | `bool` | no | When `false` (the default), placeholders are only substituted inside known credential-bearing request headers (the [auth-header allow-list](#injection-scope)). Set to `true` to also inject into the request URL (query string), every header, the request body, and WebSocket frames. See [Injection scope](#injection-scope). |
 | `inject_headers` | `list[string]` | no | Extra request headers — added to the built-in auth-header allow-list — to treat as credential-bearing under the strict default. Matched case-insensitively. Use for APIs whose auth header isn't a common convention. See [Injection scope](#injection-scope). |
@@ -53,24 +53,28 @@ secret_injection:
 ## Placeholder entropy
 
 When a rule omits `placeholder:`, agentcage generates
-`{{placeholder_<env_lowercase>_<16 hex chars>}}` (64 bits of entropy) and
-persists it into the cage's stored config the first time the rule is deployed
-(`cage create`, `cage update -c`, `cage edit`, or `agentcage run`). The token
-stays stable across updates — it is carried over by `env` name rather than
+`agentcage:secret:<ENV>:<32 hex chars>` (128 bits of entropy) and persists it
+into the cage's stored config the first time the rule is deployed (`cage
+create`, `cage update -c`, `cage edit`, or `agentcage run`). The token stays
+stable across updates — it is carried over by `env` name rather than
 regenerated, so long-running processes inside the cage keep working.
 
-Why entropy matters: the proxy substitutes the placeholder as a **literal
-string** wherever injection applies. A guessable placeholder like
-`{{GH_TOKEN}}` is an accidental-substitution hazard — if a file the agent
-sends outbound legitimately contains that text (a template file, docs, CI
-config), the real secret would be injected into it. A random suffix makes
-such collisions vanishingly unlikely. `agentcage cage create` warns when an
-explicit placeholder uses the bare `{{ENV_NAME}}` convention.
+Why this shape: the proxy substitutes the placeholder as a **literal string**
+wherever injection applies. A guessable placeholder like `{{GH_TOKEN}}` is an
+accidental-substitution hazard — if a file the agent sends outbound
+legitimately contains that text (a template file, docs, CI config), the real
+secret would be injected into it. The random 128-bit suffix makes such
+collisions vanishingly unlikely, and the `agentcage:secret:` prefix makes a
+placeholder self-identifying — tooling can recognize one on sight.
+`agentcage cage create` (and `update`/`edit`) warns when a placeholder is not
+in the `agentcage:secret:*` form.
 
-Explicit `placeholder:` values remain fully supported — some clients validate
+Explicit `placeholder:` values are still accepted — some clients validate
 credential format before sending (e.g. a `ghp_`-prefixed fake to pass a
-client-side check). To see the generated token for a cage, run
-`agentcage secret list <cage>` (placeholders are decoys, never sensitive).
+client-side check) — but they trip the validation warning above; prefer the
+generated token unless a client-side check forces your hand. To see the
+generated token for a cage, run `agentcage secret list <cage>` (placeholders
+are decoys, never sensitive).
 
 > **Note:** filling an omitted placeholder rewrites the stored `cage.yaml`
 > (under `~/.config/agentcage/cages/<name>/`), which normalizes the YAML and
@@ -87,7 +91,7 @@ agentcage secret rotate-placeholders <cage>            # all injection rules
 agentcage secret rotate-placeholders <cage> GH_TOKEN   # just this one
 ```
 
-This mints a fresh `{{placeholder_<env>_<16hex>}}` for each targeted rule,
+This mints a fresh `agentcage:secret:<ENV>:<32hex>` for each targeted rule,
 persists it to the stored `cage.yaml`, and restarts a running cage so the old
 placeholder stops injecting and the cage process picks up the new one. (A
 placeholder change can't apply zero-restart the way a *value* change can — the

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -42,19 +42,24 @@ class SecretsConfig:
     allow_plaintext: bool = False
 
 
+PLACEHOLDER_PREFIX = "agentcage:secret:"
+
+
 def generate_placeholder(env: str) -> str:
     """Return an entropic placeholder token for *env*.
 
-    Format: ``{{placeholder_<env_lowercase>_<16 hex chars>}}`` (64 bits of
-    entropy). Guessable placeholders like ``{{GH_TOKEN}}`` are an accidental-
+    Format: ``agentcage:secret:<ENV>:<32 hex chars>`` (128 bits of entropy).
+    Guessable placeholders like ``{{GH_TOKEN}}`` are an accidental-
     substitution hazard: any file the agent sends outbound that happens to
     contain that literal text (template files, docs) would get the real
     secret injected. The random suffix makes a collision with legitimate
-    content vanishingly unlikely. The token must stay inside ``{{...}}``
-    delimiters — the proxy matches placeholders as literal strings.
+    content vanishingly unlikely, and the ``agentcage:secret:`` prefix makes
+    a placeholder self-identifying (see :func:`validate_config`). The proxy
+    matches placeholders as literal strings, so the token can be any stable
+    string — no delimiters required.
     """
     import secrets as _secrets
-    return "{{placeholder_%s_%s}}" % (env.lower(), _secrets.token_hex(8))
+    return "%s%s:%s" % (PLACEHOLDER_PREFIX, env, _secrets.token_hex(16))
 
 
 def fill_raw_placeholders(raw: dict, prev_raw: dict | None = None) -> bool:
@@ -1244,17 +1249,22 @@ def validate_config(config: Config) -> list[str]:
             "and no ports are allowed through)"
         )
 
-    # Warn about guessable placeholders — the bare {{ENV_NAME}} convention
-    # is an accidental-substitution hazard (any outbound content containing
-    # the literal text gets the real secret injected). Explicit placeholders
-    # stay supported for APIs that validate credential format client-side.
+    # Warn about placeholders that aren't in the canonical
+    # ``agentcage:secret:<ENV>:<hex>`` shape. A placeholder is matched as a
+    # literal string in outbound content, so a guessable value like
+    # ``{{GH_TOKEN}}`` — or any string an outbound payload might legitimately
+    # contain — is an accidental-substitution hazard. The canonical prefix is
+    # also self-identifying: tooling can recognize an agentcage placeholder on
+    # sight. Existing cages keep working (this is a warning, not a hard
+    # error); `agentcage secret rotate-placeholders` mints a conforming token.
     for rule in config.secret_injection:
-        if rule.placeholder == "{{%s}}" % rule.env:
+        if rule.placeholder and not rule.placeholder.startswith(PLACEHOLDER_PREFIX):
             warnings.append(
                 f"secret_injection[{rule.env!r}]: placeholder "
-                f"'{rule.placeholder}' is guessable — omit `placeholder:` "
-                f"to auto-generate an entropic token, or pick a value "
-                f"unlikely to appear in outbound content"
+                f"'{rule.placeholder}' is not in the '{PLACEHOLDER_PREFIX}*' "
+                f"form — omit `placeholder:` to auto-generate an entropic "
+                f"token, or run `agentcage secret rotate-placeholders` to "
+                f"mint one"
             )
 
     # Warn about passthrough implications

--- a/src/agentcage/scaffolds/claude-code/README.md
+++ b/src/agentcage/scaffolds/claude-code/README.md
@@ -77,7 +77,7 @@ agentcage secret set myagent ANTHROPIC_API_KEY
 agentcage cage create -c cage.yaml
 ```
 
-The scaffold uses `secret_injection` for the API key. Claude Code sends a generated placeholder token (e.g. `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Claude Code sends a generated placeholder token (e.g. `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
 
 #### 3. Start a session
 

--- a/src/agentcage/scaffolds/codex/README.md
+++ b/src/agentcage/scaffolds/codex/README.md
@@ -53,7 +53,7 @@ This builds the proxy and DNS images, generates systemd quadlet files, and start
 agentcage secret set myagent OPENAI_API_KEY
 ```
 
-The scaffold uses `secret_injection` for the API key. Codex sends a generated placeholder token (e.g. `{{placeholder_openai_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Codex sends a generated placeholder token (e.g. `agentcage:secret:OPENAI_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`) in API calls, and the proxy swaps it for the real value when forwarding to `openai.com`. No real secret enters the cage.
 
 #### 4. Start a session
 

--- a/src/agentcage/scaffolds/openclaw/README.md
+++ b/src/agentcage/scaffolds/openclaw/README.md
@@ -43,7 +43,7 @@ agentcage secret set myapp OPENCLAW_GATEWAY_PASSWORD
 
 If you add `BRAVE_API_KEY`, uncomment the Brave entries in the `secret_injection` section and add `search.brave.com` to the domain allowlist in `cage.yaml`.
 
-> **Secret injection:** The config uses `secret_injection` for API keys (Anthropic, Brave). The cage container never sees the real value -- it gets a generated placeholder token like `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`, and the proxy swaps it for the real value when forwarding to the correct domain. The gateway password (`OPENCLAW_GATEWAY_PASSWORD`) stays in `podman_secrets` since it is used internally by the cage process, not in proxied HTTP requests. See [Secret injection](../../docs/reference/secret-injection.md) for details.
+> **Secret injection:** The config uses `secret_injection` for API keys (Anthropic, Brave). The cage container never sees the real value -- it gets a generated placeholder token like `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`, and the proxy swaps it for the real value when forwarding to the correct domain. The gateway password (`OPENCLAW_GATEWAY_PASSWORD`) stays in `podman_secrets` since it is used internally by the cage process, not in proxied HTTP requests. See [Secret injection](../../docs/reference/secret-injection.md) for details.
 
 ### 4. Connect and pair your browser
 

--- a/src/agentcage/scaffolds/pi/README.md
+++ b/src/agentcage/scaffolds/pi/README.md
@@ -61,7 +61,7 @@ agentcage secret set myagent ANTHROPIC_API_KEY
 agentcage cage create -c cage.yaml
 ```
 
-The scaffold uses `secret_injection` for the API key. Pi sends a generated placeholder token (e.g. `{{placeholder_anthropic_api_key_9f3a1c0b7d2e4a85}}`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
+The scaffold uses `secret_injection` for the API key. Pi sends a generated placeholder token (e.g. `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`) in API calls, and the proxy swaps it for the real value when forwarding to `anthropic.com`. No real secret enters the cage.
 
 **API key (OpenAI):**
 

--- a/tests/e2e/configs/secrets.yaml
+++ b/tests/e2e/configs/secrets.yaml
@@ -18,11 +18,14 @@ domains:
     - httpbin.org
 secret_injection:
   # No `placeholder:` — exercises declare-time generation: cage create must
-  # persist an entropic {{placeholder_my_auto_key_<16hex>}} token into the
+  # persist an entropic agentcage:secret:MY_AUTO_KEY:<32hex> token into the
   # stored config and expose it as the cage's MY_AUTO_KEY env var (phase 3.2b).
   - env: MY_AUTO_KEY
     inject_to:
       - httpbin.org
+  # Explicit, deliberately non-conforming placeholder — exercises that an
+  # explicit value is preserved verbatim (phase 3.2) and that the placeholder
+  # edit-then-restart path applies it (3.3b). validate_config warns about it.
   - env: MY_API_KEY
     placeholder: "{{MY_API_KEY}}"
     inject_to:

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -52,14 +52,14 @@ else
 fi
 
 # 3.2b: Entropic placeholder generated for a rule declared without `placeholder:`
-# (cage create persists {{placeholder_my_auto_key_<16hex>}} into the stored
+# (cage create persists agentcage:secret:MY_AUTO_KEY:<32hex> into the stored
 # config and the cage env carries it).
 e2e_timer_start
 OUTPUT=$(podman exec "${CAGE}-cage" printenv MY_AUTO_KEY 2>&1) || true
-if echo "$OUTPUT" | grep -Eq '^\{\{placeholder_my_auto_key_[0-9a-f]{16}\}\}$'; then
+if echo "$OUTPUT" | grep -Eq '^agentcage:secret:MY_AUTO_KEY:[0-9a-f]{32}$'; then
   e2e_pass "3.2b" "Entropic placeholder in cage env"
 else
-  e2e_fail "3.2b" "Entropic placeholder in cage env" "got '$OUTPUT', expected {{placeholder_my_auto_key_<16hex>}}"
+  e2e_fail "3.2b" "Entropic placeholder in cage env" "got '$OUTPUT', expected agentcage:secret:MY_AUTO_KEY:<32hex>"
 fi
 
 # 3.2c: Derived placeholders.env exists and carries the generated token
@@ -67,7 +67,7 @@ fi
 # proxy-config.yaml on every deploy/restart).
 e2e_timer_start
 DEPLOY_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/agentcage/cages/$CAGE"
-if grep -Eq '^MY_AUTO_KEY=\{\{placeholder_my_auto_key_[0-9a-f]{16}\}\}$' \
+if grep -Eq '^MY_AUTO_KEY=agentcage:secret:MY_AUTO_KEY:[0-9a-f]{32}$' \
      "$DEPLOY_DIR/cage-env/placeholders.env" 2>/dev/null; then
   e2e_pass "3.2c" "placeholders.env derived file"
 else
@@ -121,8 +121,8 @@ fi
 # placeholders via EnvironmentFile=, which podman re-reads at container
 # creation; `cage restart` regenerates the derived file from cage.yaml.
 e2e_timer_start
-NEW_PH="{{placeholder_my_api_key_e2e0000000000001}}"
-sed -i "s/{{MY_API_KEY}}/$NEW_PH/g" "$DEPLOY_DIR/cage.yaml"
+NEW_PH="agentcage:secret:MY_API_KEY:e2e0000000000001e2e0000000000001"
+sed -i "s#{{MY_API_KEY}}#$NEW_PH#g" "$DEPLOY_DIR/cage.yaml"
 agentcage cage restart "$CAGE" >/dev/null 2>&1
 wait_ready "$BASE" 60 >/dev/null || true
 OUTPUT=$(podman exec "${CAGE}-cage" printenv MY_API_KEY 2>&1) || true
@@ -196,7 +196,7 @@ echo "brand-new-value-777" | agentcage secret set "$CAGE" BRAND_NEW_KEY \
 CAGE_STARTED_4=$(podman inspect --format '{{.State.StartedAt}}' "${CAGE}-cage" 2>/dev/null)
 NEW_KEY_PH=$(agentcage cage exec "$CAGE" -- printenv BRAND_NEW_KEY 2>/dev/null | tr -d '\r') || true
 if [ "$CAGE_STARTED_3" = "$CAGE_STARTED_4" ] \
-   && echo "$NEW_KEY_PH" | grep -Eq '^\{\{placeholder_brand_new_key_[0-9a-f]{16}\}\}$'; then
+   && echo "$NEW_KEY_PH" | grep -Eq '^agentcage:secret:BRAND_NEW_KEY:[0-9a-f]{32}$'; then
   e2e_pass "3.4d" "New secret declared+usable live (exec env, no restart)"
 else
   e2e_fail "3.4d" "New secret declared+usable live (exec env, no restart)" \
@@ -238,7 +238,7 @@ OLD_PH=$(agentcage cage exec "$CAGE" -- printenv MY_AUTO_KEY 2>/dev/null | tr -d
 agentcage secret rotate-placeholders "$CAGE" MY_AUTO_KEY >/dev/null 2>&1 || true
 if wait_ready "$BASE" 60; then
   NEW_PH=$(agentcage cage exec "$CAGE" -- printenv MY_AUTO_KEY 2>/dev/null | tr -d '\r') || true
-  if echo "$NEW_PH" | grep -Eq '^\{\{placeholder_my_auto_key_[0-9a-f]{16}\}\}$' \
+  if echo "$NEW_PH" | grep -Eq '^agentcage:secret:MY_AUTO_KEY:[0-9a-f]{32}$' \
      && [ "$NEW_PH" != "$OLD_PH" ]; then
     e2e_pass "3.4f" "rotate-placeholders mints+applies a fresh token"
   else

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -249,16 +249,16 @@ else
 fi
 
 # 8.8a: cage env has a literal entropic placeholder (not the real sentinel).
-# The scaffold generates {{placeholder_anthropic_api_key_<16hex>}} at render
+# The scaffold generates agentcage:secret:ANTHROPIC_API_KEY:<32hex> at render
 # time, so the exact token differs per cage — assert the format, not a fixed
 # literal.
 e2e_timer_start
 actual=$(podman exec "${CAGE}-cage" printenv ANTHROPIC_API_KEY 2>/dev/null || echo 'not set')
-if echo "$actual" | grep -Eq '^\{\{placeholder_anthropic_api_key_[0-9a-f]{16}\}\}$'; then
+if echo "$actual" | grep -Eq '^agentcage:secret:ANTHROPIC_API_KEY:[0-9a-f]{32}$'; then
   e2e_pass "8.8a" "cage env has literal entropic placeholder"
 else
   e2e_fail "8.8a" "cage env has literal entropic placeholder" \
-    "expected {{placeholder_anthropic_api_key_<16hex>}}, got: $actual"
+    "expected agentcage:secret:ANTHROPIC_API_KEY:<32hex>, got: $actual"
 fi
 
 # 8.8b: proxy records an injection attempt on the injected domain.

--- a/tests/test_derived_secret_state.py
+++ b/tests/test_derived_secret_state.py
@@ -27,9 +27,9 @@ CFG = """\
     dns_servers: ["1.1.1.1"]
     secret_injection:
       - env: KEY_A
-        placeholder: "{{{{placeholder_key_a_0123456789abcdef}}}}"
+        placeholder: "agentcage:secret:KEY_A:0123456789abcdef0123456789abcdef"
       - env: KEY_B
-        placeholder: "{{{{placeholder_key_b_fedcba9876543210}}}}"
+        placeholder: "agentcage:secret:KEY_B:fedcba9876543210fedcba9876543210"
       - env: NOT_FILLED
 """
 
@@ -41,8 +41,8 @@ class TestSavePlaceholdersEnv:
         _seed(state, "c1", CFG.format(name="c1"))
         path = state.save_placeholders_env("c1")
         content = open(path).read()
-        assert "KEY_A={{placeholder_key_a_0123456789abcdef}}\n" in content
-        assert "KEY_B={{placeholder_key_b_fedcba9876543210}}\n" in content
+        assert "KEY_A=agentcage:secret:KEY_A:0123456789abcdef0123456789abcdef\n" in content
+        assert "KEY_B=agentcage:secret:KEY_B:fedcba9876543210fedcba9876543210\n" in content
         assert "NOT_FILLED" not in content
 
     def test_rewrite_in_place_keeps_inode(self, patch_state_dirs):
@@ -103,7 +103,7 @@ class TestVmLocalPlaceholderPaths:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: MY_KEY
-                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+                placeholder: "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
         """))
         cfg = load_config(str(p))
         units = generate_quadlets(
@@ -154,9 +154,9 @@ class TestEgressStaging:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: KEY_A
-                placeholder: "{{placeholder_key_a_0123456789abcdef}}"
+                placeholder: "agentcage:secret:KEY_A:0123456789abcdef0123456789abcdef"
               - env: KEY_B
-                placeholder: "{{placeholder_key_b_fedcba9876543210}}"
+                placeholder: "agentcage:secret:KEY_B:fedcba9876543210fedcba9876543210"
         """))
         cfg = load_config(str(p))
         units = generate_quadlets(

--- a/tests/test_exec_placeholder_injection.py
+++ b/tests/test_exec_placeholder_injection.py
@@ -27,7 +27,7 @@ def _seed(state, name, rules_yaml=""):
 RULES = """\
 secret_injection:
   - env: MY_KEY
-    placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+    placeholder: "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
 """
 
 
@@ -38,7 +38,7 @@ class TestCurrentPlaceholders:
         state = patch_state_dirs
         _seed(state, "c1", RULES)
         assert current_placeholders("c1") == [
-            ("MY_KEY", "{{placeholder_my_key_0123456789abcdef}}"),
+            ("MY_KEY", "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"),
         ]
 
     def test_missing_cage_returns_empty(self, patch_state_dirs):
@@ -61,7 +61,7 @@ class TestExecArgvInjection:
         backend = ContainerBackend()
         argv = backend.exec_argv("c1", "cage", ["bash"])
         joined = " ".join(argv)
-        assert "--env MY_KEY={{placeholder_my_key_0123456789abcdef}}" in joined
+        assert "--env MY_KEY=agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef" in joined
         # env flags must precede the container name
         assert argv.index("--env") < argv.index("c1-cage")
 
@@ -80,7 +80,7 @@ class TestExecArgvInjection:
         backend = VmBackend()
         argv = backend.exec_argv("c1", "cage", ["bash"])
         joined = " ".join(argv)
-        assert "--env MY_KEY={{placeholder_my_key_0123456789abcdef}}" in joined
+        assert "--env MY_KEY=agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef" in joined
 
     def test_no_rules_leaves_argv_unchanged(self, patch_state_dirs):
         from agentcage.backends.container import ContainerBackend
@@ -207,7 +207,7 @@ class TestSecretSetDeclare:
         rules = raw["secret_injection"]
         assert rules[0]["env"] == "NEW_KEY"
         assert re.match(
-            r"^\{\{placeholder_new_key_[0-9a-f]{16}\}\}$",
+            r"^agentcage:secret:NEW_KEY:[0-9a-f]{32}$",
             rules[0]["placeholder"],
         )
         assert "Declared secret_injection rule" in result.output
@@ -257,7 +257,7 @@ class TestSecretSetDeclare:
         rules = state.load_raw_config("c1")["secret_injection"]
         assert len(rules) == 1
         assert rules[0]["placeholder"] == \
-            "{{placeholder_my_key_0123456789abcdef}}"
+            "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
         assert "already exists" in result.output
 
     @patch("agentcage.cli._apply_secret_live_or_restart")

--- a/tests/test_live_secret_apply.py
+++ b/tests/test_live_secret_apply.py
@@ -20,7 +20,7 @@ def injector(monkeypatch, tmp_path):
     return si.SecretInjector(), tmp_path
 
 
-RULE = {"env": "MY_KEY", "placeholder": "{{placeholder_my_key_0123456789abcdef}}"}
+RULE = {"env": "MY_KEY", "placeholder": "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"}
 
 
 class TestInjectorFilePrecedence:
@@ -199,7 +199,7 @@ class TestSecretSetLiveFlow:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: MY_KEY
-                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+                placeholder: "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
         """))
         meta = state.load_metadata("c1")
         meta["agentcage_version"] = "0.22.22"
@@ -410,7 +410,7 @@ class TestAddonReloadReconfiguresInjector:
         monkeypatch.setattr(si, "_SECRETS_DIR", secrets_dir)
         cfg_path = tmp_path / "config.yaml"
         rule_a = {"env": "KEY_A",
-                  "placeholder": "{{placeholder_key_a_0123456789abcdef}}"}
+                  "placeholder": "agentcage:secret:KEY_A:0123456789abcdef0123456789abcdef"}
         self._write_cfg(cfg_path, [rule_a])
         (secrets_dir / "KEY_A").write_text("a-v1\n")
         monkeypatch.setattr(addon_mod, "CONFIG_PATH", str(cfg_path))
@@ -423,7 +423,7 @@ class TestAddonReloadReconfiguresInjector:
         # Live update: new rule declared + value staged + existing value
         # re-staged; the config rewrite bumps the mtime.
         rule_b = {"env": "KEY_B",
-                  "placeholder": "{{placeholder_key_b_fedcba9876543210}}"}
+                  "placeholder": "agentcage:secret:KEY_B:fedcba9876543210fedcba9876543210"}
         (secrets_dir / "KEY_A").write_text("a-v2\n")
         (secrets_dir / "KEY_B").write_text("b-v1\n")
         self._write_cfg(cfg_path, [rule_a, rule_b])
@@ -448,7 +448,7 @@ class TestAddonReloadReconfiguresInjector:
         monkeypatch.setattr(si, "_SECRETS_DIR", secrets_dir)
         cfg_path = tmp_path / "config.yaml"
         rule = {"env": "KEY_A",
-                "placeholder": "{{placeholder_key_a_0123456789abcdef}}"}
+                "placeholder": "agentcage:secret:KEY_A:0123456789abcdef0123456789abcdef"}
         self._write_cfg(cfg_path, [rule])
         (secrets_dir / "KEY_A").write_text("a-v1\n")
         monkeypatch.setattr(addon_mod, "CONFIG_PATH", str(cfg_path))

--- a/tests/test_placeholder_entropy.py
+++ b/tests/test_placeholder_entropy.py
@@ -23,7 +23,7 @@ from agentcage.config import (
     validate_config,
 )
 
-TOKEN_RE = re.compile(r"^\{\{placeholder_[a-z0-9_]+_[0-9a-f]{16}\}\}$")
+TOKEN_RE = re.compile(r"^agentcage:secret:[A-Za-z0-9_]+:[0-9a-f]{32}$")
 
 
 class TestGeneratePlaceholder:
@@ -31,7 +31,8 @@ class TestGeneratePlaceholder:
     def test_format(self):
         tok = generate_placeholder("GH_TOKEN")
         assert TOKEN_RE.match(tok)
-        assert tok.startswith("{{placeholder_gh_token_")
+        # Env name preserved verbatim (not lowercased) after the prefix.
+        assert tok.startswith("agentcage:secret:GH_TOKEN:")
 
     def test_unique_per_call(self):
         assert generate_placeholder("KEY") != generate_placeholder("KEY")
@@ -53,12 +54,12 @@ class TestFillRawPlaceholders:
 
     def test_carry_over_from_prev(self):
         prev = {"secret_injection": [
-            {"env": "GH_TOKEN", "placeholder": "{{placeholder_gh_token_aaaaaaaaaaaaaaaa}}"},
+            {"env": "GH_TOKEN", "placeholder": "agentcage:secret:GH_TOKEN:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
         ]}
         raw = {"secret_injection": [{"env": "GH_TOKEN"}, {"env": "NEW_KEY"}]}
         assert fill_raw_placeholders(raw, prev_raw=prev) is True
         rules = raw["secret_injection"]
-        assert rules[0]["placeholder"] == "{{placeholder_gh_token_aaaaaaaaaaaaaaaa}}"
+        assert rules[0]["placeholder"] == "agentcage:secret:GH_TOKEN:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         assert TOKEN_RE.match(rules[1]["placeholder"])
         assert rules[1]["placeholder"] != rules[0]["placeholder"]
 
@@ -113,20 +114,23 @@ class TestParserAcceptsOmittedPlaceholder:
         assert "MY_KEY" not in cfg.container.podman_secrets
         assert "MY_KEY" not in cfg.container.env
 
-    def test_guessable_placeholder_warns(self, tmp_path):
-        cfg = self._load(tmp_path, """\
-            name: test
-            container:
-              image: localhost/test:latest
-            dns_servers: ["1.1.1.1"]
-            secret_injection:
-              - env: GH_TOKEN
-                placeholder: "{{GH_TOKEN}}"
-        """)
-        warnings = validate_config(cfg)
-        assert any("guessable" in w for w in warnings)
+    def test_nonconforming_placeholder_warns(self, tmp_path):
+        """Any placeholder outside the agentcage:secret:* form warns —
+        guessable bare {{ENV}}, a custom credential-format fake, anything."""
+        for bad in ("{{GH_TOKEN}}", "ghp_fakefakefake", "sk-test-0001"):
+            cfg = self._load(tmp_path, f"""\
+                name: test
+                container:
+                  image: localhost/test:latest
+                dns_servers: ["1.1.1.1"]
+                secret_injection:
+                  - env: GH_TOKEN
+                    placeholder: "{bad}"
+            """)
+            warnings = validate_config(cfg)
+            assert any("agentcage:secret:" in w for w in warnings), bad
 
-    def test_entropic_placeholder_does_not_warn(self, tmp_path):
+    def test_conforming_placeholder_does_not_warn(self, tmp_path):
         cfg = self._load(tmp_path, """\
             name: test
             container:
@@ -134,10 +138,10 @@ class TestParserAcceptsOmittedPlaceholder:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: GH_TOKEN
-                placeholder: "{{placeholder_gh_token_0123456789abcdef}}"
+                placeholder: "agentcage:secret:GH_TOKEN:0123456789abcdef0123456789abcdef"
         """)
         warnings = validate_config(cfg)
-        assert not any("guessable" in w for w in warnings)
+        assert not any("agentcage:secret:" in w for w in warnings)
 
 
 class TestStateFillPlaceholders:
@@ -235,7 +239,7 @@ class TestQuadletEmptyPlaceholderGuard:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: MY_KEY
-                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+                placeholder: "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
         """))
         cfg = load_config(str(p))
         units = generate_quadlets(
@@ -277,7 +281,7 @@ class TestInjectorEmptyPlaceholderGuard:
         inj = SecretInjector()
         inj.configure([
             {"env": "MY_KEY",
-             "placeholder": "{{placeholder_my_key_0123456789abcdef}}"},
+             "placeholder": "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"},
         ])
         assert len(inj.rules) == 1
 
@@ -370,10 +374,10 @@ class TestSecretListPlaceholderColumn:
             dns_servers: ["1.1.1.1"]
             secret_injection:
               - env: MY_KEY
-                placeholder: "{{placeholder_my_key_0123456789abcdef}}"
+                placeholder: "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef"
         """))
         cfg = load_config(str(p))
         _render_secret_list(cfg, {"MY_KEY"})
         out = capsys.readouterr().out
         assert "PLACEHOLDER" in out
-        assert "{{placeholder_my_key_0123456789abcdef}}" in out
+        assert "agentcage:secret:MY_KEY:0123456789abcdef0123456789abcdef" in out

--- a/tests/test_rotate_placeholders.py
+++ b/tests/test_rotate_placeholders.py
@@ -14,7 +14,7 @@ from click.testing import CliRunner
 
 from agentcage.cli import main
 
-TOKEN_RE = re.compile(r"^\{\{placeholder_[a-z0-9_]+_[0-9a-f]{16}\}\}$")
+TOKEN_RE = re.compile(r"^agentcage:secret:[A-Za-z0-9_]+:[0-9a-f]{32}$")
 
 
 def _seed(state, name, body: str):
@@ -163,11 +163,11 @@ class TestRotatePlaceholders:
         mock_backend.return_value.is_running.return_value = False
 
         before = validate_config(load_config(str(state.stored_config_path("c1"))))
-        assert any("guessable" in w for w in before)
+        assert any("agentcage:secret:" in w for w in before)
 
         result = CliRunner().invoke(
             main, ["secret", "rotate-placeholders", "c1"],
         )
         assert result.exit_code == 0, result.output
         after = validate_config(load_config(str(state.stored_config_path("c1"))))
-        assert not any("guessable" in w for w in after)
+        assert not any("agentcage:secret:" in w for w in after)

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -167,7 +167,7 @@ class TestCodingAgentScaffolds:
         cfg_text = render_config("test-cc", scaffold="claude-code")
         assert "#- env: CLAUDE_CODE_OAUTH_TOKEN" in cfg_text
         assert re.search(
-            r"\{\{placeholder_claude_code_oauth_token_[0-9a-f]{16}\}\}",
+            r"agentcage:secret:CLAUDE_CODE_OAUTH_TOKEN:[0-9a-f]{32}",
             cfg_text,
         )
         parsed = yaml.safe_load(cfg_text)


### PR DESCRIPTION
## Summary

Changes the secret-injection placeholder format from `{{placeholder_<env>_<16 hex>}}` to **`agentcage:secret:<ENV>:<32 hex chars>`** (e.g. `agentcage:secret:ANTHROPIC_API_KEY:9f3c1a7e8b204d56c1e0a4f7b2d8369a`), and adds validation that every placeholder must be in the `agentcage:secret:*` shape.

Stacks conceptually on the entropic-placeholders work (#258) and `rotate-placeholders` (#263).

## What changed

- **Format** (`generate_placeholder`): `agentcage:secret:<ENV>:<token_hex(16)>` — **128 bits** of entropy (was 64), env name preserved verbatim (no lowercasing), no `{{ }}` delimiters. The proxy matches placeholders as literal strings, so the braces were never required; the colon-namespaced prefix makes a placeholder **self-identifying** and even less likely to collide with legitimate outbound content.
- **Validation** (`validate_config`): warns when any `secret_injection` placeholder doesn't start with `agentcage:secret:` — this replaces the narrower bare-`{{ENV}}` guessable check and now also flags arbitrary custom values. It points at `agentcage secret rotate-placeholders` to mint a conforming token.
- All generators emit the new format: omitted-placeholder fill, the four coding-agent scaffolds (render-time `placeholder()` helper), `secret set --declare`, and `secret rotate-placeholders`.

## Compatibility

A **warning, not a hard error.** Existing cages keep working untouched — their stored `{{...}}` placeholders are still matched verbatim by the proxy; nothing is rewritten until the operator rotates or recreates. Explicit `placeholder:` values remain accepted (some clients validate credential format before sending) — they just trip the warning. The migration path is one command: `agentcage secret rotate-placeholders <cage>`.

## Testing

- Full unit suite: **1765 passed** (8 `test_egress_image` deselected — environmental). Updated `TOKEN_RE`/literals/assertions across `test_placeholder_entropy`, `test_rotate_placeholders`, `test_derived_secret_state`, `test_exec_placeholder_injection`, `test_scaffolds`, `test_live_secret_apply`; the guessable-warning test became a non-conforming-warning test (bare `{{ENV}}`, `ghp_…`, `sk-…` all warn).
- e2e phase 3: **21/21** on podman 5.x rootless (regexes updated to the new format).
- Manual operator check: auto-generated token renders as `agentcage:secret:MY_AUTO_KEY:<32hex>`; `cage create` warns on an explicit non-conforming `{{MY_API_KEY}}` with the rotate hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)