### PR TITLE
fix(apple-container): tolerate container 1.0 inspect schema

### DIFF
--- a/src/agentcage/apple_container/cli.py
+++ b/src/agentcage/apple_container/cli.py
@@ -92,6 +92,50 @@ def inspect(name: str) -> dict | None:
         return None
 
 
+def container_state(data: dict | None) -> str | None:
+    """Run state from an :func:`inspect` result, tolerating both schemas.
+
+    Apple's `container` CLI changed the `container inspect` JSON shape in
+    v1.0.0: the run state used to be a top-level string field (``status``
+    == ``"running"``) and is now nested under an object
+    (``status.state`` == ``"running"``, alongside ``networks`` /
+    ``startedDate``). Reading ``data["status"]`` directly and comparing it
+    to ``"running"`` therefore silently broke against 1.0 — a dict never
+    equals ``"running"``, so every cage looked stopped and the egress
+    readiness wait raised a spurious "exited before becoming ready".
+
+    Return the normalised state string (``"running"`` / ``"stopped"`` /
+    ...) or ``None`` when ``data`` is empty or carries no state field.
+    """
+    if not data:
+        return None
+    status = data.get("status") or data.get("Status")
+    if isinstance(status, dict):
+        return status.get("state") or status.get("State")
+    return status
+
+
+def container_networks(data: dict | None) -> list:
+    """Network entries from an :func:`inspect` result, tolerating both schemas.
+
+    Same v1.0.0 reshuffle as :func:`container_state`: the ``networks`` list
+    used to sit at the top level and now lives under the nested ``status``
+    object (``status.networks``), alongside ``state`` / ``startedDate``.
+    Reading top-level ``networks`` therefore returned ``[]`` against 1.0 and
+    the cage could never learn the egress sibling's gateway IP. Returns the
+    list (possibly empty), preferring the nested location.
+    """
+    if not data:
+        return []
+    status = data.get("status")
+    if isinstance(status, dict):
+        nets = status.get("networks") or status.get("Networks")
+        if isinstance(nets, list) and nets:
+            return nets
+    nets = data.get("networks") or data.get("Networks")
+    return nets if isinstance(nets, list) else []
+
+
 def image_inspect(image: str) -> dict | None:
     """Return the parsed JSON image inspect result, or None if absent."""
     try:

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1415,29 +1415,29 @@ class AppleContainerBackend:
     def _container_ip(self, name: str) -> str | None:
         """Return the IPv4 address Apple's network plugin assigned to *name*.
 
-        Apple's `container inspect` (CLI v0.12.x) returns a list (one
-        entry per container). The IP lives under
-        ``networks[].ipv4Address`` (CIDR-form, e.g. ``192.168.64.5/24``);
-        we strip the mask. Returns None if no address is populated yet
-        (still booting — caller should poll briefly).
+        Apple's `container inspect` returns a list (one entry per
+        container). The IP lives under ``networks[].ipv4Address``
+        (CIDR-form, e.g. ``192.168.64.5/24``); we strip the mask. The
+        ``networks`` list sat at the top level pre-1.0 and moved under the
+        nested ``status`` object in v1.0.0 — ``ac_cli.container_networks``
+        absorbs both. Returns None if no address is populated yet (still
+        booting — caller should poll briefly).
         """
         data = ac_cli.inspect(name)
         if not data:
             return None
-        networks = data.get("networks") or data.get("Networks") or []
-        if isinstance(networks, list):
-            for net in networks:
-                # Apple's schema (verified empirically against v0.12.3):
-                # `ipv4Address` is the populated field. Defensively also
-                # check `address`/`Address` for older/newer schema variants.
-                addr = (
-                    net.get("ipv4Address")
-                    or net.get("address")
-                    or net.get("Address")
-                    or ""
-                ).strip()
-                if addr:
-                    return addr.split("/", 1)[0]
+        for net in ac_cli.container_networks(data):
+            # Apple's schema (verified empirically against v0.12.3 and
+            # v1.0.0): `ipv4Address` is the populated field. Defensively
+            # also check `address`/`Address` for other schema variants.
+            addr = (
+                net.get("ipv4Address")
+                or net.get("address")
+                or net.get("Address")
+                or ""
+            ).strip()
+            if addr:
+                return addr.split("/", 1)[0]
         # Fallback: some schemas put the IP at `network.address`.
         n = data.get("network") or {}
         addr = (n.get("ipv4Address") or n.get("address") or n.get("Address") or "").strip()
