### PR TITLE
fix(apple-container): mount cage /certs read-only (#275)

### DIFF
--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -1196,7 +1196,13 @@ class AppleContainerBackend:
             # cert for any allowlisted host. Bind public_certs_dir
             # instead — egress's Step E copies only the public cert
             # there. The full mitmproxy dir is now egress-only.
-            "--volume", f"{public_certs_dir}:/certs",
+            #
+            # CTF (#275, 0.25.4): mount :ro so the uid-1000 workload can
+            # only read the public CA cert it's told to trust via
+            # SSL_CERT_FILE / NODE_EXTRA_CA_CERTS — not tamper with,
+            # replace, or persist host-backed files under /certs. Matches
+            # the quadlet backend's `:/certs:ro,Z` (cage.container.j2).
+            "--volume", f"{public_certs_dir}:/certs:ro",
             # CTF F2 (0.22.6): the cage's local dnsmasq (cage-init stage A')
             # reads the same allowlist-scoped config the egress sibling
             # uses, bind-mounted from the host's egress-config dir. macOS

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -840,6 +840,32 @@ def test_start_argv_injects_proxy_ca_env_vars(tmp_path, monkeypatch):
     assert "NODE_EXTRA_CA_CERTS=/certs/mitmproxy-ca-cert.pem" in cage_argv
 
 
+def test_start_cage_mounts_certs_read_only(tmp_path, monkeypatch):
+    """CTF (#275, 0.25.4): the public-cert dir must be bound at /certs
+    read-only. The uid-1000 workload is told to TRUST this CA via
+    SSL_CERT_FILE / NODE_EXTRA_CA_CERTS; a writable virtiofs mount let it
+    tamper with, replace, or persist host-backed files under /certs,
+    violating the cage->egress trust boundary. Mirrors the quadlet
+    backend's `:/certs:ro,Z` (cage.container.j2)."""
+    public_certs_dir = tmp_path / "public-certs"
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x",
+            "cpus": "", "memory": "", "lifecycle": "interactive",
+        },
+    )
+
+    backend.start("demo", quiet=True)
+
+    cage_argv = _cage_run_argv(captured)
+    # The cage sees /certs read-only — never a writable bind.
+    assert f"{public_certs_dir}:/certs:ro" in cage_argv
+    assert f"{public_certs_dir}:/certs" not in cage_argv
+    certs_binds = [a for a in cage_argv if a.endswith((":/certs", ":/certs:ro"))]
+    assert certs_binds == [f"{public_certs_dir}:/certs:ro"]
+
+
 def test_start_cage_binds_dnsmasq_conf_for_local_resolver(tmp_path, monkeypatch):
     """CTF F2 (0.22.6): the cage's local dnsmasq (cage-init.sh stage A')
     reads the same dnsmasq.conf the egress sibling does, bind-mounted
@@ -902,8 +928,9 @@ def test_start_cage_bind_excludes_ca_private_key(tmp_path, monkeypatch):
     certs_dir = str(tmp_path / "certs")
     public_certs_dir = str(tmp_path / "public-certs")
 
-    # Cage's /certs MUST come from public_certs_dir.
-    assert f"{public_certs_dir}:/certs" in cage_argv
+    # Cage's /certs MUST come from public_certs_dir (and be read-only;
+    # see test_start_cage_mounts_certs_read_only / #275).
+    assert f"{public_certs_dir}:/certs:ro" in cage_argv
     # Cage MUST NOT mount certs_dir anywhere (any guest path) — that
     # would re-introduce the CA-private-key leak. Anchor on the host
     # path so an empty certs_dir name (unlikely tmp_path collision)


### PR DESCRIPTION
Fixes #275.

## Problem

In the apple-container backend, the cage workload received the public MITM CA cert directory at `/certs` as a **writable** `virtiofs` mount:

```py
"--volume", f"{public_certs_dir}:/certs",   # no :ro
```

The uid-1000 workload is explicitly configured to *trust* this CA via `SSL_CERT_FILE` and `NODE_EXTRA_CA_CERTS`, yet could create, modify, delete, or replace files under `/certs` — a host-backed persistence/tamper surface that violates the intended cage→egress trust boundary.

This was **not** a private-key exposure: only the public `mitmproxy-ca-cert.pem` lives in `public_certs_dir`; the full mitmproxy dir holding `mitmproxy-ca.pem` (the CA private key) has been egress-only since 0.22.6. The remaining gap was mount mutability.

## Fix

Add `:ro` to the cage's `/certs` bind, matching the quadlet backend's `Volume={{ name }}-public-certs.volume:/certs:ro,Z` in `cage.container.j2`:

```py
"--volume", f"{public_certs_dir}:/certs:ro",
```

Apple's `container run` already accepts the `:ro` mode flag — the egress argv uses it for several binds. The egress sibling keeps its **writable** `public-certs` bind so `supervisor-egress.sh` Step E can still copy the public cert in for the cage to pick up.

## Tests

- New `test_start_cage_mounts_certs_read_only` asserts the cage mounts `/certs` read-only and never via a writable bind.
- Updated the existing CA-private-key exclusion test for the new `:ro` suffix.
- All 130 `tests/test_apple_container.py` tests pass. (9 unrelated failures in secret-rotation/apply tests pre-exist on `master`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)