### PR TITLE
fix(config): detect DNS via scutil on macOS when resolv.conf is loopback-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`agentcage run` no longer dies at startup on macOS hosts whose `/etc/resolv.conf` holds only a loopback resolver.** DNS auto-detection (`_host_dns_servers`) read `/etc/resolv.conf`, dropped loopback addresses (unreachable from inside containers), and — when nothing usable remained — fell back to systemd-resolved's `/run/systemd/resolve/resolv.conf`. That fallback is Linux-only. On a Mac running a local resolver (Cloudflare WARP, a corporate VPN client, dnsmasq, Little Snitch, etc.), `/etc/resolv.conf` points at `127.0.0.1`, the systemd path doesn't exist, and startup hard-failed with `Could not detect usable DNS servers`. macOS doesn't consult `/etc/resolv.conf` for resolution anyway (the file itself says so) — the source of truth is the System Configuration framework. Detection now falls back to `scutil --dns` on macOS, parsing the real upstream `nameserver[N]` entries (deduped, loopback dropped), before raising. Setting `dns_servers` explicitly in the config still bypasses auto-detection entirely.
+
 ## [0.25.2] - 2026-06-18
 
 ### Fixed

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -6,6 +6,7 @@ import ipaddress
 import os
 import platform
 import re
+import subprocess
 from dataclasses import dataclass, field
 
 import yaml
@@ -449,14 +450,47 @@ def _read_nameservers(path: str) -> list[str]:
 # /etc/resolv.conf points at the 127.0.0.53 stub listener.
 _RESOLVED_CONF = "/run/systemd/resolve/resolv.conf"
 
