### PR TITLE
docs(apple-container): correct --as-root egress claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Corrected the `--as-root` docs/help — root cannot bypass the egress filter on apple-container.** The `agentcage run` / `cage exec` / `cage shell` `--as-root` help text, the `apple_container.py` module docstring, and `docs/explain/isolation-modes.md` all claimed that an `--as-root` (`container exec --user 0`) session "re-acquires `CAP_NET_ADMIN`" and could "rewrite its default route to skip the egress sibling" / "disable iptables and read injected secrets" — described as a known limitation of a "single-microVM architecture." None of this is true on the current 2-microVM backend with Apple `container` 1.0.0. An exec session is granted only the **default OCI capability set** (`CapEff` `a80425fb`, no `CAP_NET_ADMIN`), so as uid 0 `iptables -F` returns EPERM, `ip route replace/del default` returns "Operation not permitted," and non-allowlisted egress (arbitrary ports, direct `:53`, and HTTP to non-allowlisted hosts → 403) stays blocked while allowlisted traffic works. Verified end-to-end on a ubuntu cage. Docs now state that even root remains confined behind the egress sibling; no behavior changed.
+
 ## [0.26.0] - 2026-06-26
 
 ### Added

--- a/docs/explain/isolation-modes.md
+++ b/docs/explain/isolation-modes.md
@@ -45,8 +45,6 @@ For the threat-by-threat matrix, see [Security model](security-model.md).
 
 **vm — host bind mounts are restricted.** Paths under blocked directories like `~/.ssh` or `~/.aws` are rejected, and the path must exist on the host before `cage create`. Mounts are read-only by default.
 
