### PR TITLE
feat(cli): make `agentcage run` an alias of `agentcage cage run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`agentcage cage run` is now the canonical command; `agentcage run` is a top-level alias of it.** `run` was the only cage lifecycle verb that lived outside the `cage` group, while its siblings (`create`, `exec`, `shell`, `logs`, `status`, …) all sit under `cage` with short top-level aliases. `run` now follows the same shape: the command is registered under `cage`, and `agentcage run` resolves to it via the existing `_BannerGroup` alias mechanism (shown as `run → cage run` in `agentcage --help`). No flags or behavior changed — `agentcage run <scaffold>` works exactly as before.
+
 ### Changed
 
 - **`container.add_capabilities` no longer emits a "silently has no effect on apple-container" warning.** The warning fired on every default apple-container cage: every stock package-manager scaffold (ubuntu/debian/arch/openclaw) sets `add_capabilities` unconditionally for the *container* backend's package-install path, so an operator running `agentcage run ubuntu` saw the noise without having opted into anything. The field is genuinely inert on apple-container — the cage workload always runs as uid 1000 with an empty capability set (`cage-init.sh` Stage D capsh-`--drop=all`s before exec, and the backend never threads `add_capabilities` into `container run`) — but that inertness is harmless rather than a misconfiguration, so it doesn't warrant a warning on the common path. This mirrors the earlier tuning of the `read_only` / `tmpfs` warnings, which were narrowed for the same reason. (The warning's old text also referenced a non-existent "stage 90" from the retired single-VM supervisor.)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ Reference for every `agentcage` command, subcommand, and flag. Pair with [Config
 agentcage <command> [args] [options]
 ```
 
-Top-level commands: `run`, `init`, `doctor`. Command groups: `cage`, `secret`, `domain`, `scaffold`.
+Top-level commands: `run` (alias of `cage run`), `init`, `doctor`. Command groups: `cage`, `secret`, `domain`, `scaffold`.
 
 ## init
 
@@ -30,6 +30,8 @@ agentcage init [NAME] [options]
 ## run
 
 Create a sandboxed cage from a scaffold, open an interactive session, and stop the cage on exit. The cage state is preserved after exit for auditing — use `cage prune` to clean up.
