### PR TITLE
[AGENTCAGE-170] Guard writable workspace Git hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Harden writable workspace binds against the `.git/hooks` cage→host pivot ([#170](https://github.com/agentcage/agentcage/issues/170)). agentcage now discovers and masks every existing Git hooks directory under writable host binds (including nested repos and additional mounted repos) and emits stop-time warnings if active hooks or adjacent host-trusted files such as `.git/config`, `.gitattributes`, `.gitmodules`, `.lfsconfig`, or `.claude/settings.json` are created, removed, or modified while the cage runs. The mask is only applied to paths that already exist on the host to avoid runtime mountpoint litter in clean projects. Set `git_hooks_mask: false` to opt out.
 ## [0.32.0] - 2026-08-18
 
 ### Added

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,6 +16,7 @@ Example configs: [`basic/cage.yaml`](../../examples/basic/) and [`openclaw/cage.
 | `log_allowed` | `bool` | `false` | Log allowed requests to the proxy journal. |
 | `max_request_body` | `int` | `10485760` (10 MB) | Max request body size in bytes. Set to `0` to disable the body-size limit. |
 | `dns_servers` | `list[string]` | *(from host `/etc/resolv.conf`)* | Upstream DNS servers used by both the dnsmasq sidecar and the proxy container. |
+| `git_hooks_mask` | `bool` | `true` | Security ([#170](https://github.com/agentcage/agentcage/issues/170)): mask existing Git hook directories discovered under writable host binds and warn when host-trusted workspace files (active Git hooks, `.git/config`, `.gitattributes`, `.gitmodules`, `.lfsconfig`, `.claude/settings.json`) are created/modified/removed while the cage runs. Set `false` to opt out. |
 
 ### VM settings
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -56,6 +56,11 @@ from agentcage.apple_container import prerequisites as ac_prereq
 from agentcage.apple_container import scaffold as ac_scaffold
 from agentcage.apple_container import wrapper as ac_wrapper
 from agentcage.config import Config
+from agentcage.git_hooks_guard import (
+    diff_tamper_state,
+    discover_git_hooks_masks,
+    snapshot_tamper_state,
+)
 from agentcage.quadlets import _effective_port_policy
 
 
@@ -848,6 +853,10 @@ class AppleContainerBackend:
                 # already-absolute paths, so start() re-running it is a safe
                 # revalidation, not a re-expansion.
                 "volumes": self._user_volume_argv(config.container.volumes),
+                # Security (#170): opt-out for Git hook masks and workspace
+                # tamper warnings. Existence checks happen at start() against
+                # live host state so nested/new repos are discovered then.
+                "git_hooks_mask": bool(config.git_hooks_mask),
                 # User-defined ``container.env:`` entries. Apple's
                 # `container run` accepts `-e KEY=VAL` like podman. The
                 # container backend wires these via quadlets.py:338;
@@ -1288,8 +1297,25 @@ class AppleContainerBackend:
         # _user_volume_argv here is an idempotent revalidation, NOT a
         # re-expansion: absolute paths have no `~`/`$VAR` left to resolve, so
         # this no longer depends on PROJECT_DIR being in the start() env.
-        for vol_entry in self._user_volume_argv(meta.get("volumes") or []):
+        cage_volumes = self._user_volume_argv(meta.get("volumes") or [])
+        for vol_entry in cage_volumes:
             cage_argv += ["--volume", vol_entry]
+        git_guard = discover_git_hooks_masks(
+            cage_volumes, enabled=bool(meta.get("git_hooks_mask", True))
+        )
+        if git_guard.watch_roots:
+            self._write_workspace_guard_baseline(name, git_guard.watch_roots)
+        for mask in git_guard.masks:
+            # Apple `container run --tmpfs` takes a bare path only (no
+            # `:rw,size=...` options; those are treated as literal path text).
+            cage_argv += ["--tmpfs", mask.cage_path]
+        if git_guard.masks and not quiet:
+            click.echo(
+                "masking Git hooks under writable host binds: "
+                + ", ".join(mask.cage_path for mask in git_guard.masks)
+                + ". Disable with `git_hooks_mask: false`.",
+                err=True,
+            )
         # Apple's --cpus / --memory normalization (uppercase suffix, ceil
         # fractions). Backward-compat fallback to pre-0.20.6 `mem_mb` int.
         cpus_raw = meta.get("cpus")
@@ -1505,9 +1531,37 @@ class AppleContainerBackend:
             f"for the supervisor's last step"
         )
 
+    def _workspace_guard_baseline_path(self, name: str) -> Path:
+        return self._state_dir(name) / "workspace-guard-baseline.json"
+
+    def _write_workspace_guard_baseline(self, name: str, roots: tuple[str, ...]) -> None:
+        path = self._workspace_guard_baseline_path(name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"roots": list(roots), "snapshot": snapshot_tamper_state(roots)}
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+    def _check_workspace_guard(self, name: str) -> None:
+        path = self._workspace_guard_baseline_path(name)
+        if not path.exists():
+            return
+        try:
+            payload = json.loads(path.read_text())
+            roots = tuple(str(r) for r in (payload.get("roots") or []))
+            before = dict(payload.get("snapshot") or {})
+            after = snapshot_tamper_state(roots)
+            for warning in diff_tamper_state(before, after):
+                click.echo(
+                    f"agentcage warning: host-trusted workspace file {warning} "
+                    "while cage was running",
+                    err=True,
+                )
+        finally:
+            path.unlink(missing_ok=True)
+
     def stop(self, name: str) -> None:
         """Stop both microVMs (cage + egress)."""
         ac_cli.run(["stop", name], check=False)
+        self._check_workspace_guard(name)
         ac_cli.run(["stop", f"{name}-egress"], check=False)
 
     def restart(self, name: str) -> None:

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -431,6 +431,11 @@ class Config:
     # control which cages come back after a reboot. Other isolation
     # backends ignore this. See docs/apple-container.md.
     apple_container_autostart: bool = False
+    # Security (#170): mask existing Git hook directories under writable host
+    # binds and warn if host-trusted workspace files (active hooks,
+    # .git/config, .gitattributes, .claude/settings.json) are created/modified
+    # while the cage runs. Set False to opt out.
+    git_hooks_mask: bool = True
 
 
 def default_isolation() -> str:
@@ -934,6 +939,9 @@ def load_config(path: str) -> Config:
 
     # apple-container only: opt-in launchd autostart at user login.
     cfg.apple_container_autostart = bool(raw.get("apple_container_autostart", False))
+
+    # Security (#170): Git hooks mask + host-trusted workspace tamper warnings.
+    cfg.git_hooks_mask = bool(raw.get("git_hooks_mask", True))
 
     # Help text
     cfg.help = str(raw.get("help", "") or "")

--- a/src/agentcage/git_hooks_guard.py
+++ b/src/agentcage/git_hooks_guard.py
@@ -1,0 +1,335 @@
+"""Git hook masking and workspace tamper warnings (issue #170).
+
+The primary cage→host pivot is a writable host bind that exposes one or more
+Git hook directories to the cage.  A malicious in-cage agent can plant an
+active hook and have it execute later when the operator runs ``git`` on the
+host.
+
+The guard has two layers:
+
+* mask every **existing** ``.git/.../hooks`` directory discovered under
+  writable host binds; the existence guard avoids runtime-created mountpoints
+  littering clean host projects;
+* snapshot selected host-trusted files before the cage starts and warn on stop
+  if they were created, removed, or modified.  This catches newly-created repos
+  and adjacent pivots that cannot be safely tmpfs-mounted after the container
+  has already started.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import os
+import shlex
+from pathlib import Path, PurePosixPath
+
+# tmpfs spec used by the container/vm (quadlet) backends. Apple's
+# ``container run --tmpfs`` takes a *bare path* only, so the apple backend uses
+# the discovered cage paths directly instead of this ``path:opts`` form.
+GIT_HOOKS_TMPFS_OPTS = "rw,noexec,nosuid,size=8M"
+
+# Git executes only these exact basenames from a hooks directory.  ``*.sample``
+# files are intentionally not listed: they are templates, not active hooks.
+GIT_HOOK_NAMES = (
+    "applypatch-msg",
+    "pre-applypatch",
+    "post-applypatch",
+    "pre-commit",
+    "pre-merge-commit",
+    "prepare-commit-msg",
+    "commit-msg",
+    "post-commit",
+    "pre-rebase",
+    "post-checkout",
+    "post-merge",
+    "pre-push",
+    "pre-receive",
+    "update",
+    "proc-receive",
+    "post-receive",
+    "post-update",
+    "reference-transaction",
+    "push-to-checkout",
+    "pre-auto-gc",
+    "post-rewrite",
+    "sendemail-validate",
+    "fsmonitor-watchman",
+    "p4-pre-submit",
+    "post-index-change",
+)
+
+# Other workspace files that can affect host-side tool execution.  This is a
+# warning layer (not a blocker) because these files are normal project files and
+# broad prevention would break legitimate edits.
+TAMPER_SENTINELS = (
+    ".git",  # worktree gitdir pointer file
+    ".git/config",
+    ".git/config.worktree",
+    ".git/info/attributes",
+    ".gitattributes",
+    ".gitmodules",
+    ".lfsconfig",
+    ".claude/settings.json",
+)
+
+# Common project-local hook script directories.  ``.git/**/hooks`` is masked
+# when present; the rest are warning-only because projects often legitimately
+# track them as source files and broad prevention would be too disruptive.
+TAMPER_HOOK_DIR_NAMES = ("hooks", ".githooks", ".husky")
+
+# Keep scans bounded in common large dependency/cache trees.  Nested git repos
+# inside these directories are intentionally ignored to avoid turning every cage
+# start/stop into a full dependency traversal.
+_PRUNE_DIRS = frozenset({"node_modules", ".venv", "venv", "__pycache__", ".cache"})
+
+
+@dataclass(frozen=True)
+class BindMount:
+    """A writable host bind visible in the cage."""
+
+    host_path: str
+    cage_path: str
+    options: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class GitHooksMask:
+    """One host hook directory and its corresponding cage-side path."""
+
+    host_path: str
+    cage_path: str
+
+    @property
+    def tmpfs_spec(self) -> str:
+        return f"{self.cage_path}:{GIT_HOOKS_TMPFS_OPTS}"
+
+
+@dataclass(frozen=True)
+class GitHooksGuardPlan:
+    """Computed guard actions for a set of expanded volume specs."""
+
+    binds: tuple[BindMount, ...]
+    masks: tuple[GitHooksMask, ...]
+
+    @property
+    def watch_roots(self) -> tuple[str, ...]:
+        """Host paths to snapshot/check for tampering."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for bind in self.binds:
+            real = os.path.realpath(bind.host_path)
+            if real not in seen:
+                seen.add(real)
+                out.append(real)
+        return tuple(out)
+
+
+def _split_volume_spec(spec: str) -> tuple[str, str, tuple[str, ...]] | None:
+    """Parse ``host:cage[:opts]`` volume specs.
+
+    The project already limits host bind sources to Unix-like paths, so a split
+    on ``:`` is sufficient here (no Windows drive-letter support).
+    """
+    parts = spec.split(":")
+    if len(parts) < 2:
+        return None
+    host, cage = parts[0], parts[1]
+    options = tuple(
+        opt for field in parts[2:] for opt in field.split(",") if opt
+    )
+    return host, cage, options
+
+
+def writable_host_binds(expanded_volumes: list[str]) -> tuple[BindMount, ...]:
+    """Return writable host binds from already-expanded volume specs.
+
+    Named volumes are ignored (their source is not a host path) and read-only
+    binds are ignored (the cage cannot plant hooks through them).  The caller is
+    expected to pass the same validated/expanded volume list that will be
+    rendered into the runtime configuration.
+    """
+    out: list[BindMount] = []
+    for spec in expanded_volumes:
+        parsed = _split_volume_spec(spec)
+        if not parsed:
+            continue
+        host, cage, options = parsed
+        if not host.startswith(("/", "~")):
+            continue
+        if not cage.startswith("/"):
+            continue
+        if "ro" in options:
+            continue
+        out.append(BindMount(host, cage, options))
+    return tuple(out)
+
+
+def _is_git_hooks_dir(host_root: str, dirpath: str) -> bool:
+    rel = os.path.relpath(dirpath, host_root)
+    if rel == os.curdir:
+        return False
+    parts = rel.split(os.sep)
+    return parts[-1] == "hooks" and ".git" in parts[:-1]
+
+
+def discover_git_hooks_masks(expanded_volumes: list[str], *, enabled: bool) -> GitHooksGuardPlan:
+    """Discover all existing Git hook dirs under writable host binds.
+
+    Only existing directories are returned.  This is load-bearing: container
+    runtimes create an absent tmpfs/bind mountpoint *through* the parent host
+    bind, which would litter clean projects with stray ``.git`` directories.
+    """
+    binds = writable_host_binds(expanded_volumes)
+    if not enabled:
+        return GitHooksGuardPlan(binds=binds, masks=())
+
+    masks: list[GitHooksMask] = []
+    seen_cage_paths: set[str] = set()
+    for bind in binds:
+        host_root = os.path.realpath(os.path.expanduser(bind.host_path))
+        if not os.path.isdir(host_root):
+            continue
+        for dirpath, dirnames, _filenames in os.walk(host_root, followlinks=False):
+            dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+            if not _is_git_hooks_dir(host_root, dirpath):
+                continue
+            rel = os.path.relpath(dirpath, host_root)
+            cage_path = str(PurePosixPath(bind.cage_path, *rel.split(os.sep)))
+            if cage_path in seen_cage_paths:
+                continue
+            seen_cage_paths.add(cage_path)
+            masks.append(GitHooksMask(host_path=dirpath, cage_path=cage_path))
+    return GitHooksGuardPlan(binds=binds, masks=tuple(masks))
+
+
+def _file_fingerprint(path: Path) -> str:
+    if path.is_symlink():
+        return "symlink:" + os.readlink(path)
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def _is_active_hook(path: Path) -> bool:
+    if path.name not in GIT_HOOK_NAMES:
+        return False
+    if path.parent.name == "hooks" and ".git" in path.parts:
+        return True
+    return path.parent.name in {".githooks", ".husky"}
+
+
+def _is_tamper_sentinel(root: Path, path: Path) -> bool:
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        return False
+    if _is_active_hook(path):
+        return True
+    return rel in TAMPER_SENTINELS or rel.endswith("/.claude/settings.json")
+
+
+def snapshot_tamper_state(roots: tuple[str, ...]) -> dict[str, str]:
+    """Return ``{path: fingerprint}`` for host-trusted files under *roots*."""
+    state: dict[str, str] = {}
+    for root_s in roots:
+        root = Path(os.path.realpath(os.path.expanduser(root_s)))
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIRS]
+            dpath = Path(dirpath)
+            for filename in filenames:
+                path = dpath / filename
+                if not _is_tamper_sentinel(root, path):
+                    continue
+                try:
+                    state[str(path)] = _file_fingerprint(path)
+                except OSError:
+                    continue
+    return dict(sorted(state.items()))
+
+
+def diff_tamper_state(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Return human-readable tamper warnings for changed sentinel files."""
+    warnings: list[str] = []
+    for path in sorted(set(before) | set(after)):
+        if path not in before:
+            warnings.append(f"created: {path}")
+        elif path not in after:
+            warnings.append(f"removed: {path}")
+        elif before[path] != after[path]:
+            warnings.append(f"modified: {path}")
+    return warnings
+
+
+def _bash_array(values: tuple[str, ...]) -> str:
+    return " ".join(shlex.quote(v) for v in values)
+
+
+def _guard_snapshot_bash() -> str:
+    hooks = _bash_array(GIT_HOOK_NAMES)
+    hook_dirs = _bash_array(TAMPER_HOOK_DIR_NAMES)
+    sentinels = _bash_array(TAMPER_SENTINELS)
+    prunes = " -o ".join(f"-name {shlex.quote(d)}" for d in sorted(_PRUNE_DIRS))
+    prune_expr = f"\\( {prunes} \\) -prune -o" if prunes else ""
+    # Emits ``<hash>  <path>`` lines.  Active Git hooks and selected
+    # host-trusted config files are included; sample hooks are ignored.
+    return (
+        f"hooks=({hooks}); hook_dirs=({hook_dirs}); sentinels=({sentinels}); "
+        "is_hook(){ local p=\"$1\" b=\"${p##*/}\" parent=\"${p%/*}\" d=\"${parent##*/}\"; "
+        "[[ \" ${hooks[*]} \" == *\" $b \"* ]] || return 1; "
+        "[[ \"$p\" == */.git/hooks/* || \"$p\" == */.git/*/hooks/* ]] && return 0; "
+        "[[ \" ${hook_dirs[*]} \" == *\" $d \"* ]] && [[ \"$d\" != hooks ]] && return 0; "
+        "return 1; }; "
+        "is_sentinel(){ local r=\"$1\" p=\"$2\" rel=\"${p#$r/}\"; for s in \"${sentinels[@]}\"; do [[ \"$rel\" == \"$s\" || \"$rel\" == */.claude/settings.json ]] && return 0; done; return 1; }; "
+        "snapshot(){ "
+        "for root in \"${roots[@]}\"; do "
+        "[ -d \"$root\" ] || continue; "
+        f"while IFS= read -r -d '' p; do "
+        "is_hook \"$p\" || is_sentinel \"$root\" \"$p\" || continue; "
+        "if command -v sha256sum >/dev/null 2>&1; then sha256sum -- \"$p\" 2>/dev/null || true; "
+        "else cksum \"$p\" 2>/dev/null || true; fi; "
+        f"done < <(find \"$root\" {prune_expr} \\( -type f -o -type l \\) -print0 2>/dev/null); "
+        "done | sort; "
+        "}; "
+    )
+
+
+def render_guard_baseline_command(name: str, roots: tuple[str, ...]) -> str:
+    """Return a systemd ExecStartPre command that snapshots tamper state."""
+    if not roots:
+        return ""
+    roots_arr = _bash_array(roots)
+    script = (
+        "set -u; "
+        f"roots=({roots_arr}); "
+        f"base=\"%t/agentcage-{name}-workspace-guard.baseline\"; "
+        + _guard_snapshot_bash()
+        + "snapshot > \"$base\""
+    )
+    return "/bin/bash -lc " + shlex.quote(script)
+
+
+def render_guard_check_command(name: str, roots: tuple[str, ...]) -> str:
+    """Return a systemd ExecStopPost command that warns about tampering."""
+    if not roots:
+        return ""
+    roots_arr = _bash_array(roots)
+    script = (
+        "set -u; "
+        f"roots=({roots_arr}); "
+        f"base=\"%t/agentcage-{name}-workspace-guard.baseline\"; "
+        + _guard_snapshot_bash()
+        + "if [ -f \"$base\" ]; then "
+        "now=\"$base.now\"; snapshot > \"$now\"; "
+        "comm -13 \"$base\" \"$now\" | while IFS= read -r line; do "
+        "echo \"agentcage warning: host-trusted workspace file created or modified while cage ran: $line\" >&2; done; "
+        "comm -23 \"$base\" \"$now\" | while IFS= read -r line; do "
+        "echo \"agentcage warning: host-trusted workspace file removed while cage ran: $line\" >&2; done; "
+        "rm -f \"$now\" \"$base\"; "
+        "fi"
+    )
+    return "/bin/bash -lc " + shlex.quote(script)

--- a/src/agentcage/git_hooks_guard.py
+++ b/src/agentcage/git_hooks_guard.py
@@ -199,7 +199,9 @@ def discover_git_hooks_masks(expanded_volumes: list[str], *, enabled: bool) -> G
             if cage_path in seen_cage_paths:
                 continue
             seen_cage_paths.add(cage_path)
-            masks.append(GitHooksMask(host_path=dirpath, cage_path=cage_path))
+            masks.append(
+                GitHooksMask(host_path=os.path.realpath(dirpath), cage_path=cage_path)
+            )
     return GitHooksGuardPlan(binds=binds, masks=tuple(masks))
 
 

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -14,6 +14,11 @@ from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 
 from agentcage.config import Config
+from agentcage.git_hooks_guard import (
+    discover_git_hooks_masks,
+    render_guard_baseline_command,
+    render_guard_check_command,
+)
 
 
 def cage_network_addrs(
@@ -370,6 +375,33 @@ def generate_quadlets(
             continue
 
         expanded_volumes.append(expanded)
+
+    # Security (#170): mask every existing Git hooks directory reachable via
+    # writable host binds, including nested repos and extra mounted repos. The
+    # guard deliberately only emits masks for paths that already exist on the
+    # host; runtimes create absent mountpoints through the parent bind, which
+    # would litter clean projects. A lightweight stop-time tamper check watches
+    # for newly-created hooks and adjacent host-trusted config surfaces.
+    git_guard = discover_git_hooks_masks(
+        expanded_volumes, enabled=config.git_hooks_mask
+    )
+    cage_tmpfs = list(cc.tmpfs)
+    for mask in git_guard.masks:
+        cage_tmpfs.append(mask.tmpfs_spec)
+    if git_guard.masks:
+        click.echo(
+            "masking Git hooks under writable host binds: "
+            + ", ".join(mask.cage_path for mask in git_guard.masks)
+            + ". Disable with `git_hooks_mask: false`.",
+            err=True,
+        )
+    guard_baseline_command = render_guard_baseline_command(
+        name, git_guard.watch_roots if config.git_hooks_mask else ()
+    )
+    guard_check_command = render_guard_check_command(
+        name, git_guard.watch_roots if config.git_hooks_mask else ()
+    )
+
     expanded_env = {k: os.path.expandvars(str(v)) for k, v in cc.env.items()}
 
     # Cage placeholders are delivered via an EnvironmentFile (read by podman
@@ -657,7 +689,7 @@ def generate_quadlets(
         patches_host_dir=patches_host_dir,
         volumes=expanded_volumes,
         named_volumes=cc.named_volumes,
-        tmpfs=cc.tmpfs,
+        tmpfs=cage_tmpfs,
         podman_secrets=cage_podman_secrets,
         placeholders_env_path=placeholders_env_path,
         cage_env_dir=cage_env_dir,
@@ -679,6 +711,8 @@ def generate_quadlets(
         deploy_name=deploy_name,
         nested_containers=nested_containers,
         lifecycle=lifecycle,
+        guard_baseline_command=guard_baseline_command,
+        guard_check_command=guard_check_command,
     )
 
     return files

--- a/src/agentcage/templates/cage.container.j2
+++ b/src/agentcage/templates/cage.container.j2
@@ -97,6 +97,9 @@ Exec={{ command | systemd_exec }}
 {% endif %}
 
 [Service]
+{% if guard_baseline_command %}
+ExecStartPre={{ guard_baseline_command }}
+{% endif %}
 ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do podman exec {{ name }}-egress test -f /home/acproxy/.mitmproxy/mitmproxy-ca-cert.pem && exit 0; sleep 1; done; echo "Timed out waiting for CA cert"; exit 1'
 # Add the cage's default route via the egress container. Retries because
 # the container PID is briefly invalid (0/empty) right after `podman start`
@@ -106,6 +109,9 @@ ExecStartPre=/bin/bash -c 'for i in $(seq 1 30); do podman exec {{ name }}-egres
 # fails fast with ECONNREFUSED — surfacing as 502s in tests that
 # exercise the data path after a domain add or secret set restart.
 ExecStartPost=/bin/sh -c 'LAST_ERR=""; for i in $(seq 1 30); do PID=$(podman inspect --format "{{"{{"}}.State.Pid{{"}}"}}" {{ name }}-cage 2>/dev/null); if [ -n "$PID" ] && [ "$PID" != "0" ]; then LAST_ERR=$(nsenter -t "$PID" -U -n -- ip route replace default via {{ ip_egress }} 2>&1) && { echo "added default route via {{ ip_egress }} (attempt $i)"; exit 0; }; fi; sleep 0.5; done; echo "WARNING: failed to add cage default route via {{ ip_egress }} after 30 attempts: $LAST_ERR" >&2; exit 1'
+{% if guard_check_command %}
+ExecStopPost={{ guard_check_command }}
+{% endif %}
 Restart={{ restart }}
 RestartSec={{ restart_sec }}
 {% if timeout_start_sec %}

--- a/tests/test_git_hooks_guard.py
+++ b/tests/test_git_hooks_guard.py
@@ -1,0 +1,125 @@
+"""Tests for Git hook masking and tamper warnings (issue #170)."""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+from agentcage.config import load_config
+from agentcage.git_hooks_guard import (
+    diff_tamper_state,
+    discover_git_hooks_masks,
+    snapshot_tamper_state,
+)
+from agentcage.quadlets import generate_quadlets
+
+
+def _vol(host: Path, cage: str = "/workspace") -> str:
+    return f"{host}:{cage}:rw"
+
+
+class TestDiscovery:
+    def test_discovers_top_level_nested_and_extra_repo_binds(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        other = tmp_path / "other"
+        (workspace / ".git" / "hooks").mkdir(parents=True)
+        (workspace / "sub" / ".git" / "hooks").mkdir(parents=True)
+        (other / ".git" / "hooks").mkdir(parents=True)
+
+        plan = discover_git_hooks_masks(
+            [_vol(workspace), _vol(other, "/other")], enabled=True
+        )
+
+        assert [m.cage_path for m in plan.masks] == [
+            "/workspace/.git/hooks",
+            "/workspace/sub/.git/hooks",
+            "/other/.git/hooks",
+        ]
+
+    def test_does_not_mask_absent_hooks_or_read_only_binds(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        readonly = tmp_path / "readonly"
+        (workspace / ".git").mkdir(parents=True)
+        (readonly / ".git" / "hooks").mkdir(parents=True)
+
+        plan = discover_git_hooks_masks(
+            [f"{workspace}:/workspace:rw", f"{readonly}:/readonly:ro"],
+            enabled=True,
+        )
+
+        assert plan.masks == ()
+        assert plan.watch_roots == (os.path.realpath(workspace),)
+
+    def test_opt_out_keeps_watch_roots_but_no_masks(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        (workspace / ".git" / "hooks").mkdir(parents=True)
+        plan = discover_git_hooks_masks([_vol(workspace)], enabled=False)
+        assert plan.masks == ()
+        assert plan.watch_roots == (os.path.realpath(workspace),)
+
+
+class TestTamperSnapshot:
+    def test_warns_on_active_hook_git_config_and_claude_settings(self, tmp_path):
+        before = snapshot_tamper_state((str(tmp_path),))
+        (tmp_path / ".git" / "hooks").mkdir(parents=True)
+        (tmp_path / ".git" / "hooks" / "pre-commit").write_text("#!/bin/sh\n")
+        (tmp_path / ".git" / "hooks" / "pre-commit.sample").write_text("ignored\n")
+        (tmp_path / ".git" / "config").write_text("[core]\n")
+        (tmp_path / "nested" / ".claude").mkdir(parents=True)
+        (tmp_path / "nested" / ".claude" / "settings.json").write_text("{}\n")
+
+        warnings = diff_tamper_state(before, snapshot_tamper_state((str(tmp_path),)))
+
+        assert any("pre-commit" in w for w in warnings)
+        assert not any("pre-commit.sample" in w for w in warnings)
+        assert any(".git/config" in w for w in warnings)
+        assert any(".claude/settings.json" in w for w in warnings)
+
+
+def _yaml_with_workspace(tmp_path, project_dir, *, extra=""):
+    p = tmp_path / "config.yaml"
+    p.write_text(textwrap.dedent(f"""\
+        name: test
+        dns_servers: ["1.1.1.1"]
+        container:
+          image: localhost/test:latest
+          volumes:
+            - "{project_dir}:/workspace:rw"
+        {extra}
+    """))
+    return str(p)
+
+
+class TestQuadletIntegration:
+    def test_masks_all_existing_hooks_and_adds_tamper_check(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        project = tmp_path / "project"
+        (project / ".git" / "hooks").mkdir(parents=True)
+        (project / "sub" / ".git" / "hooks").mkdir(parents=True)
+
+        cfg = load_config(_yaml_with_workspace(tmp_path, project))
+        content = generate_quadlets(cfg, "/c.yaml", "/patches")["test-cage.container"]
+
+        assert "Tmpfs=/workspace/.git/hooks:rw,noexec,nosuid,size=8M" in content
+        assert "Tmpfs=/workspace/sub/.git/hooks:rw,noexec,nosuid,size=8M" in content
+        assert "workspace-guard.baseline" in content
+        assert "ExecStopPost=" in content
+
+    def test_opt_out_suppresses_masks_and_tamper_check(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        project = tmp_path / "project"
+        (project / ".git" / "hooks").mkdir(parents=True)
+
+        cfg = load_config(
+            _yaml_with_workspace(tmp_path, project, extra="git_hooks_mask: false")
+        )
+        content = generate_quadlets(cfg, "/c.yaml", "/patches")["test-cage.container"]
+
+        assert "/workspace/.git/hooks" not in content
+        assert "workspace-guard.baseline" not in content
+
+    def test_default_config_field_is_true(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text("name: test\ndns_servers: ['1.1.1.1']\ncontainer:\n  image: x\n")
+        assert load_config(str(p)).git_hooks_mask is True


### PR DESCRIPTION
Replaces PR #272's single-path /workspace/.git/hooks mask with broader workspace hardening for #170.\n\nSummary:\n- discover and tmpfs-mask every existing Git hooks directory under writable host binds, including nested repos and additional mounted repos\n- keep the existing litter guard by masking only host paths that already exist\n- add tamper warnings for newly-created/modified host-trusted workspace files such as active hooks, .git/config, .gitattributes, .gitmodules, .lfsconfig, and .claude/settings.json\n- support container/vm quadlets and apple-container start/stop paths\n- document git_hooks_mask