-**apple-container — `--as-root` can bypass egress.** A `cage exec --user 0` session inside the cage microVM can re-acquire `CAP_NET_ADMIN` and rewrite its default route to skip the egress sibling. It still cannot read cleartext secrets (those live in the separate egress microVM). For hardened `--as-root` sessions, use `vm`.
-
 **apple-container — most edits need `cage update`.** Allowlist, command, env, secret-injection rules, capture, and autostart are baked into the wrapper image at build time. `domain add / rm` auto-rebuilds; other edits need an explicit `cage update`.
 
 **apple-container — `cage backup --include-secrets` is unsupported.** Secrets are provided once at `cage create` and never reconciled into a portable backup. The backup manifest records the env-var names; re-set them on the restore host with `--set-secret`.

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -18,17 +18,24 @@ capsh-drops to uid 1000 and exec's the user's CMD.
 
 Threat model — workload (uid 1000) cannot:
   * read /home/acproxy/secrets/* (not in cage VM's namespace at all)
-  * modify iptables (no binary in cage wrapper)
+  * modify iptables (no NET_ADMIN in CapEff/CapPrm at uid 1000 — the
+    nft/iptables netlink ops require it)
   * change routes (no NET_ADMIN in CapEff/CapPrm at uid 1000)
   * see other UIDs' processes (kernel namespace gives this for free —
     no need for the legacy supervisor.sh's hidepid=2 remount)
 
-Known residual: cage VM is started with --cap-add CAP_NET_ADMIN (needed
-for cage-init's `ip route replace`). `container exec --user 0 <cage>`
-re-acquires NET_ADMIN per the spike on Apple's runtime; an operator with
---as-root can `ip route replace default via <host-bridge-ip>` to bypass
-the egress sibling. Workload threat is unaffected. Tracked for v0.23 via
-macOS pf rules.
+--as-root is also confined: the cage VM is started with --cap-add
+CAP_NET_ADMIN (needed for cage-init's stage-B `ip route replace`), but
+capsh drops it before the workload runs, and a later operator
+`container exec --user 0 <cage>` does NOT inherit it — Apple's
+`container` 1.0.0 grants an exec session only the DEFAULT OCI capability
+set (CapEff a80425fb: chown, setuid, net_bind_service, net_raw, …; no
+NET_ADMIN). Verified end-to-end on a ubuntu cage (container 1.0.0): as
+uid 0, `iptables -F` returns EPERM, `ip route replace/del default`
+returns "Operation not permitted", and non-allowlisted egress (arbitrary
+ports, direct :53, 403'd HTTP) stays blocked — even root cannot bypass
+the egress sibling. The exec path's `setpriv --bounding-set=-net_admin`
+wrap is defense-in-depth on top of that.
 """
 
 from __future__ import annotations
@@ -1182,10 +1189,11 @@ class AppleContainerBackend:
 
         # 5. Cage VM. CAP_NET_ADMIN is needed for cage-init's `ip route
         # replace default via <egress_ip>`. capsh drops it before the
-        # workload runs, so uid 1000 has no caps — but `cage exec --user 0`
-        # re-acquires NET_ADMIN per the spike (known residual; see module
-        # docstring). The cage VM has NO secrets bind, NO config bind,
-        # NO mitmproxy/dnsmasq/iptables.
+        # workload runs, so uid 1000 has no caps. `cage exec --user 0`
+        # does NOT re-acquire it either: container 1.0.0 hands exec
+        # sessions only the default OCI cap set (no NET_ADMIN), so even
+        # --as-root can't change routes/iptables (see module docstring).
+        # The cage VM has NO secrets bind, NO config bind.
         cage_argv = [
             "run", "-d", "--name", name,
             "--cap-add", "CAP_NET_ADMIN",
@@ -1602,10 +1610,12 @@ class AppleContainerBackend:
             it's stripped from uid 1000's CapEff by the uid 0→1000
             transition that `container exec -u` performs.
           * ``as_root=True``           → ``-u 0:0``. Operator debug
-            path. Image USER (root on the slim wrapper) applies. Per
-            the spike on Apple's runtime, --user 0 RE-acquires
-            NET_ADMIN — operator with --as-root can change the cage's
-            default route. Workload-uid-1000 is unaffected.
+            path. Image USER (root on the slim wrapper) applies, but
+            `container exec -u 0` on Apple `container` 1.0.0 grants only
+            the DEFAULT OCI cap set (no CAP_NET_ADMIN), so even this
+            session cannot change the cage's default route or touch
+            iptables — `ip route replace` / `iptables -F` return EPERM.
+            Verified on a ubuntu cage; see the module docstring.
 
         The legacy capsh wrap is gone: with no iptables/dnsmasq inside
         the cage VM and no secrets bind-mount, there's no

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -577,13 +577,8 @@ def init(name: str | None, output: str, image: str, isolation: str | None,
               default=None,
               help="Isolation backend (default: auto-detect from platform).")
 @click.option("--as-root", is_flag=True,
-              help="Run the session as root inside the cage (debug only — "
-                   "bypasses the cage's egress filter via CAP_NET_ADMIN). "
-                   "Default is the cage workload's uid 1000 user. "
-                   "NOTE: on apple-container the egress filter and secret "
-                   "store share the cage's microVM, so --as-root can "
-                   "disable iptables and read injected secrets — a known "
-                   "limitation of the single-microVM architecture.")
+              help="Run the session as root (uid 0) instead of the "
+                   "workload's uid 1000 user (debug only).")
 @click.option("--time", "show_timing", is_flag=True,
               help="Echo per-phase wall times and print a summary on completion.")
 @click.option("--no-cache", is_flag=True,
@@ -2216,13 +2211,8 @@ def _logs_apple_container(name, services, lines, no_follow, min_level=None, cfg=
               type=click.Choice(["cage", "egress"]),
               help="Container service to exec into.", show_default=True)
 @click.option("--as-root", is_flag=True,
-              help="Run the command as root inside the cage (debug only — "
-                   "bypasses the cage's egress filter via CAP_NET_ADMIN). "
-                   "Default is the cage workload's uid 1000 user. "
-                   "NOTE: on apple-container the egress filter and secret "
-                   "store share the cage's microVM, so --as-root can "
-                   "disable iptables and read injected secrets — a known "
-                   "limitation of the single-microVM architecture.")
+              help="Run the command as root (uid 0) instead of the "
+                   "workload's uid 1000 user (debug only).")
 @click.argument("command", nargs=-1, type=click.UNPROCESSED, required=True)
 def cage_exec(name: str, service: str, command: tuple[str, ...], as_root: bool):
     """Run a command inside a cage container.
@@ -2306,13 +2296,8 @@ def cage_exec(name: str, service: str, command: tuple[str, ...], as_root: bool):
               type=click.Choice(["cage", "egress"]),
               help="Container service to shell into.", show_default=True)
 @click.option("--as-root", is_flag=True,
-              help="Open the shell as root (debug only — bypasses the "
-                   "cage's egress filter via CAP_NET_ADMIN). Default is "
-                   "the cage workload's uid 1000 user. "
-                   "NOTE: on apple-container the egress filter and secret "
-                   "store share the cage's microVM, so --as-root can "
-                   "disable iptables and read injected secrets — a known "
-                   "limitation of the single-microVM architecture.")
+              help="Open the shell as root (uid 0) instead of the "
+                   "workload's uid 1000 user (debug only).")
 def cage_shell(name: str, service: str, as_root: bool):
     """Open an interactive shell in a cage container."""
     if not state.deployment_exists(name):


### PR DESCRIPTION
## What

Corrects the `--as-root` documentation/help. The text claimed root can bypass the egress filter on apple-container; **verified false** — root stays confined.

## Background

Following the question "can root on apple-container bypass the egress and exfil data?", I tested it end-to-end on a ubuntu cage (macOS 26.5.1, Apple `container` 1.0.0). The docs were wrong: a `cage exec --user 0` session gets only the **default OCI capability set** (`CapEff a80425fb`, no `CAP_NET_ADMIN`), not the cage's run-time `--cap-add CAP_NET_ADMIN`.

| Test (as uid 0, `--as-root`) | Result |
|---|---|
| `iptables -L/-F OUTPUT` | Permission denied (EPERM) |
| `ip route replace default via <host-gw>` | Operation not permitted |
| `ip route del default` | Operation not permitted |
| TCP to arbitrary port / direct `:53` | blocked / timeout |
| DNS `evil.example.com` | sinkholed |
| HTTP to non-allowlisted host | 403 Forbidden |
| HTTP to allowlisted host | 200 OK |

So even root cannot tamper with the filter or routes, and all egress stays confined to the allowlist.

## Wrong claims removed/corrected

- **`cli.py`** — `run` / `cage exec` / `cage shell` `--as-root` help said it "bypasses the cage's egress filter via CAP_NET_ADMIN" and that on apple-container "the egress filter and secret store share the cage's microVM, so --as-root can disable iptables and read injected secrets — a known limitation of the single-microVM architecture." All false on the 2-microVM backend. Replaced with a short, accurate note.
- **`apple_container.py`** — module docstring "Known residual" + the `exec_argv`/`start()` comments claiming `container exec --user 0` "re-acquires NET_ADMIN per the spike" and can `ip route replace ... to bypass the egress sibling." Corrected to the verified behavior.
- **`docs/explain/isolation-modes.md`** — removed the false "**apple-container — `--as-root` can bypass egress**" limitation bullet.

## Notes

- **No behavior changed** — docs/help only. The backend already confines root correctly.
- Detailed reasoning lives in the docstrings + CHANGELOG; the help text is kept short per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)