+
+The canonical command is `agentcage cage run`; `agentcage run` is a top-level alias of it (like `agentcage exec` / `agentcage shell`). Both forms take the same arguments.
 
 ```bash
 agentcage run SCAFFOLD [options] [-- EXTRA_ARGS...]
@@ -65,6 +67,7 @@ Manage cages.
 | Command | Description |
 |---------|-------------|
 | `cage create -c CONFIG` | Build images, generate quadlets, install, and start a new cage |
+| `cage run SCAFFOLD` | Create a cage from a scaffold, open an interactive session, and stop on exit (top-level alias: `agentcage run` — see [run](#run)) |
 | `cage update NAME [-c CONFIG]` | Rebuild images and restart an existing cage |
 | `cage edit NAME` | Edit a cage's stored config in `$EDITOR` with validation and live-reload |
 | `cage list` | List all cages with status |
@@ -85,7 +88,7 @@ Manage cages.
 
 Aliases: `ls`/`ps`/`status` → `list`, `rm`/`delete` → `destroy`, `reload` → `restart`, `describe`/`inspect` → `show`, `config` → `edit`, `update` → `update`.
 
-> **Note**: `agentcage` also supports dropping the `cage` group prefix for all standard cage commands and these aliases (e.g. `agentcage ls`, `agentcage start`, `agentcage stop`, `agentcage update`, `agentcage logs` function as their `cage` equivalents).
+> **Note**: `agentcage` also supports dropping the `cage` group prefix for all standard cage commands and these aliases (e.g. `agentcage run`, `agentcage ls`, `agentcage start`, `agentcage stop`, `agentcage update`, `agentcage logs` function as their `cage` equivalents).
 
 ### cage create
 

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -398,6 +398,7 @@ class _BannerGroup(click.Group):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._global_aliases = {
+            "run": ("run", "cage run"),
             "ls": ("cage_list", "cage list"),
             "rm": ("cage_destroy", "cage destroy"),
             "delete": ("cage_destroy", "cage destroy"),
@@ -563,7 +564,7 @@ def init(name: str | None, output: str, image: str, isolation: str | None,
 # ── run ──────────────────────────────────────────────────
 
 
-@main.command(context_settings={"ignore_unknown_options": True})
+@click.command("run", context_settings={"ignore_unknown_options": True})
 @click.argument("scaffold")
 @click.option("--project", "project_dir", default=None, type=click.Path(exists=True),
               help="Project directory to mount (default: current directory).")
@@ -634,6 +635,13 @@ def run(scaffold: str, project_dir: str | None, name: str | None,
 @main.group(cls=AliasGroup, aliases={"ls": "list", "rm": "destroy", "ps": "list", "reload": "restart", "delete": "destroy", "describe": "show", "inspect": "show", "config": "edit"})
 def cage():
     """Manage cages."""
+
+
+# `agentcage run` is a top-level alias of `agentcage cage run` (wired via
+# _BannerGroup._global_aliases, same mechanism as exec / shell / logs). The
+# canonical command lives under the cage group; the `run` Command object is
+# defined above (@click.command("run")) and registered here.
+cage.add_command(run, "run")
 
 
 @cage.command("create")

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -230,6 +230,24 @@ class TestRunCommand:
         assert result.exit_code == 0
         assert "scaffold" in result.output.lower() or "SCAFFOLD" in result.output
 
+    def test_cage_run_help(self):
+        """`run` is canonically `cage run`; the subcommand resolves and
+        carries the same SCAFFOLD argument as the top-level alias."""
+        result = _runner().invoke(main, ["cage", "run", "--help"])
+        assert result.exit_code == 0
+        assert "scaffold" in result.output.lower() or "SCAFFOLD" in result.output
+
+    def test_run_is_alias_of_cage_run(self):
+        """Top-level `run` and `cage run` resolve to the same command."""
+        from agentcage.cli import cage, main as main_grp
+        top = main_grp.get_command(None, "run")
+        sub = cage.get_command(None, "run")
+        assert top is not None and top is sub
+
+    def test_run_listed_in_top_level_aliases(self):
+        result = _runner().invoke(main, ["--help"])
+        assert "run → cage run" in result.output
+
     def test_cage_help_shows_prune(self):
         result = _runner().invoke(main, ["cage", "--help"])
         assert "prune" in result.output


### PR DESCRIPTION
## What

Makes `agentcage cage run` the canonical command and `agentcage run` a top-level alias of it.

## Why

`run` was the only cage lifecycle verb that lived outside the `cage` group. Its siblings — `create`, `exec`, `shell`, `logs`, `status`, etc. — all sit under `cage` and are exposed at the top level via short aliases. `run` now follows the same shape, so the command tree is consistent.

## How

- The `run` command is now defined as a standalone `@click.command("run")` and registered under the `cage` group (`cage.add_command(run, "run")`).
- `agentcage run` resolves to it through the existing `_BannerGroup._global_aliases` mechanism — the exact path that already powers `agentcage exec` / `shell` / `logs`. It shows as `run → cage run` in `agentcage --help`.

No flags or behavior changed — `agentcage run <scaffold> ...` works exactly as before.

## Tests

- `test_cage_run_help` — `agentcage cage run --help` resolves with the `SCAFFOLD` arg.
- `test_run_is_alias_of_cage_run` — top-level `run` and `cage run` resolve to the **same** Command object.
- `test_run_listed_in_top_level_aliases` — `run → cage run` appears in `--help`.
- Existing `test_run_help` still passes.

## Docs

Updated `docs/reference/cli.md`: overview line, the `## run` section note, a `cage run` table row, and the prefix-dropping note.

> Note: 3 pre-existing failures in `tests/test_run.py` (`TestExecuteMissingSecrets` / `TestExecuteForwardsBuildFlags`) fail identically on clean `master` — they exercise `run.execute`'s build path and are unrelated to this CLI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)