### PR TITLE
chore(release): 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-29
+
 ### Added
 
 - **`agentcage cage run` is now the canonical command; `agentcage run` is a top-level alias of it.** `run` was the only cage lifecycle verb that lived outside the `cage` group, while its siblings (`create`, `exec`, `shell`, `logs`, `status`, …) all sit under `cage` with short top-level aliases. `run` now follows the same shape: the command is registered under `cage`, and `agentcage run` resolves to it via the existing `_BannerGroup` alias mechanism (shown as `run → cage run` in `agentcage --help`). No flags or behavior changed — `agentcage run <scaffold>` works exactly as before.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.26.0"
+version = "0.27.0"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.25.5"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Minor release `0.26.0` → `0.27.0` (minor because a new feature landed).

Rolls up everything merged to master since 0.26.0:

- **Added** — `agentcage cage run` is now the canonical command; `agentcage run` is a top-level alias of it (#286).
- **Changed** — `container.add_capabilities` no longer emits a "silently has no effect on apple-container" warning (#283).
- **Fixed** — corrected the `--as-root` docs/help: root cannot bypass the egress filter on apple-container (#284).

Updates `pyproject.toml` + `uv.lock` and moves the `[Unreleased]` CHANGELOG entries under `[0.27.0] - 2026-06-29`.

Supersedes #285 (which cut a 0.26.1 patch before the `feat` landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)