### PR TITLE
fix(egress): don't chown public-certs volume to acproxy (crashes cage restart on hardened podman)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The egress — and with it the cage — crashed on every restart after the first, on hardened rootless podman (`default_capabilities = []`).** The egress quadlet ran an `ExecStartPre` that chowned the `agentcage-public-certs-<name>` volume mountpoint to `acproxy` (uid 200), mirroring the chown of the *private* certs volume. But unlike the private volume (written by mitmproxy *as* acproxy), the public-certs volume is written **only** by the supervisor, which runs as uid 0 and publishes the public CA cert with `install -m 0644` (`supervisor-egress.sh` Step E). On a host whose `containers.conf` sets `default_capabilities = []`, container uid 0 holds none of `CAP_DAC_OVERRIDE` / `CAP_FOWNER`, so once the directory was acproxy-owned the supervisor could no longer `unlink()` the existing cert to rewrite it — `install: cannot remove '/home/acproxy/public-certs/mitmproxy-ca-cert.pem': Permission denied`, exit 1, and systemd tore the dependent cage down. The first `cage create` came up (nothing to overwrite yet), but every subsequent `cage start` / `cage restart` / `cage update` (e.g. after editing a workspace mount path) failed. The chown is removed: the public-certs dir stays root-owned, the uid-0 supervisor overwrites it freely, and the `0644` cert is still world-readable for the cage's `:ro` `/certs` mount — so the cage→egress trust boundary (CTF F6/F9) is unaffected. The apple-container backend was never affected (it `chmod 1777`s the dir instead of chowning it). Regressed in 0.22.10 ([#211](https://github.com/agentcage/agentcage/issues/211)).
+
 ## [0.25.5] - 2026-06-26
 
 ### Fixed

--- a/src/agentcage/templates/egress.container.j2
+++ b/src/agentcage/templates/egress.container.j2
@@ -174,7 +174,19 @@ ExecStartPre=-/bin/bash -c 'umask 077; f="%t/agentcage/{{ name }}/secrets/{{ sec
 ExecStartPre=-/bin/bash -c '{% if rootless %}podman unshare chown -R 200:200{% else %}chown -R 200:200{% endif %} "%t/agentcage/{{ name }}/secrets"'
 {% endif %}
 ExecStartPre=/bin/bash -c 'mp=$(podman volume inspect agentcage-certs-{{ name }} --format "{{"{{"}}.Mountpoint{{"}}"}}") && {% if rootless %}podman unshare chown{% else %}chown{% endif %} 200:200 "$mp"'
-ExecStartPre=/bin/bash -c 'mp=$(podman volume inspect agentcage-public-certs-{{ name }} --format "{{"{{"}}.Mountpoint{{"}}"}}") && {% if rootless %}podman unshare chown{% else %}chown{% endif %} 200:200 "$mp"'
+{# The agentcage-public-certs-{{ name }} volume is deliberately NOT chowned to
+   acproxy. Unlike the private certs volume above (written by mitmproxy AS
+   acproxy, hence its 200:200 chown), public-certs is written ONLY by the
+   supervisor — which runs as uid 0 — when Step E `install`s the public CA
+   cert into it, and the cage mounts it read-only. Chowning the dir to acproxy
+   made the supervisor a non-owner: on hardened hosts (`default_capabilities =
+   []`) uid 0 lacks CAP_DAC_OVERRIDE/CAP_FOWNER, so `install` could not
+   unlink+rewrite the existing cert on any restart after the first
+   (`install: cannot remove ...: Permission denied`), crashing the egress —
+   and with it the cage — on every restart. Leaving the dir root-owned lets
+   the supervisor overwrite it freely; the 0644 cert stays world-readable for
+   the cage's :ro /certs mount, so the cage→egress trust boundary (CTF F6/F9)
+   is unaffected. #}
 {% if capture_enabled %}
 ExecStartPre=/bin/bash -c '{% if rootless %}podman unshare chown 200:200 "{{ capture_host_dir }}" 2>/dev/null || chmod 1777 "{{ capture_host_dir }}"{% else %}chown 200:200 "{{ capture_host_dir }}"{% endif %}'
 {% endif %}

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -98,6 +98,31 @@ class TestEgressQuadlet:
         assert "AddCapability=SETPCAP" in content
         assert "AddCapability=KILL" in content
 
+    def test_egress_chowns_private_certs_but_not_public_certs(self, minimal_yaml):
+        """The private certs volume (/home/acproxy/.mitmproxy) is written by
+        mitmproxy AS acproxy, so the egress chowns its mountpoint to 200:200.
+        The public-certs volume is the opposite: written ONLY by the uid-0
+        supervisor (Step E ``install``s the public CA cert into it) and mounted
+        ``:ro`` by the cage, so its mountpoint must stay root-owned.
+
+        REGRESSION GUARD: #211 added an ExecStartPre that chowned the
+        public-certs mountpoint to 200:200. On hardened hosts
+        (``default_capabilities = []``) the supervisor runs as uid 0 without
+        CAP_DAC_OVERRIDE/CAP_FOWNER; once it no longer owned the dir, ``install``
+        could not unlink+rewrite the existing cert on restart — ``install:
+        cannot remove ...: Permission denied`` crashed the egress (and with it
+        the cage) on every start after the first.
+        """
+        cfg = load_config(minimal_yaml)
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-egress.container"]
+        # Private certs volume IS chowned to acproxy.
+        assert "podman volume inspect agentcage-certs-test --format" in content
+        assert '200:200 "$mp"' in content
+        # Public-certs volume mountpoint must NOT be chowned (no inspect+chown
+        # ExecStartPre targeting it).
+        assert "agentcage-public-certs-test --format" not in content
+
     def test_egress_port_policy_default(self, minimal_yaml):
         """A cage with no `ports:` override gets the default policy —
         tcp.allow=[80,443], no passthrough, no UDP. The supervisor reads
@@ -192,19 +217,15 @@ class TestEgressQuadlet:
         assert "Volume=test-certs.volume:/home/acproxy/.mitmproxy:Z" in content
 
     def test_egress_public_certs_volume(self, minimal_yaml):
-        """Egress also mounts the public-certs volume RW so
-        supervisor-egress.sh Step E can publish mitmproxy-ca-cert.pem
-        there. Cage will mount the SAME volume read-only at /certs."""
+        """Egress mounts the public-certs volume RW so supervisor-egress.sh
+        Step E can publish mitmproxy-ca-cert.pem there. The cage mounts the
+        SAME volume read-only at /certs. The mountpoint is intentionally NOT
+        chowned to acproxy — see
+        test_egress_chowns_private_certs_but_not_public_certs for why."""
         cfg = load_config(minimal_yaml)
         files = generate_quadlets(cfg, "/c.yaml", "/patches")
         content = files["test-egress.container"]
         assert "Volume=test-public-certs.volume:/home/acproxy/public-certs:Z" in content
-        # Chown ExecStartPre for the public-certs mountpoint mirrors the
-        # private-certs one — uid 200 = acproxy inside the egress image.
-        assert (
-            "podman volume inspect agentcage-public-certs-test" in content
-            and "200:200" in content
-        )
 
     def test_egress_config_bind(self, minimal_yaml):
         """The proxy-config bind source is the host path passed to


### PR DESCRIPTION
## Summary

On hardened rootless podman (`containers.conf` with `default_capabilities = []`), the egress container — and with it the dependent cage — **crashes on every restart after the first**. `cage create` comes up, but `cage start` / `cage restart` / `cage update` (e.g. after editing a workspace mount path) tears the cage down with:

```
my-claude-egress: install: cannot remove '/home/acproxy/public-certs/mitmproxy-ca-cert.pem': Permission denied
my-claude-egress.service: Main process exited, code=exited, status=1/FAILURE
Stopping agentcage cage...
```

## Root cause

The egress quadlet ran an `ExecStartPre` that chowned the **public-certs** volume mountpoint to `acproxy` (uid 200), mirroring the chown of the *private* certs volume:

```
ExecStartPre=... podman unshare chown 200:200 "$mp"   # agentcage-public-certs-<name>
```

But the two volumes are written by different users:

- **private** `agentcage-certs-<name>` (`/home/acproxy/.mitmproxy`) — written by **mitmproxy, as acproxy** → the 200:200 chown is correct and stays.
- **public** `agentcage-public-certs-<name>` (`/home/acproxy/public-certs`) — written **only by the supervisor**, which runs as **uid 0**, via `install -m 0644` (`supervisor-egress.sh` Step E). The cage only reads it, `:ro`, at `/certs`.

With `default_capabilities = []`, container uid 0 holds none of `CAP_DAC_OVERRIDE` / `CAP_FOWNER`. Once the directory is acproxy-owned (0755), root is "other" and can't get write on it — so `install` can't `unlink()` the existing cert to rewrite it → `EACCES` → exit 1 → systemd stops the cage.

First `cage create` succeeds because the cert doesn't exist yet (no unlink needed); every restart afterward finds the existing cert and fails.

Regressed in **0.22.10** (#211), which split the public cert into its own volume + added the chown. The sibling "egress starts on hardened podman" work hardened the pidfile dir and ready-marker for no-`DAC_OVERRIDE` hosts but missed this `install` overwrite.

## Fix

Remove the public-certs chown. The directory stays root-owned, so the uid-0 supervisor can create **and** overwrite the cert on every start. The `0644` cert remains world-readable for the cage's `:ro` `/certs` mount, so the cage→egress trust boundary (CTF F6/F9) is unaffected.

This aligns the container/vm quadlet path with the **apple-container** backend, which was never affected because it already `chmod 1777`s the dir instead of chowning it (`apple_container.py`).

## Verification

- New regression guard `test_egress_chowns_private_certs_but_not_public_certs` — asserts the private certs volume **is** chowned and the public-certs mountpoint **is not**. Fails on the pre-fix template, passes after. Full `test_quadlets.py`: 87 passed.
- Live on a host with `default_capabilities = []` (repro): recreated a cage, then `cage restart` ×4 + a `cage update` that changed the workspace mount path → `running (2/2)` every time, `published public cert` in the egress log, **zero** `cannot remove` errors. `cage verify` → 7 passed / 0 failed.

## Scope

`egress.container.j2` is shared by the **container** and **vm** backends, so both are fixed by the one-line template change. apple-container unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