@@ -1467,11 +1467,11 @@ class AppleContainerBackend:
             if marker.exists():
                 return
             data = ac_cli.inspect(egress_name)
-            status = (data or {}).get("status") or (data or {}).get("Status")
-            if data is not None and status not in ("running", None):
+            state = ac_cli.container_state(data)
+            if data is not None and state not in ("running", None):
                 raise RuntimeError(
                     f"egress sibling {egress_name!r} exited before becoming "
-                    f"ready (status={status!r}); see `container logs {egress_name}`"
+                    f"ready (state={state!r}); see `container logs {egress_name}`"
                 )
             time.sleep(self._READY_POLL_INTERVAL_S)
         raise RuntimeError(
@@ -1556,8 +1556,7 @@ class AppleContainerBackend:
         data = ac_cli.inspect(target)
         if not data:
             return False
-        status = data.get("status") or data.get("Status")
-        return status == "running"
+        return ac_cli.container_state(data) == "running"
 
     def service_names(self, name: str) -> list[str]:  # noqa: ARG002
         """The 2-microVM model has two addressable services.

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -1620,6 +1620,130 @@ def test_start_raises_when_supervisor_dies_before_ready(tmp_path, monkeypatch):
         backend.start("demo", quiet=True)
 
 
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # Pre-1.0 schema: top-level string.
+        ({"status": "running"}, "running"),
+        ({"status": "stopped"}, "stopped"),
+        ({"Status": "running"}, "running"),
+        # container 1.0.0 schema: state nested under the status object,
+        # alongside networks / startedDate.
+        ({"status": {"state": "running", "networks": []}}, "running"),
+        ({"status": {"state": "stopped"}}, "stopped"),
+        ({"status": {"State": "running"}}, "running"),
+        # Degenerate / absent.
+        ({}, None),
+        (None, None),
+        ({"status": {}}, None),
+    ],
+)
+def test_container_state_handles_both_inspect_schemas(data, expected):
+    """`container_state` normalizes both the pre-1.0 top-level string
+    `status` and the 1.0+ nested `status.state` schema. Regression for the
+    1.0.0 breaking change that made every cage look stopped."""
+    assert ac_cli.container_state(data) == expected
+
+
+def test_wait_supervisor_ready_accepts_container_1_0_running_status(
+    tmp_path, monkeypatch
+):
+    """Regression: with container 1.0's nested `status` object, a *running*
+    egress must NOT trip the death-detector. Pre-fix, `status` was a dict
+    that never equalled "running", so the wait raised a spurious
+    "exited before becoming ready" on the first poll."""
+    monkeypatch.setattr(AppleContainerBackend, "_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(AppleContainerBackend, "_READY_TIMEOUT_S", 1.0)
+    backend = AppleContainerBackend()
+    marker = tmp_path / "ready"
+
+    # Egress reports the new nested-running schema; marker appears after a
+    # couple of polls (mirrors the supervisor finishing steps A-F).
+    calls = {"n": 0}
+
+    def fake_inspect(_name):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            marker.touch()
+        return {"status": {"state": "running", "networks": [],
+                           "startedDate": "2026-06-22T11:02:42Z"}}
+
+    monkeypatch.setattr(ac_cli, "inspect", fake_inspect)
+    # Must return cleanly (no RuntimeError).
+    backend._wait_supervisor_ready("demo", marker)
+
+
+def test_wait_supervisor_ready_detects_death_with_nested_status(
+    tmp_path, monkeypatch
+):
+    """A genuinely-dead egress under the 1.0 nested schema
+    (`status.state == "stopped"`) must still raise."""
+    monkeypatch.setattr(AppleContainerBackend, "_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(AppleContainerBackend, "_READY_TIMEOUT_S", 1.0)
+    backend = AppleContainerBackend()
+    marker = tmp_path / "ready"  # never created
+    monkeypatch.setattr(
+        ac_cli, "inspect",
+        lambda _n: {"status": {"state": "stopped"}},
+    )
+    with pytest.raises(RuntimeError, match="exited before becoming ready"):
+        backend._wait_supervisor_ready("demo", marker)
+
+
+@pytest.mark.parametrize(
+    "data, expected_ips",
+    [
+        # Pre-1.0: networks at top level.
+        ({"networks": [{"ipv4Address": "192.168.64.5/24"}]}, ["192.168.64.5/24"]),
+        # container 1.0.0: networks nested under status.
+        (
+            {"status": {"state": "running",
+                        "networks": [{"ipv4Address": "192.168.67.2/24"}]}},
+            ["192.168.67.2/24"],
+        ),
+        ({"status": {"networks": []}}, []),
+        ({}, []),
+        (None, []),
+    ],
+)
+def test_container_networks_handles_both_inspect_schemas(data, expected_ips):
+    """`container_networks` finds the network list whether it sits at the
+    top level (pre-1.0) or nested under `status` (1.0+)."""
+    nets = ac_cli.container_networks(data)
+    assert [n["ipv4Address"] for n in nets] == expected_ips
+
+
+def test_container_ip_reads_nested_container_1_0_networks(monkeypatch):
+    """Regression: `_container_ip` must find the egress gateway IP under the
+    1.0 nested `status.networks` schema. Pre-fix it read top-level
+    `networks` (absent in 1.0), so `start()` raised "could not resolve IP"
+    even though the egress had an address."""
+    backend = AppleContainerBackend()
+    monkeypatch.setattr(
+        ac_cli, "inspect",
+        lambda _n: {"status": {"state": "running", "networks": [
+            {"ipv4Address": "192.168.67.2/24",
+             "ipv4Gateway": "192.168.67.1"}]}},
+    )
+    assert backend._container_ip("demo-egress") == "192.168.67.2"
+
+
+def test_is_running_reads_nested_container_1_0_state(monkeypatch):
+    """`is_running` must read `status.state` under the 1.0 schema; pre-fix
+    it compared the whole dict to "running" and always returned False."""
+    backend = AppleContainerBackend()
+    monkeypatch.setattr(
+        ac_cli, "inspect",
+        lambda _n: {"status": {"state": "running", "networks": []}},
+    )
+    assert backend.is_running("demo", "egress") is True
+    monkeypatch.setattr(
+        ac_cli, "inspect",
+        lambda _n: {"status": {"state": "stopped"}},
+    )
+    assert backend.is_running("demo", "egress") is False
+
+
 # test_supervisor_touches_ready_marker_before_capsh removed in PR 3:
 # supervisor.sh is gone. The ready-marker invariant moved to the egress
 # image's supervisor-egress.sh (tested in tests/test_egress_image.py).


### PR DESCRIPTION
## Problem

`agentcage run claude-code` (and any cage) fails to start on macOS with Apple's `container` CLI **v1.0.0**. The failure surfaces in two ways depending on timing:

```
✗ Failed to build/deploy cage: egress sibling '<name>-egress' exited before becoming ready (status={... 'state': 'running'}); see `container logs <name>-egress`
```
```
✗ Failed to build/deploy cage: could not resolve IP of <name>-egress within 10s — `container inspect` returned no address.
```

Note the first error prints `state: 'running'` while claiming the egress "exited" — the tell that this is a parsing mismatch, not an unhealthy egress.

## Root cause

`container` CLI v1.0.0 reshuffled the `container inspect` JSON. The run **state** and the **networks** list — previously top-level fields — are now nested under a `status` object:

```jsonc
// pre-1.0 (what the backend expected)
{ "id": "...", "status": "running", "networks": [{ "ipv4Address": "..." }] }

// container 1.0.0
{ "id": "...", "status": { "state": "running", "networks": [{ "ipv4Address": "..." }], "startedDate": "..." } }
```

The apple-container backend read them at the old top-level locations:

- **`_wait_supervisor_ready`** compared `data["status"]` (now a dict) to the string `"running"`, so the guard `status not in ("running", None)` fired on the first poll and aborted the deploy with a spurious *"exited before becoming ready"* — even though the egress was healthy and had written its ready marker.
- **`_container_ip`** read top-level `networks` (absent in 1.0), so the cage never learned the egress gateway IP and `start()` raised *"could not resolve IP"*.
- **`is_running`** compared the `status` dict to `"running"` and always returned `False`, making `cage status` / `cage verify` misreport cages.

## Fix

Centralize the schema knowledge in two helpers in `apple_container/cli.py` — `container_state()` and `container_networks()` — that prefer the nested 1.0 location and fall back to the pre-1.0 top-level fields, and route all three call sites through them.

## Tests

Existing tests only mocked the pre-1.0 string `status`, so the break was invisible. Added regression tests covering **both** schemas for the helpers, the readiness wait, IP resolution, and `is_running`.

## Verification

Verified end-to-end on macOS 26.5 / Apple Silicon with `container` CLI 1.0.0: `agentcage run claude-code` now builds the wrapper image, brings up the egress, resolves its IP, and starts the cage (ran a command inside it and observed its output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)