### PR TITLE
fix(run): persist apple-container secrets to the configured store

### DIFF
--- a/src/agentcage/run.py
+++ b/src/agentcage/run.py
@@ -206,16 +206,21 @@ def _ensure_volume_dirs(volumes: list[str]) -> None:
 
 
 def _stage_set_secrets(
-    cage_name: str, secrets: tuple[str, ...], isolation: str, podman,
+    cage_name: str, secrets: tuple[str, ...], cfg, podman,
 ) -> set[str]:
     """Stage ``--set-secret`` values and return the set of provided keys.
 
     Container mode writes them straight to the host Podman store. The VM
     backend has no host Podman, so values are staged to
     ``pending_secrets.json`` in the deployment dir (mode 0600) — the VM
-    backend reads it and creates the secrets inside the VM. This mirrors
-    what ``agentcage cage create`` already does for VM cages.
+    backend reads it and creates the secrets inside the VM. The
+    apple-container backend re-stages secrets at every start() from the
+    cage's configured at-rest store (macOS keychain by default), so its
+    values must be persisted via that store — NOT the legacy
+    ``pending_secrets.json``, which the keychain-backed backend never
+    reads. All three paths mirror ``agentcage cage create``.
     """
+    isolation = cfg.isolation
     parsed: list[tuple[str, str]] = []
     for spec in secrets:
         if "=" in spec:
