### PR TITLE
chore(release): 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-06-29
+
+### Fixed
+
+- **`agentcage run` now injects `--set-secret` values on apple-container.** `agentcage run` (and its `cage run` alias) staged apple-container secrets to the legacy `pending_secrets.json` plaintext file, but the apple-container backend re-stages secrets at `start()` from the cage's configured at-rest store — the macOS keychain under the default `auto` backend — and never reads `pending_secrets.json` unless the cage opted into the plaintext backend. With an unlocked login keychain the typed value was orphaned: the start-time lookup returned nothing and the cage warned `secret_injection env '…' not provided via --set-secret; placeholder will NOT be substituted`, so the agent failed to authenticate. `agentcage cage create` was unaffected because it already persisted apple-container secrets through the keychain; `run` was never migrated off the pre-keychain code path. `run` now routes apple-container secrets through the same store as `create` (VM `pending_secrets.json` and container host-Podman paths are unchanged). ([#288](https://github.com/agentcage/agentcage/pull/288))
+
 ## [0.27.0] - 2026-06-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.27.0"
+version = "0.27.1"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release.

### Fixed
- **`agentcage run` now injects `--set-secret` values on apple-container** ([#288](https://github.com/agentcage/agentcage/pull/288)). `run` staged apple-container secrets to the legacy `pending_secrets.json`, which the keychain-backed backend never reads — the value was orphaned and the placeholder went unsubstituted. `run` now persists through the same configured at-rest store as `cage create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)