### PR TITLE
[AGENTCAGE-272] Skip host-dependent tests when deps are absent

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,28 @@ sys.modules.setdefault("mitmproxy.proxy", _proxy)
 sys.modules.setdefault("mitmproxy.proxy.mode_specs", _mode_specs)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_host_dns(monkeypatch):
+    """Stub host DNS auto-detection for the whole unit suite.
+
+    ``load_config()`` calls ``_host_dns_servers()`` whenever a config omits
+    ``dns_servers``. On a host whose ``/etc/resolv.conf`` only lists loopback
+    resolvers (systemd-resolved stubs, a local DNS proxy, a sandbox, etc.)
+    and which has no ``/run/systemd/resolve/resolv.conf``, that raises — so
+    every test that loads a config without pinning ``dns_servers`` would fail
+    for reasons unrelated to what it asserts. Pin a deterministic upstream
+    here so the unit suite never depends on the host resolver.
+
+    Tests that specifically exercise detection (``test_*dns*`` /
+    ``TestHostDnsServers``) re-``monkeypatch`` ``_host_dns_servers`` or the
+    lower-level ``_read_nameservers`` / ``_scutil_dns_servers`` in their own
+    body; those later setattrs override this one and are restored normally.
+    """
+    monkeypatch.setattr(
+        "agentcage.config._host_dns_servers", lambda: ["1.1.1.1"]
+    )
+
+
 @pytest.fixture
 def patch_state_dirs(tmp_path, monkeypatch):
     """Redirect agentcage.state's filesystem roots into tmp_path. Prevents

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -1,0 +1,29 @@
+"""Shared pytest skip markers for optional host dependencies.
+
+Some unit tests drive code paths that shell out to real host tooling
+(``podman``) or probe host devices (``/dev/kvm``). Those binaries/devices
+exist on the Linux CI runners, so the tests run there — but on a developer
+laptop, a macOS host, or a minimal/sandboxed environment they are absent and
+the test fails with a ``FileNotFoundError`` (or a spurious prerequisite issue)
+for reasons unrelated to what it asserts.
+
+Gate such tests on the dependency actually being present so the suite skips
+gracefully instead of failing where the dependency is missing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+REQUIRES_PODMAN = pytest.mark.skipif(
+    shutil.which("podman") is None,
+    reason="needs the host `podman` binary (present on Linux CI)",
+)
+
+REQUIRES_KVM = pytest.mark.skipif(
+    not os.path.exists("/dev/kvm"),
+    reason="needs /dev/kvm (present on the virtualization-enabled Linux CI)",
+)

--- a/tests/test_egress_image.py
+++ b/tests/test_egress_image.py
@@ -12,12 +12,13 @@ is ~120MB) so the container-required tests share a module-scope fixture.
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 import time
 from pathlib import Path
 
 import pytest
+
+from tests.markers import REQUIRES_PODMAN
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -27,11 +28,7 @@ IMAGE_TAG = "agentcage-egress:test"
 CONTAINER_NAME = "egress-smoke"
 
 
-def _have_podman() -> bool:
-    return shutil.which("podman") is not None
-
-
-pytestmark = pytest.mark.skipif(not _have_podman(), reason="podman not available")
+pytestmark = REQUIRES_PODMAN
 
 
 def _podman(*args: str, check: bool = True, timeout: int = 600) -> subprocess.CompletedProcess[str]:

--- a/tests/test_lima_prerequisites.py
+++ b/tests/test_lima_prerequisites.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from agentcage.lima.prerequisites import check_prerequisites, detect_platform
+from tests.markers import REQUIRES_KVM
 
 LINUX_ONLY = pytest.mark.skipif(
     platform.system() != "Linux",
@@ -42,6 +43,7 @@ class TestCheckPrerequisites:
         assert any("https://" in i for i in issues)
 
     @LINUX_ONLY
+    @REQUIRES_KVM
     def test_limactl_available_on_linux(self):
         with patch("shutil.which", return_value="/usr/bin/limactl"), \
              patch("platform.system", return_value="Linux"):

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from agentcage.cli import main
+from tests.markers import REQUIRES_PODMAN
 
 
 def _runner():
@@ -37,6 +38,7 @@ class TestInitWithScaffold:
         assert result.exit_code != 0
         assert "unknown scaffold" in result.output
 
+    @REQUIRES_PODMAN
     @patch("agentcage.registry.resolve_latest_tag", return_value="2026.2.24")
     def test_openclaw_scaffold_creates_file(self, mock_resolve, tmp_path):
         dest = tmp_path / "cage.yaml"

--- a/tests/test_secret_cli.py
+++ b/tests/test_secret_cli.py
@@ -9,6 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from agentcage.cli import main
+from tests.markers import REQUIRES_PODMAN
 
 # These drive `secret set/rm` through the host's default secret backend
 # (systemd-creds / podman secrets on Linux). On macOS the default backend is
@@ -35,6 +36,7 @@ def _mock_container_config():
 
 class TestSecretSet:
     @LINUX_ONLY
+    @REQUIRES_PODMAN
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
     def test_set_creates_secret(self, mock_state, MockPodman):
@@ -49,6 +51,7 @@ class TestSecretSet:
         assert "myapp.API_KEY" in result.output
 
     @LINUX_ONLY
+    @REQUIRES_PODMAN
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
     def test_set_replaces_existing(self, mock_state, MockPodman):
@@ -117,6 +120,7 @@ class TestSecretFailClosed:
         podman.secret_create.assert_not_called()
 
     @LINUX_ONLY
+    @REQUIRES_PODMAN
     @patch("agentcage.secret_resolver.detect_default_backend", return_value="podman")
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
@@ -219,6 +223,7 @@ class TestSecretList:
 
 class TestSecretRm:
     @LINUX_ONLY
+    @REQUIRES_PODMAN
     @patch("agentcage.cli.Podman")
     @patch("agentcage.cli.state")
     def test_rm_removes_secret(self, mock_state, MockPodman, tmp_path):


### PR DESCRIPTION
Splits the test-environment reliability fixes out of PR #272.\n\nSummary:\n- stub host DNS auto-detection in unit tests\n- add shared skip markers for optional Podman and /dev/kvm dependencies\n- apply those markers to tests that shell out to host tooling