@@ -225,16 +230,19 @@ def _stage_set_secrets(
             val = click.prompt(f"Value for {key}", hide_input=True)
         parsed.append((key, val))
 
-    if isolation in ("vm", "apple-container"):
-        # Neither backend has access to host podman on macOS. Stage to a
-        # per-cage pending_secrets.json (0600) and let the backend pick
-        # it up at start time. VM backend reads the file and creates
-        # podman secrets INSIDE the VM (then unlinks the file).
-        # apple-container backend reads the file at every start() to
-        # resolve `secret_injection` rules — the 0600 plaintext file IS
-        # the persistence mechanism (no host podman; Keychain is a
-        # follow-up, see #120). Values are NEVER read from the host
-        # shell's environment for the apple-container backend.
+    if isolation == "apple-container":
+        # Persist via the configured backend (keychain by default; encrypted
+        # at rest). The apple-container backend reads these back through
+        # `resolve_store` at start() — writing pending_secrets.json here
+        # would be silently ignored unless the cage opted into the plaintext
+        # backend. Matches `agentcage cage create` exactly.
+        from agentcage.cli import _store_secret
+        for key, val in parsed:
+            _store_secret(None, cfg, cage_name, key, val)
+    elif isolation == "vm":
+        # VM backend has no host podman. Stage to a per-cage
+        # pending_secrets.json (0600); the VM backend reads the file and
+        # creates podman secrets INSIDE the VM (then unlinks the file).
         if parsed:
             secrets_file = state.deployment_dir(cage_name) / "pending_secrets.json"
             # 0o600 — staged secret values must not be world-readable.
@@ -461,7 +469,7 @@ def execute(
         # Set secrets passed via --set-secret. Container mode writes the
         # host Podman store; VM mode stages them for the VM backend (there
         # is no host Podman on macOS).
-        provided_keys = _stage_set_secrets(cage_name, secrets, cfg.isolation, podman)
+        provided_keys = _stage_set_secrets(cage_name, secrets, cfg, podman)
 
         # Resolve secrets from configured backends (env:, cmd:, systemd-creds:).
         # Container mode only — matches `agentcage cage create`; on the VM

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -125,11 +125,18 @@ class TestEnsureVolumeDirs:
 
 
 class TestStageSetSecrets:
-    """--set-secret values: host Podman in container mode, staged file in VM mode."""
+    """--set-secret values: host Podman (container), staged file (VM),
+    or the configured at-rest store (apple-container → keychain)."""
+
+    @staticmethod
+    def _cfg(isolation):
+        from types import SimpleNamespace
+        return SimpleNamespace(isolation=isolation)
 
     def test_vm_mode_writes_pending_file(self, tmp_path):
         with patch("agentcage.run.state.deployment_dir", return_value=tmp_path):
-            keys = _stage_set_secrets("my-cage", ("API_KEY=secret123",), "vm", None)
+            keys = _stage_set_secrets(
+                "my-cage", ("API_KEY=secret123",), self._cfg("vm"), None)
         assert keys == {"API_KEY"}
         pending = tmp_path / "pending_secrets.json"
         assert json.loads(pending.read_text()) == [["API_KEY", "secret123"]]
@@ -138,14 +145,15 @@ class TestStageSetSecrets:
 
     def test_vm_mode_no_secrets_writes_nothing(self, tmp_path):
         with patch("agentcage.run.state.deployment_dir", return_value=tmp_path):
-            keys = _stage_set_secrets("my-cage", (), "vm", None)
+            keys = _stage_set_secrets("my-cage", (), self._cfg("vm"), None)
         assert keys == set()
         assert not (tmp_path / "pending_secrets.json").exists()
 
     def test_container_mode_uses_host_podman(self):
         podman = MagicMock()
         podman.secret_exists.return_value = False
-        keys = _stage_set_secrets("my-cage", ("API_KEY=v",), "container", podman)
+        keys = _stage_set_secrets(
+            "my-cage", ("API_KEY=v",), self._cfg("container"), podman)
         assert keys == {"API_KEY"}
         podman.secret_create.assert_called_once_with("my-cage.API_KEY", "v")
 
@@ -155,8 +163,24 @@ class TestStageSetSecrets:
         with patch("agentcage.run.state.deployment_dir") as dd:
             import tempfile
             dd.return_value = __import__("pathlib").Path(tempfile.mkdtemp())
-            _stage_set_secrets("c", ("K=V",), "vm", podman)
+            _stage_set_secrets("c", ("K=V",), self._cfg("vm"), podman)
         podman.secret_create.assert_not_called()
+
+    def test_apple_container_persists_via_store_not_pending_file(self, tmp_path):
+        # Regression: apple-container's backend re-stages secrets from the
+        # configured at-rest store (keychain) at start(), so `run` must
+        # persist there — NOT pending_secrets.json, which the keychain-backed
+        # backend never reads (the secret would be silently orphaned).
+        cfg = self._cfg("apple-container")
+        with patch("agentcage.cli._store_secret") as store, \
+             patch("agentcage.run.state.deployment_dir", return_value=tmp_path):
+            keys = _stage_set_secrets(
+                "my-cage", ("ANTHROPIC_API_KEY=sk-abc",), cfg, None)
+        assert keys == {"ANTHROPIC_API_KEY"}
+        store.assert_called_once_with(
+            None, cfg, "my-cage", "ANTHROPIC_API_KEY", "sk-abc")
+        # The legacy plaintext file must NOT be written for apple-container.
+        assert not (tmp_path / "pending_secrets.json").exists()
 
 
 class TestGenerateName:


### PR DESCRIPTION
## Problem

`agentcage cage run claude-code -s ANTHROPIC_API_KEY` prompts for the value, but the cage then warns:

```
warning: secret_injection env 'ANTHROPIC_API_KEY' not provided via --set-secret; placeholder will NOT be substituted in cage requests
```

The secret is never injected.

## Root cause

The two entry points had diverged:

- **`agentcage cage create`** (cli.py) persists apple-container secrets through `_store_secret` → `resolve_store` → the **macOS keychain** (the default `auto` backend).
- **`agentcage run`** (run.py) wrote apple-container secrets to the legacy `pending_secrets.json` plaintext file.

But the apple-container backend reads secrets back at `start()` via `resolve_store(...).get(...)` — i.e. from the **keychain**. With an unlocked login keychain (any Mac GUI session) the keychain store is selected and `pending_secrets.json` is never read. So the typed value landed in a file nothing reads, the start-time lookup returned `None`, and the placeholder was left unsubstituted.

run.py's comment confirmed the staleness: *"Keychain is a follow-up, see #120."* The backend was migrated to the keychain; `run` was never updated to match.

## Fix

`_stage_set_secrets` now routes by backend, mirroring `cage create` exactly:

- **apple-container** → `_store_secret(None, cfg, cage_name, key, val)` → configured at-rest store (keychain by default, encrypted)
- **vm** → `pending_secrets.json` (the VM backend genuinely reads this file) — unchanged
- **container** → host Podman store — unchanged

As a bonus, users now get the `Secret '…' stored in the macOS keychain.` confirmation that was previously missing.

## Tests

- Updated `TestStageSetSecrets` for the new `cfg` signature.
- Added `test_apple_container_persists_via_store_not_pending_file`: asserts the secret goes through `_store_secret` and that `pending_secrets.json` is **not** written.

All 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)