### PR TITLE
feat(apple-container): dns_upstream: direct escape hatch for WARP / unreachable host resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`dns_upstream: direct` — apple-container DNS escape hatch for Cloudflare WARP and other unreachable host resolvers.** On apple-container the egress normally rewrites DNS upstreams to the vmnet gateway at startup — a host-tracking resolver that follows host network changes with no rebuild. But that gateway proxies to whatever resolver the host uses, and some resolvers are unreachable from inside the microVM: **Cloudflare WARP** repoints the system at a loopback DNS proxy (`127.0.2.2`/`127.0.2.3`), and locked-down corporate DNS can behave the same way. The result was cages that couldn't resolve anything (and, because the apple-container path never repointed mitmproxy's own resolver at the in-egress dnsmasq the way the container/vm path does, every allowlisted host `502`'d). Setting `dns_upstream: direct` in `cage.yaml` makes the egress forward allowlisted zones straight to the configured `dns_servers` **and** repoints mitmproxy's resolver at the in-egress dnsmasq, bypassing the vmnet gateway entirely — mirroring the `--dns 1.1.1.1` remedy Docker/Lima/Colima document for WARP. Set `dns_servers` explicitly when using it (auto-detection can't read the host's real upstreams behind a loopback resolver). The trade-off is losing host-tracking: after a host DNS change, run `agentcage cage update <name>`. Default (`gateway`) is unchanged; other backends ignore the setting (their egress already queries `dns_servers` as a parallel `--all-servers` upstream). See [docs/reference/configuration.md](docs/reference/configuration.md).
 ## [0.32.0] - 2026-08-18
 
 ### Added

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,4 +1,4 @@
-<!-- owner: @luca  last-reviewed: 2026-05-28 -->
+<!-- owner: @luca  last-reviewed: 2026-06-24 -->
 # Configuration
 
 The top-level settings, container block, hardening, and restart policy for `cage.yaml`. Pair with the per-feature pages under `docs/reference/` for everything else.
