### PR TITLE
fix(secrets): inject/redact placeholders inside HTTP Basic auth headers

### DIFF
--- a/src/agentcage/data/proxy/secret_injector.py
+++ b/src/agentcage/data/proxy/secret_injector.py
@@ -8,6 +8,8 @@ inspector chain.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import os
 from dataclasses import dataclass, field
@@ -60,6 +62,37 @@ _SECRETS_DIR = Path(
 # ``?api_key=``, Firebase ``?auth=``) or the request body (Plaid) are outside
 # the header channel and need ``inject_body: true``.
 AUTH_HEADER_KEYWORDS: tuple[str, ...] = ("auth", "key", "token")
+
+
+def _rewrite_basic_auth(value: str, find: str, replace: str) -> tuple[str, bool]:
+    """Rewrite ``find`` → ``replace`` inside an HTTP **Basic** credential.
+
+    A literal substring match can't reach a placeholder (or a real secret)
+    carried in ``Authorization: Basic base64("user:<secret>")`` — git over
+    HTTPS sends exactly this, base64-encoding the token so it never appears
+    verbatim in the header value. (The ``Bearer``/``token`` channel used by
+    REST clients carries the credential in cleartext, which the literal match
+    already handles.)
+
+    Decode the base64, substitute in the decoded ``user:pass`` text, and
+    re-encode. Returns ``(new_value, changed)``; ``(value, False)`` when the
+    header isn't Basic, isn't decodable base64/UTF-8, or doesn't contain
+    ``find`` — so the caller's literal path stays authoritative for every
+    other case.
+    """
+    parts = value.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "basic":
+        return value, False
+    try:
+        decoded = base64.b64decode(parts[1].strip(), validate=True).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return value, False
+    if find not in decoded:
+        return value, False
+    new_b64 = base64.b64encode(
+        decoded.replace(find, replace).encode("utf-8")
+    ).decode("ascii")
+    return f"{parts[0]} {new_b64}", True
 
 
 @dataclass
@@ -229,12 +262,18 @@ class SecretInjector:
         return False
 
     def _find_placeholder(self, flow: http.HTTPFlow, rule: InjectionRule) -> bool:
-        """Check if a rule's placeholder is present in the flow."""
+        """Check if a rule's placeholder is present in the flow.
+
+        Also detects a placeholder carried base64-encoded inside an
+        ``Authorization: Basic`` header (git over HTTPS) — otherwise the
+        per-rule gate in ``inject_request`` would skip the rule before the
+        Basic-aware header substitution ever runs.
+        """
         ph = rule.placeholder
         if ph in flow.request.url:
             return True
         for v in flow.request.headers.values():
-            if ph in v:
+            if ph in v or _rewrite_basic_auth(v, ph, ph)[1]:
                 return True
         if flow.request.content and ph.encode() in flow.request.content:
             return True
@@ -379,6 +418,14 @@ class SecretInjector:
                     if ph in v:
                         flow.request.headers[k] = v.replace(ph, value)
                         injected = True
+                        continue
+                    # git-over-HTTPS sends the token base64-encoded inside
+                    # `Authorization: Basic ...`, where the literal match
+                    # above can't see it. Decode/substitute/re-encode.
+                    new_v, changed = _rewrite_basic_auth(v, ph, value)
+                    if changed:
+                        flow.request.headers[k] = new_v
+                        injected = True
 
             if injected:
                 names.append(rule.name)
@@ -416,6 +463,11 @@ class SecretInjector:
                 v = flow.request.headers[k]
                 if real in v:
                     flow.request.headers[k] = v.replace(real, ph)
+                    found = True
+                    continue
+                new_v, changed = _rewrite_basic_auth(v, real, ph)
+                if changed:
+                    flow.request.headers[k] = new_v
                     found = True
 
             # Redact body
@@ -481,6 +533,11 @@ class SecretInjector:
                 if real in v:
                     flow.request.headers[k] = v.replace(real, ph)
                     found = True
+                    continue
+                new_v, changed = _rewrite_basic_auth(v, real, ph)
+                if changed:
+                    flow.request.headers[k] = new_v
+                    found = True
 
             # Redact body — only when the bytes are actually present;
             # avoid touching ``flow.request.content`` otherwise so we
@@ -526,6 +583,11 @@ class SecretInjector:
                 v = flow.response.headers[k]
                 if real in v:
                     flow.response.headers[k] = v.replace(real, ph)
+                    found = True
+                    continue
+                new_v, changed = _rewrite_basic_auth(v, real, ph)
+                if changed:
+                    flow.response.headers[k] = new_v
                     found = True
 
             # Redact response body

--- a/tests/test_secret_injector.py
+++ b/tests/test_secret_injector.py
@@ -1476,3 +1476,114 @@ class TestConfigureWithTransform:
             assert len(inj.rules) == 0
         finally:
             _REGISTRY.pop("test-broken", None)
+
+
+# ── Basic-auth (base64) injection / redaction — git over HTTPS ──────────────
+#
+# git sends `Authorization: Basic base64("x-access-token:<secret>")`, so the
+# placeholder/secret never appears verbatim in the header. These tests guard
+# the base64-aware path that lets git-over-HTTPS auth work (regression: the
+# literal-only matcher injected for api.github.com `token`/`Bearer` but not for
+# github.com git endpoints, so private `git pull` failed with "invalid
+# credentials").
+
+import base64 as _b64
+
+from secret_injector import _rewrite_basic_auth
+
+
+def _basic(userinfo: str) -> str:
+    return "Basic " + _b64.b64encode(userinfo.encode()).decode()
+
+
+def _decode_basic(value: str) -> str:
+    return _b64.b64decode(value.split(" ", 1)[1]).decode()
+
+
+def _gh_rule(placeholder="agentcage:secret:GH_TOKEN:deadbeef",
+             real="ghp_realtokenvalue000000000000000000000000"):
+    return InjectionRule(
+        name="GH_TOKEN", placeholder=placeholder, real_value=real,
+        inject_to=["github.com"],
+    )
+
+
+class TestRewriteBasicAuthHelper:
+    def test_substitutes_inside_basic(self):
+        rule = _gh_rule()
+        v = _basic(f"x-access-token:{rule.placeholder}")
+        out, changed = _rewrite_basic_auth(v, rule.placeholder, rule.real_value)
+        assert changed is True
+        assert _decode_basic(out) == f"x-access-token:{rule.real_value}"
+
+    def test_non_basic_unchanged(self):
+        v = f"Bearer agentcage:secret:GH_TOKEN:deadbeef"
+        out, changed = _rewrite_basic_auth(v, "agentcage:secret:GH_TOKEN:deadbeef", "X")
+        assert (out, changed) == (v, False)
+
+    def test_invalid_base64_unchanged(self):
+        v = "Basic not!!base64!!"
+        out, changed = _rewrite_basic_auth(v, "anything", "X")
+        assert (out, changed) == (v, False)
+
+    def test_needle_absent_unchanged(self):
+        v = _basic("user:somethingelse")
+        out, changed = _rewrite_basic_auth(v, "agentcage:secret:GH_TOKEN:deadbeef", "X")
+        assert (out, changed) == (v, False)
+
+
+class TestBasicAuthInjection:
+    def test_injects_into_basic_auth_header(self):
+        rule = _gh_rule()
+        inj = _injector_with_rules([rule])
+        flow = _make_flow(
+            url="https://github.com/TrueLayer/repo.git/info/refs",
+            host="github.com",
+            headers={"Authorization": _basic(f"x-access-token:{rule.placeholder}")},
+        )
+        names = inj.inject_request(flow)
+        assert names == ["GH_TOKEN"]
+        assert _decode_basic(flow.request.headers["Authorization"]) == (
+            f"x-access-token:{rule.real_value}"
+        )
+
+    def test_bearer_literal_path_still_works(self):
+        rule = _gh_rule()
+        inj = _injector_with_rules([rule])
+        flow = _make_flow(
+            url="https://github.com/x", host="github.com",
+            headers={"Authorization": f"token {rule.placeholder}"},
+        )
+        names = inj.inject_request(flow)
+        assert names == ["GH_TOKEN"]
+        assert flow.request.headers["Authorization"] == f"token {rule.real_value}"
+
+    def test_unauthorized_domain_not_injected(self):
+        rule = _gh_rule()
+        inj = _injector_with_rules([rule])
+        ph_header = _basic(f"x-access-token:{rule.placeholder}")
+        flow = _make_flow(
+            url="https://evil.example/x", host="evil.example",
+            headers={"Authorization": ph_header},
+        )
+        names = inj.inject_request(flow)
+        assert names == []
+        assert flow.request.headers["Authorization"] == ph_header  # untouched
+
+
+class TestBasicAuthRedaction:
+    def test_redact_request_scrubs_basic_auth(self):
+        # After injection the real token rides base64-encoded in the Basic
+        # header; redact_request must restore placeholder form so capture.jsonl
+        # never serializes the raw token (even base64-encoded).
+        rule = _gh_rule()
+        inj = _injector_with_rules([rule])
+        flow = _make_flow(
+            url="https://github.com/x", host="github.com",
+            headers={"Authorization": _basic(f"x-access-token:{rule.real_value}")},
+        )
+        names = inj.redact_request(flow)
+        assert names == ["GH_TOKEN"]
+        assert _decode_basic(flow.request.headers["Authorization"]) == (
+            f"x-access-token:{rule.placeholder}"
+        )


### PR DESCRIPTION
## Problem

The strict-mode secret injector matched a placeholder only as a **literal substring** of a credential header value. git-over-HTTPS sends its credential as:

```
Authorization: Basic base64("x-access-token:<placeholder>")
```

so the placeholder never appears verbatim — it rides **base64-encoded** inside the blob. As a result, token injection worked for the `token`/`Bearer` channel (`api.github.com`, the `gh` CLI) but **not** for `github.com` git endpoints. A private `git pull` / `clone` / `ls-remote` went out carrying the literal placeholder and GitHub rejected it with `remote: invalid credentials`.

Notably this never surfaced as a *blocked* request in the audit log — every `github.com` request was `allowed`; the failure was a silent auth rejection at GitHub.

## Fix

Add a base64-aware `Basic` auth path (`_rewrite_basic_auth`): decode `Authorization: Basic ...`, substitute in the decoded `user:pass`, and re-encode. Wired into:

- the strict-mode injection header loop, and `_find_placeholder` (the per-rule gate in `inject_request`, which would otherwise skip the rule before the Basic-aware substitution ran);
- **all redaction paths** (`redact_request`, `redact_response`, `_redact_request`) — so the real token can't leak into the world-readable `capture.jsonl` base64-encoded.

Non-`Basic` and undecodable values fall through to the existing literal behavior unchanged.

## Tests

`tests/test_secret_injector.py` gains coverage for the helper (substitute / non-Basic / invalid-base64 / needle-absent), Basic-auth injection (incl. unauthorized-domain skip and that the `Bearer`/`token` literal path still works), and Basic-auth redaction (real token base64-encoded in the header is restored to placeholder form). Full file: **133 passed**.

## Verification

Built the egress with the patch and ran it against a live apple-container cage: a private `git ls-remote https://github.com/...` now authenticates and returns the HEAD SHA instead of failing with `invalid credentials`, and the real token is absent (raw and base64) from the audit/capture output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)