+# macOS does not consult /etc/resolv.conf for resolution (the file even says
+# so) — the System Configuration framework is the source of truth, exposed
+# via `scutil --dns`. Its output lists upstreams as `nameserver[N] : <addr>`.
+_SCUTIL_NS_RE = re.compile(r"^\s*nameserver\[\d+\]\s*:\s*(\S+)")
+
+
+def _scutil_dns_servers() -> list[str]:
+    """Return non-loopback upstream nameservers from `scutil --dns` (macOS).
+
+    macOS may leave /etc/resolv.conf pointing at a loopback resolver (a local
+    VPN client, dnsmasq, Cloudflare WARP, etc.), which is unreachable from
+    inside containers. `scutil --dns` reports the real upstreams. Returns an
+    empty list if scutil is unavailable or yields nothing usable.
+    """
+    try:
+        out = subprocess.run(
+            ["scutil", "--dns"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+    seen: dict[str, None] = {}
+    for line in out.splitlines():
+        m = _SCUTIL_NS_RE.match(line)
+        if m and not _is_loopback(m.group(1)):
+            # scutil repeats each resolver across resolver scopes; dedupe
+            # while preserving first-seen order.
+            seen.setdefault(m.group(1), None)
+    return list(seen)
+
 
 def _host_dns_servers() -> list[str]:
-    """Read nameservers from /etc/resolv.conf.
+    """Detect the host's usable upstream DNS servers.
 
     Loopback addresses (e.g. 127.0.0.53 from systemd-resolved) are filtered
     out because they are unreachable from inside containers.  When all
-    nameservers are loopback, the real upstreams are read from
-    /run/systemd/resolve/resolv.conf.
+    nameservers in /etc/resolv.conf are loopback, the real upstreams are read
+    from /run/systemd/resolve/resolv.conf (systemd-resolved) on Linux, or from
+    `scutil --dns` on macOS.
 
     Raises RuntimeError if no usable DNS servers can be found.  Set
     ``dns_servers`` explicitly in the config to avoid auto-detection.
@@ -471,6 +505,18 @@ def _host_dns_servers() -> list[str]:
     resolved = [s for s in resolved if not _is_loopback(s)]
     if resolved:
         return resolved
+    # On macOS /etc/resolv.conf is not authoritative; ask the System
+    # Configuration framework for the real upstreams.
+    if platform.system() == "Darwin":
+        scutil = _scutil_dns_servers()
+        if scutil:
+            return scutil
+        raise RuntimeError(
+            "Could not detect usable DNS servers: /etc/resolv.conf contains "
+            "only loopback addresses and `scutil --dns` reported no usable "
+            "upstream resolvers. Set dns_servers explicitly in your agentcage "
+            "config."
+        )
     raise RuntimeError(
         "Could not detect usable DNS servers: /etc/resolv.conf contains only "
         "loopback addresses (e.g. 127.0.0.53 from systemd-resolved) and "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ import textwrap
 
 import pytest
 
-from agentcage.config import Config, ContainerConfig, DomainConfig, LoggingConfig, _host_dns_servers, _RESOLVED_CONF, _VALID_LEVELS, load_config, validate_config
+from agentcage.config import Config, ContainerConfig, DomainConfig, LoggingConfig, _host_dns_servers, _RESOLVED_CONF, _scutil_dns_servers, _VALID_LEVELS, load_config, validate_config
 
 # These assert that a valid config yields NO validation warnings. On macOS the
 # default isolation is apple-container, which legitimately warns (e.g.
@@ -818,8 +818,16 @@ class TestValidateConfig:
 
 
 class TestHostDnsServers:
-    def _patch_resolv(self, monkeypatch, tmp_path, etc_text, resolved_text=None):
-        """Mock /etc/resolv.conf and optionally _RESOLVED_CONF."""
+    def _patch_resolv(
+        self, monkeypatch, tmp_path, etc_text, resolved_text=None,
+        scutil_servers=(), system="Linux",
+    ):
+        """Mock /etc/resolv.conf, _RESOLVED_CONF, scutil, and platform.
+
+        Defaults to Linux with no scutil upstreams so the existing
+        resolv.conf/systemd-resolved tests stay deterministic regardless of
+        the host the suite runs on (notably real macOS dev machines).
+        """
         etc_file = tmp_path / "etc-resolv.conf"
         etc_file.write_text(etc_text)
         resolved_file = None
@@ -838,6 +846,11 @@ class TestHostDnsServers:
             return _real_open(path, *a, **kw)
 
         monkeypatch.setattr("builtins.open", _fake_open)
+        monkeypatch.setattr(
+            "agentcage.config._scutil_dns_servers",
+            lambda: list(scutil_servers),
+        )
+        monkeypatch.setattr("agentcage.config.platform.system", lambda: system)
 
     def test_parses_resolv_conf(self, tmp_path, monkeypatch):
         self._patch_resolv(
@@ -861,6 +874,8 @@ class TestHostDnsServers:
                 raise OSError("No such file")
             return _real_open(path, *a, **kw)
         monkeypatch.setattr("builtins.open", _fake_open)
+        monkeypatch.setattr("agentcage.config._scutil_dns_servers", list)
+        monkeypatch.setattr("agentcage.config.platform.system", lambda: "Linux")
         with pytest.raises(RuntimeError, match="Could not detect usable DNS"):
             _host_dns_servers()
 
@@ -902,6 +917,73 @@ class TestHostDnsServers:
         )
         with pytest.raises(RuntimeError, match="Could not detect usable DNS"):
             _host_dns_servers()
+
+    def test_macos_loopback_falls_back_to_scutil(self, tmp_path, monkeypatch):
+        """macOS with a loopback /etc/resolv.conf reads upstreams from scutil."""
+        self._patch_resolv(
+            monkeypatch, tmp_path,
+            etc_text="nameserver 127.0.0.1\nsearch localdomain\n",
+            scutil_servers=["192.168.1.1", "8.8.8.8"],
+            system="Darwin",
+        )
+        assert _host_dns_servers() == ["192.168.1.1", "8.8.8.8"]
+
+    def test_macos_resolv_conf_wins_over_scutil(self, tmp_path, monkeypatch):
+        """A usable /etc/resolv.conf short-circuits before scutil is consulted."""
+        self._patch_resolv(
+            monkeypatch, tmp_path,
+            etc_text="nameserver 9.9.9.9\n",
+            scutil_servers=["192.168.1.1"],
+            system="Darwin",
+        )
+        assert _host_dns_servers() == ["9.9.9.9"]
+
+    def test_macos_no_scutil_servers_raises(self, tmp_path, monkeypatch):
+        """macOS loopback + scutil yields nothing → actionable error."""
+        self._patch_resolv(
+            monkeypatch, tmp_path,
+            etc_text="nameserver 127.0.0.1\n",
+            scutil_servers=[],
+            system="Darwin",
+        )
+        with pytest.raises(RuntimeError, match="scutil --dns"):
+            _host_dns_servers()
+
+
+class TestScutilDnsServers:
+    def _patch_scutil(self, monkeypatch, stdout, exc=None):
+        import subprocess as _subprocess
+
+        def _fake_run(*a, **kw):
+            if exc is not None:
+                raise exc
+            return _subprocess.CompletedProcess(a[0], 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr("agentcage.config.subprocess.run", _fake_run)
+
+    def test_parses_and_dedupes(self, monkeypatch):
+        self._patch_scutil(
+            monkeypatch,
+            stdout=(
+                "resolver #1\n"
+                "  nameserver[0] : 192.168.1.1\n"
+                "  nameserver[1] : 8.8.8.8\n"
+                "resolver #2\n"
+                "  nameserver[0] : 192.168.1.1\n"
+            ),
+        )
+        assert _scutil_dns_servers() == ["192.168.1.1", "8.8.8.8"]
+
+    def test_filters_loopback(self, monkeypatch):
+        self._patch_scutil(
+            monkeypatch,
+            stdout="  nameserver[0] : 127.0.0.1\n  nameserver[1] : 1.1.1.1\n",
+        )
+        assert _scutil_dns_servers() == ["1.1.1.1"]
+
+    def test_missing_binary_returns_empty(self, monkeypatch):
+        self._patch_scutil(monkeypatch, stdout="", exc=FileNotFoundError("scutil"))
+        assert _scutil_dns_servers() == []
 
 
 class TestDomainConfigNewFormat:


### PR DESCRIPTION
## Problem

`agentcage run` dies at startup on a macOS host whose `/etc/resolv.conf` contains only a loopback nameserver:

```
RuntimeError: Could not detect usable DNS servers: /etc/resolv.conf contains only
loopback addresses (e.g. 127.0.0.53 from systemd-resolved) and
/run/systemd/resolve/resolv.conf is missing or empty.
```

This happens whenever a Mac runs a **local DNS resolver** — Cloudflare WARP, a corporate VPN client, dnsmasq, Little Snitch, etc. — which leaves `/etc/resolv.conf` pointing at `127.0.0.1`.

## Root cause

`_host_dns_servers()` reads `/etc/resolv.conf`, drops loopback addresses (unreachable from inside containers), and when nothing usable remains falls back to systemd-resolved's `/run/systemd/resolve/resolv.conf`. That fallback is **Linux-only** — on macOS the file doesn't exist, so detection raises.

macOS doesn't consult `/etc/resolv.conf` for resolution at all (the file itself says so). The authoritative source is the System Configuration framework, exposed via `scutil --dns`. It happens to work on most Macs only because `/etc/resolv.conf` usually mirrors a real upstream — but not when a loopback resolver is configured.

## Fix

Add a darwin branch to `_host_dns_servers()` that consults `scutil --dns` when `/etc/resolv.conf` yields only loopback addresses, parsing the real `nameserver[N] : <addr>` upstreams (deduped, loopback filtered). A macOS-specific error message is raised only if scutil also yields nothing. Setting `dns_servers` explicitly in the config still bypasses auto-detection entirely.

## Workaround (no upgrade needed)

Set upstreams explicitly in the cage config:

```yaml
dns_servers:
  - 1.1.1.1
  - 8.8.8.8
```

## Tests

- New `TestScutilDnsServers`: parsing/dedup, loopback filtering, missing-binary → `[]`.
- New macOS cases in `TestHostDnsServers`: loopback `resolv.conf` → scutil fallback, usable `resolv.conf` short-circuits scutil, scutil-empty → actionable error.
- Existing loopback/empty tests pinned to `system="Linux"` + stubbed scutil so they stay deterministic on real macOS dev machines.

Verified live on macOS: `_scutil_dns_servers()` and `_host_dns_servers()` both return the host's real upstream. Full `test_config.py` passes (161 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)