### PR TITLE
chore(release): 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-06-29
+
 ### Changed
 
 - **`container.add_capabilities` no longer emits a "silently has no effect on apple-container" warning.** The warning fired on every default apple-container cage: every stock package-manager scaffold (ubuntu/debian/arch/openclaw) sets `add_capabilities` unconditionally for the *container* backend's package-install path, so an operator running `agentcage run ubuntu` saw the noise without having opted into anything. The field is genuinely inert on apple-container — the cage workload always runs as uid 1000 with an empty capability set (`cage-init.sh` Stage D capsh-`--drop=all`s before exec, and the backend never threads `add_capabilities` into `container run`) — but that inertness is harmless rather than a misconfiguration, so it doesn't warrant a warning on the common path. This mirrors the earlier tuning of the `read_only` / `tmpfs` warnings, which were narrowed for the same reason. (The warning's old text also referenced a non-existent "stage 90" from the retired single-VM supervisor.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.26.0"
+version = "0.26.1"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.25.5"
+version = "0.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release bumping `0.26.0` → `0.26.1`.

Rolls up the two changes already merged to master since 0.26.0:

- **Changed** — `container.add_capabilities` no longer emits a "silently has no effect on apple-container" warning (#283).
- **Fixed** — corrected the `--as-root` docs/help: root cannot bypass the egress filter on apple-container (#284).

Updates `pyproject.toml`, `uv.lock`, and moves the `[Unreleased]` CHANGELOG entries under `[0.26.1] - 2026-06-29`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)