@@ -36,6 +36,23 @@ dns_servers:
   - 1.1.1.1
   - 8.8.8.8
 ```
+
+### DNS upstream mode (apple-container)
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `dns_upstream` | `string` | `gateway` | `gateway` or `direct`. apple-container only. |
+
+*Since 0.26.0.* `dns_upstream` controls how the apple-container egress reaches upstream DNS. `gateway` (default) forwards to the vmnet gateway, which tracks host network changes (Wi-Fi/VPN) without a rebuild. Set `direct` when the host runs a resolver the microVM can't reach — Cloudflare WARP and other loopback/NetworkExtension resolvers, or locked-down corporate DNS — which shows up as cages failing to resolve, or allowlisted hosts returning `502`. `direct` forwards to `dns_servers` and resolves the proxy through the in-egress dnsmasq, bypassing the gateway. See [Architecture](../explain/architecture.md) for how egress DNS flows.
+
+```yaml
+dns_servers:
+  - 1.1.1.1
+  - 8.8.8.8
+dns_upstream: direct
+```
+
+Set `dns_servers` explicitly with `direct` — auto-detection can't read the host's real upstreams behind a loopback resolver. The trade-off is losing live host-tracking: after the host's DNS changes, run `agentcage cage update <name>`. Other backends ignore this setting (their egress already queries `dns_servers` as a parallel `--all-servers` upstream).
 
 ## Container settings
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -873,6 +873,15 @@ class AppleContainerBackend:
                 # start() emits it as ALLOW_ICMP=0/1; the supervisor
                 # installs the FORWARD accept rule only when "1".
                 "allow_icmp": bool(config.ports.icmp.allow),
+                # DNS upstream mode (see Config.dns_upstream). "direct" makes
+                # the egress forward allowlisted zones straight to dns_servers
+                # and resolve mitmproxy via the in-egress dnsmasq, bypassing
+                # the vmnet gateway — for hosts whose resolver is unreachable
+                # from the microVM (Cloudflare WARP etc.). start() turns
+                # "direct" into `-e AGENTCAGE_DNS_DIRECT=1` on the egress.
+                "dns_upstream": str(
+                    getattr(config, "dns_upstream", "gateway") or "gateway"
+                ),
             },
             indent=2,
             sort_keys=True,
@@ -1118,6 +1127,15 @@ class AppleContainerBackend:
             "-e", "AGENTCAGE_AUDIT_LOG=/var/log/agentcage/audit.jsonl",
             "-e", "AGENTCAGE_CAPTURE=/var/log/agentcage/capture.jsonl",
         ]
+        # DNS upstream mode. When the operator set `dns_upstream: direct`
+        # (persisted into metadata by generate_units), tell supervisor-egress.sh
+        # to forward allowlisted zones straight to the baked dns_servers and
+        # repoint mitmproxy's resolver at the in-egress dnsmasq — skipping the
+        # vmnet-gateway rewrite that is unreachable behind Cloudflare WARP and
+        # similar loopback resolvers. Default ("gateway") emits nothing, so the
+        # host-tracking path and legacy metadata without the key are unchanged.
+        if str(meta.get("dns_upstream") or "gateway") == "direct":
+            egress_argv += ["-e", "AGENTCAGE_DNS_DIRECT=1"]
         # Egress port policy. generate_units() persisted these three int
         # lists (from cage.yaml's nested ``ports.*`` via the shared
         # _effective_port_policy). supervisor-egress.sh Step A turns them

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -417,6 +417,19 @@ class Config:
     inspectors: list[dict] = field(default_factory=list)
     protocol_relays: list[ProtocolRelay] = field(default_factory=list)
     dns_servers: list[str] = field(default_factory=list)
+    # apple-container only: how the egress forwards allowlisted DNS zones.
+    # "gateway" (default) rewrites the per-zone upstreams to the vmnet
+    # gateway at egress startup — a host-tracking recursive resolver that
+    # follows host network changes (Wi-Fi/VPN) with no rebuild. "direct"
+    # forwards straight to ``dns_servers`` instead AND repoints the egress's
+    # own resolver (mitmproxy's getaddrinfo) at the in-egress dnsmasq,
+    # bypassing the vmnet gateway entirely. Needed when the host's resolver
+    # is unreachable from the microVM — Cloudflare WARP and other
+    # loopback/NetworkExtension resolvers, or locked-down corporate DNS.
+    # Trades host-tracking for reachability: a host DNS change then needs
+    # ``cage update``. Other isolation backends ignore this (their egress
+    # already queries dns_servers as a parallel `--all-servers` upstream).
+    dns_upstream: str = "gateway"
     domains: DomainConfig = field(default_factory=DomainConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     capture: CaptureConfig = field(default_factory=CaptureConfig)
@@ -810,6 +823,7 @@ def load_config(path: str) -> Config:
 
     # DNS servers (default to host resolvers if not specified)
     cfg.dns_servers = list(raw.get("dns_servers") or _host_dns_servers())
+    cfg.dns_upstream = str(raw.get("dns_upstream", "gateway") or "gateway").strip().lower()
 
     # Domains
     dom_raw = raw.get("domains") or {}
@@ -999,6 +1013,12 @@ def validate_config(config: Config) -> list[str]:
                 f"current arch is {platform.machine()}"
             )
 
+    if config.dns_upstream not in ("gateway", "direct"):
+        raise ValueError(
+            "dns_upstream must be 'gateway' or 'direct' "
+            f"(got: {config.dns_upstream!r})"
+        )
+
     if config.isolation == "vm":
         vm = config.vm
         if vm.vcpus < 1:
@@ -1149,6 +1169,13 @@ def validate_config(config: Config) -> list[str]:
         )
 
     warnings = []
+
+    if config.dns_upstream == "direct" and config.isolation != "apple-container":
+        warnings.append(
+            "dns_upstream: direct only affects the apple-container backend; "
+            f"on {config.isolation!r} the egress already queries dns_servers "
+            "as a parallel upstream (--all-servers), so this is a no-op"
+        )
 
     def _is_scaffold_default_tmpfs(entries: list[str]) -> bool:
         """A single entry whose target is /tmp matches the stock scaffold

--- a/src/agentcage/data/containers/supervisor-egress.sh
+++ b/src/agentcage/data/containers/supervisor-egress.sh
@@ -224,8 +224,51 @@ if [ -f /etc/agentcage/dnsmasq.conf ]; then
     | awk '/inet / {sub(/\/.*/,"",$4); print $4; exit}')
   _gw=$(printf '%s\n' "${_eth0_ip}" \
     | awk -F. 'NF==4 {print $1"."$2"."$3".1"}')
+  #
+  # (3) DIRECT-MODE ESCAPE HATCH (AGENTCAGE_DNS_DIRECT, from
+  #     `dns_upstream: direct`): some hosts run a resolver the vmnet gateway
+  #     can't reach from inside the microVM — Cloudflare WARP and other
+  #     loopback/NetworkExtension resolvers (scutil shows 127.0.2.x),
+  #     locked-down corporate DNS. There the host-tracking gateway rewrite in
+  #     (2) makes every lookup time out. Direct mode skips the rewrite and
+  #     forwards allowlisted zones straight to the baked dns_servers, and (see
+  #     below) repoints mitmproxy's own resolver at this dnsmasq too. Trades
+  #     host-tracking for reachability: a host DNS change then needs
+  #     `cage update`.
   mkdir -p /run/agentcage
-  if [ -n "${_eth0_ip}" ] && [ -n "${_gw}" ] \
+  if [ -n "${AGENTCAGE_DNS_DIRECT:-}" ] && [ -n "${_eth0_ip}" ] \
+     && grep -vE '^(server=/|listen-address=)' /etc/agentcage/dnsmasq.conf \
+          > /run/agentcage/dnsmasq.egress.conf 2>/dev/null \
+     && cp /etc/agentcage/dns-allowlist.conf \
+          /run/agentcage/dns-allowlist.egress.conf 2>/dev/null; then
+    # Keep the eth0 listen-address fix (so the cage's lookups are answered)
+    # but leave the upstream as the operator's dns_servers — no gateway rewrite.
+    chmod 0644 /run/agentcage/dnsmasq.egress.conf /run/agentcage/dns-allowlist.egress.conf
+    log "step B: apple-container path — DNS DIRECT mode: forwarding allowlisted zones to configured dns_servers (vmnet-gateway rewrite disabled), listen ${_eth0_ip}"
+    prlimit --as=$((256 * 1024 * 1024)) -- \
+      setpriv --reuid=acdns --regid=acdns --clear-groups \
+              --bounding-set=-all,+net_bind_service --inh-caps=-all -- \
+      /opt/agentcage/dns-audit.sh \
+        /usr/sbin/dnsmasq -k \
+          --pid-file="$DNSMASQ_PID_FILE" \
+          --conf-file=/run/agentcage/dnsmasq.egress.conf \
+          --servers-file=/run/agentcage/dns-allowlist.egress.conf \
+          --listen-address="${_eth0_ip}" \
+          --listen-address=127.0.0.1 \
+          --bind-interfaces \
+      &
+    # mitmproxy (uid 200) resolves upstream Host headers via the egress's OWN
+    # /etc/resolv.conf, which on apple-container defaults to the vmnet gateway
+    # — the same resolver WARP makes unreachable. The gateway path (2) leaves
+    # resolv.conf untouched (it works there), but direct mode MUST repoint it
+    # at this dnsmasq on loopback or mitmproxy still 502s every allowlisted
+    # host. The egress microVM owns a writable /etc/resolv.conf (no bind).
+    if printf 'nameserver 127.0.0.1\noptions edns0\n' > /etc/resolv.conf 2>/dev/null; then
+      log "step B: DNS DIRECT mode — mitmproxy resolver = local dnsmasq (127.0.0.1)"
+    else
+      log "warn: DNS DIRECT mode — could not repoint /etc/resolv.conf at local dnsmasq"
+    fi
+  elif [ -n "${_eth0_ip}" ] && [ -n "${_gw}" ] \
      && grep -vE '^(server=/|listen-address=)' /etc/agentcage/dnsmasq.conf \
           > /run/agentcage/dnsmasq.egress.conf 2>/dev/null \
      && awk -F/ -v up="${_gw}" '/^server=\//{print "server=/" $2 "/" up}' \

--- a/src/agentcage/scaffolds/openclaw/cage.yaml.j2
+++ b/src/agentcage/scaffolds/openclaw/cage.yaml.j2
@@ -80,6 +80,14 @@ container:
 #   - 100.100.100.100
 #   - 1.1.1.1
 #   - 8.8.8.8
+#
+# apple-container only — dns_upstream: gateway (default) | direct
+# Default ("gateway") follows the host's resolver live (Wi-Fi/VPN changes
+# need no rebuild). Set "direct" if cages can't resolve because the host
+# runs a resolver the microVM can't reach — Cloudflare WARP and other
+# loopback resolvers, or locked-down corporate DNS. Direct forwards
+# straight to dns_servers above (set them explicitly), losing host-tracking.
+# dns_upstream: direct
 
 # ── Secret injection ──
 # API keys are swapped by the proxy — the cage only sees placeholders.

--- a/tests/test_apple_container_egress_ports.py
+++ b/tests/test_apple_container_egress_ports.py
@@ -265,3 +265,55 @@ class TestStartEgressArgvPortEnv:
             "allow_icmp": True,
         })
         assert _env_value(argv, "ALLOW_ICMP") == "1"
+
+# ── dns_upstream: Config → metadata → egress AGENTCAGE_DNS_DIRECT ──
+
+
+class TestGenerateUnitsDnsUpstream:
+    def test_default_gateway_persisted(self, tmp_path):
+        cfg = _config(tmp_path, """\
+            name: demo
+            container:
+              image: test:latest
+        """)
+        meta = json.loads(
+            AppleContainerBackend().generate_units(
+                cfg, "/c.yaml", "/patches", "demo",
+            )["demo.json"]
+        )
+        assert meta["dns_upstream"] == "gateway"
+
+    def test_direct_persisted(self, tmp_path):
+        cfg = _config(tmp_path, """\
+            name: demo
+            dns_servers:
+              - 1.1.1.1
+            dns_upstream: direct
+            container:
+              image: test:latest
+        """)
+        meta = json.loads(
+            AppleContainerBackend().generate_units(
+                cfg, "/c.yaml", "/patches", "demo",
+            )["demo.json"]
+        )
+        assert meta["dns_upstream"] == "direct"
+
+
+class TestStartEgressDnsUpstreamEnv:
+    def test_direct_emits_env(self, tmp_path):
+        """dns_upstream: direct → egress gets AGENTCAGE_DNS_DIRECT=1, which
+        flips supervisor-egress.sh to skip the vmnet-gateway rewrite."""
+        argv = _start_with_meta(tmp_path, {"dns_upstream": "direct"})
+        assert _env_value(argv, "AGENTCAGE_DNS_DIRECT") == "1"
+
+    def test_gateway_omits_env(self, tmp_path):
+        """Default mode emits nothing — the host-tracking path is unchanged."""
+        argv = _start_with_meta(tmp_path, {"dns_upstream": "gateway"})
+        assert _env_value(argv, "AGENTCAGE_DNS_DIRECT") is None
+
+    def test_legacy_metadata_omits_env(self, tmp_path):
+        """A cage created before this feature has no dns_upstream key →
+        treated as gateway, no env var emitted (no behavior change)."""
+        argv = _start_with_meta(tmp_path, {})
+        assert _env_value(argv, "AGENTCAGE_DNS_DIRECT") is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -881,6 +881,58 @@ class TestValidateConfig:
         assert warnings == []
 
 
+class TestDnsUpstream:
+    """dns_upstream knob (apple-container DNS escape hatch for WARP etc.)."""
+
+    def _yaml(self, tmp_path, *extra, isolation="apple-container"):
+        p = tmp_path / "config.yaml"
+        lines = [
+            "name: dns-demo",
+            f"isolation: {isolation}",
+            "dns_servers:",
+            "  - 1.1.1.1",
+            "container:",
+            "  image: localhost/test:latest",
+            *extra,
+        ]
+        p.write_text("\n".join(lines) + "\n")
+        return str(p)
+
+    def _validate_apple(self, cfg):
+        from unittest.mock import patch
+        with patch("agentcage.config.platform.system", return_value="Darwin"), \
+             patch("agentcage.config.platform.machine", return_value="arm64"):
+            return validate_config(cfg)
+
+    def test_default_is_gateway(self, tmp_path):
+        cfg = load_config(self._yaml(tmp_path))
+        assert cfg.dns_upstream == "gateway"
+
+    def test_direct_parsed_and_valid(self, tmp_path):
+        cfg = load_config(self._yaml(tmp_path, "dns_upstream: direct"))
+        assert cfg.dns_upstream == "direct"
+        # Valid on apple-container; must not emit the non-apple no-op warning.
+        warnings = self._validate_apple(cfg)
+        assert not any("dns_upstream" in w for w in warnings)
+
+    def test_normalized_case_and_whitespace(self, tmp_path):
+        cfg = load_config(self._yaml(tmp_path, "dns_upstream: '  DIRECT  '"))
+        assert cfg.dns_upstream == "direct"
+
+    def test_invalid_value_raises(self, tmp_path):
+        cfg = load_config(self._yaml(tmp_path, "dns_upstream: bogus"))
+        with pytest.raises(ValueError, match="dns_upstream must be"):
+            self._validate_apple(cfg)
+
+    @LINUX_ONLY
+    def test_direct_on_non_apple_backend_warns_noop(self, tmp_path):
+        cfg = load_config(
+            self._yaml(tmp_path, "dns_upstream: direct", isolation="container")
+        )
+        warnings = validate_config(cfg)
+        assert any("only affects the apple-container backend" in w for w in warnings)
+
+
 class TestHostDnsServers:
     def _patch_resolv(
         self, monkeypatch, tmp_path, etc_text, resolved_text=None,


### PR DESCRIPTION
## Problem

On the **apple-container** backend, the egress rewrites DNS upstreams to the vmnet gateway at startup (`supervisor-egress.sh` step B) — a host-tracking resolver that NATs to the host's *current* resolver. This breaks whenever the host runs a resolver the microVM can't reach:

- **Cloudflare WARP** repoints the macOS system resolver at a loopback DNS proxy (`scutil --dns` shows `127.0.2.2` / `127.0.2.3`), which is unreachable across the VM boundary.
- Locked-down corporate DNS behaves the same way.

Two distinct failures result:
1. The cage can't resolve at all — its queries flow `cage dnsmasq → egress dnsmasq → vmnet gateway → (unreachable host resolver)`.
2. Every allowlisted host `502`s. The apple-container path — unlike container/vm — **never repoints mitmproxy's own `/etc/resolv.conf`** at the in-egress dnsmasq (that repoint is container/vm-only, `supervisor-egress.sh:351-358`), so mitmproxy resolves Host headers via the vmnet gateway directly. With `keep_host_header=true` mitmproxy re-resolves every upstream, so a dead gateway = universal 502.

This is the runtime layer behind the WARP reports; the `scutil` build-time detection fix (0.25.4) didn't help because WARP only exposes loopback addresses to `scutil`, which detection filters out.

## Fix

Add `dns_upstream: gateway | direct` to `cage.yaml` (default `gateway`, apple-container only). `direct`:
- forwards allowlisted zones **straight to the configured `dns_servers`** (no vmnet-gateway rewrite), and
- repoints mitmproxy's resolver at the in-egress dnsmasq (`127.0.0.1`), so its `getaddrinfo` also bypasses the gateway.

This mirrors the `--dns 1.1.1.1` remedy Docker Desktop / Lima / Colima document for WARP — plain UDP/53 to a routable public resolver is tunneled fine by WARP; it's the loopback-proxy path that breaks. Trade-off: `direct` loses live host-tracking, so after a host DNS change run `agentcage cage update <name>`.

## Plumbing

`Config.dns_upstream` → validated (enum; no-op warning on non-apple backends) → persisted in apple-container unit metadata (`generate_units`) → emitted as `-e AGENTCAGE_DNS_DIRECT=1` on the egress (`start`) → **new first branch** in `supervisor-egress.sh` step B. The default (`gateway`) path is byte-identical to before (gateway moved from `if` to `elif`); legacy metadata without the key is treated as `gateway`, so existing cages are unaffected.

## Tests

- `test_config.py::TestDnsUpstream` — default, parse, case/whitespace normalize, invalid→`ValueError`, no-op warning on non-apple backends.
- `test_apple_container_egress_ports.py` — `generate_units` persists the mode; `start()` egress argv emits `AGENTCAGE_DNS_DIRECT=1` only for `direct` (omitted for `gateway` and legacy metadata).
- `shellcheck` (as CI runs it) + `bash -n` clean on `supervisor-egress.sh`; `ruff` clean.

All config/apple-container/egress tests pass. (9 pre-existing secret-store failures on macOS dev are unrelated — identical set fails on clean `master`; they pass in Linux CI.)

## ⚠️ Validation note

The Python/metadata/argv plumbing is fully unit-tested, but the **runtime shell behavior under WARP can't be exercised in CI** (needs a macOS + Apple `container` CLI + WARP host). The change is structured to be safe regardless — opt-in, default path untouched — but the end-to-end "cage resolves under WARP with `dns_upstream: direct`" claim should be confirmed on @skos-ninja's machine before relying on it. Recommend Jake validates on the branch:

```yaml
dns_servers: [1.1.1.1, 8.8.8.8]
dns_upstream: direct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)