### PR TITLE
feat(egress): gate outbound ICMP behind ports.icmp.allow (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ports.icmp.allow` knob gates outbound ICMP echo-request (`ping`).** A new boolean under `ports:` controls whether the egress installs the `filter:FORWARD -p icmp --icmp-type echo-request ACCEPT` rule. It is plumbed through both backends identically to the existing TCP/UDP port policy (`config.py` → `quadlets._effective_port_policy` siblings → `egress.container.j2` / apple-container metadata → `ALLOW_ICMP` env → `supervisor-egress.sh`).
+
+### Changed
+
+- **Outbound ICMP echo-request is now off by default (was unconditionally allowed).** `ping` from inside a cage previously worked unconditionally — the egress always installed an echo-request ACCEPT rule with no config knob. ICMP egress is now opt-in via `ports.icmp.allow: true`, matching the default-deny posture of every other protocol. When disabled, the default-deny `filter:FORWARD` policy drops outbound echo-request for **every** in-cage privilege level, including `agentcage cage exec --as-root` (which holds `CAP_NET_RAW` but routes through the egress sibling and cannot alter its FORWARD chain). Path-MTU discovery is unaffected — `fragmentation-needed` errors are `RELATED` to an existing flow and ride the `ESTABLISHED,RELATED` rule regardless. **Migration:** existing cages that rely on outbound `ping` must add `ports.icmp.allow: true` and re-run `agentcage cage update`.
+
 ## [0.27.1] - 2026-06-29
 
 ### Fixed

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -5,7 +5,7 @@ The proxy container's default-deny `filter:FORWARD` policy and the `ports.tcp` /
 
 `ports.tcp.allow` lists TCP destination ports the cage may reach (audited via mitmdump unless also in `passthrough`). `ports.tcp.passthrough` is the subset that bypasses mitmdump — auto-merged into the effective TCP allow set if not listed in `tcp.allow`. `ports.udp.allow` lists UDP destination ports; UDP is never inspected (mitmdump is HTTP-only).
 
-Inspected TCP ports = `tcp.allow - tcp.passthrough`. Outbound ICMP echo-request is always permitted for diagnostics. IPv6 forwarding is dropped by an `ip6tables -P FORWARD DROP` failsafe. There is no opt-out flag for the default-deny posture; every cage gets it on next `agentcage cage update`.
+Inspected TCP ports = `tcp.allow - tcp.passthrough`. Outbound ICMP echo-request (`ping`) is **off by default** and opt-in via `ports.icmp.allow: true`. IPv6 forwarding is dropped by an `ip6tables -P FORWARD DROP` failsafe. There is no opt-out flag for the default-deny posture; every cage gets it on next `agentcage cage update`.
 
 *Since 0.15.0* — pre-0.15 anything not in the audit list was silently L3-forwarded uninspected, so an agent that resolved an allowed hostname could exfiltrate over any port (NTP, custom binary protocols, QUIC) with the audit pipeline blind. Cages that talk *only* on the default `tcp.allow` (`[80, 443]`) keep working unchanged. Cages that depend on outbound on any other port — NTP (`123/udp`), Postgres (`5432/tcp`), IMAP (`993/tcp`), QUIC/HTTP3 (`443/udp`) — must add those ports or lose connectivity. DNS is unaffected: cages talk to the sidecar dns container directly on the same subnet and never traverse the proxy's FORWARD chain.
 
@@ -25,7 +25,7 @@ Each cage netns has a default route via the proxy container's IP. Inside the pro
 │         (inspected_tcp = tcp.allow - tcp.passthrough)         │
 │   filter:FORWARD                                              │
 │     -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT      │
-│     -p icmp --icmp-type echo-request -j ACCEPT                │
+│     -p icmp --icmp-type echo-request -j ACCEPT  (icmp.allow)  │
 │     -p tcp --dport <tcp.passthrough> -j ACCEPT                │
 │     -p udp --dport <udp.allow>       -j ACCEPT                │
 │   policy: DROP                                                │
@@ -121,13 +121,25 @@ Per-entry rules apply to all three lists: integers only (YAML strings, booleans,
 
 ## ICMP and IPv6
 
-ICMP echo-request is always allowed outbound — `ping` from inside the cage works for diagnostics, and replies ride the `ESTABLISHED,RELATED` rule. There's no config knob; the rule is unconditional. Any other ICMP type (unsolicited echo-reply, unreachables, redirects) is dropped by the default policy.
+Outbound ICMP echo-request (`ping`) is **off by default** and gated by a config knob:
+
+```yaml
+ports:
+  icmp:
+    allow: true   # default false — install the FORWARD echo-request ACCEPT rule
+```
+
+When `allow` is false (the default) the egress installs no echo-request rule, so the default-deny `filter:FORWARD` policy drops outbound `ping` for **every** in-cage privilege level — including `agentcage cage exec --as-root`, which holds `CAP_NET_RAW` but routes through the egress sibling and cannot alter its FORWARD chain (no `CAP_NET_ADMIN`, separate microVM). When `allow` is true the rule is installed and replies ride the `ESTABLISHED,RELATED` rule. Any other ICMP type (unsolicited echo-reply, unreachables, redirects) is always dropped by the default policy.
+
+This knob does **not** affect path-MTU discovery: ICMP `fragmentation-needed` errors arrive as `RELATED` to an existing TCP flow and ride the `ESTABLISHED,RELATED` rule regardless of `icmp.allow`.
+
+> **Behavior change (since 0.28.0).** ICMP echo-request was unconditionally allowed before this release. Existing cages lose outbound `ping` on their next `agentcage cage update` unless they add `ports.icmp.allow: true`. The change is intentional: ICMP egress is now opt-in, matching the default-deny posture of every other protocol.
 
 IPv6 is uncovered. The proxy installs an `ip6tables -P FORWARD DROP` failsafe so any IPv6 traffic the cage attempts is dropped. Today's podman networks are IPv4-only (`10.89.x.0/24`), so this is a latent-gap failsafe rather than active filtering.
 
 ## Disabling transparent capture
 
-Setting `ports.tcp.allow: []` removes the `nat:PREROUTING` REDIRECTs entirely. The cage relies solely on the L7 path (apps that honor `HTTP_PROXY` send `CONNECT` requests to mitmdump on `:8080`). Validation emits a warning when this is detected. If `tcp.allow`, `tcp.passthrough`, and `udp.allow` are all empty, the cage has zero outbound TCP/UDP — only ICMP echo and `ESTABLISHED,RELATED` traverse. Validation surfaces this as a warning so the posture is visible.
+Setting `ports.tcp.allow: []` removes the `nat:PREROUTING` REDIRECTs entirely. The cage relies solely on the L7 path (apps that honor `HTTP_PROXY` send `CONNECT` requests to mitmdump on `:8080`). Validation emits a warning when this is detected. If `tcp.allow`, `tcp.passthrough`, and `udp.allow` are all empty, the cage has zero outbound TCP/UDP — only `ESTABLISHED,RELATED` (and outbound ICMP echo when `icmp.allow: true`) traverse. Validation surfaces this as a warning so the posture is visible.
 
 ## Trade-offs
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -869,6 +869,10 @@ class AppleContainerBackend:
                 "inspected_tcp_ports": inspected_tcp,
                 "passthrough_tcp_ports": passthrough_tcp,
                 "allow_udp_ports": allow_udp,
+                # Outbound ICMP echo-request opt-in (ports.icmp.allow).
+                # start() emits it as ALLOW_ICMP=0/1; the supervisor
+                # installs the FORWARD accept rule only when "1".
+                "allow_icmp": bool(config.ports.icmp.allow),
             },
             indent=2,
             sort_keys=True,
@@ -1145,6 +1149,13 @@ class AppleContainerBackend:
             udp_with_dns.append(53)
         egress_argv += [
             "-e", f"ALLOW_UDP_PORTS={' '.join(str(p) for p in udp_with_dns)}",
+        ]
+        # Outbound ICMP echo-request: off unless ports.icmp.allow opted in.
+        # Legacy metadata (created before this knob) has no key → default 0,
+        # matching the supervisor's locked-down default.
+        allow_icmp = bool(meta.get("allow_icmp", False))
+        egress_argv += [
+            "-e", f"ALLOW_ICMP={1 if allow_icmp else 0}",
         ]
         # Egress is small — 512M is plenty. We don't normalize here
         # because the value is internal, not operator-supplied.

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -265,16 +265,38 @@ class UdpPortsConfig:
 
 
 @dataclass
+class IcmpPortsConfig:
+    """Outbound ICMP (echo-request / ``ping``) egress policy.
+
+    - ``allow`` — when true, the egress installs a ``filter:FORWARD
+      -p icmp --icmp-type echo-request ACCEPT`` rule so the cage can
+      ``ping`` out for diagnostics; replies ride the ``ESTABLISHED,RELATED``
+      rule. When false (the default) no such rule is installed and the
+      default-deny FORWARD policy drops outbound echo-request — for every
+      in-cage privilege level, including ``--as-root`` (which holds
+      ``CAP_NET_RAW`` but cannot reach the egress's FORWARD chain).
+
+    Defaults to false: ICMP is OFF unless explicitly opted in. This does
+    NOT affect path-MTU discovery — the ICMP ``fragmentation-needed``
+    errors arrive as ``RELATED`` to an existing TCP flow and ride the
+    ``ESTABLISHED,RELATED`` rule regardless of this knob.
+    """
+    allow: bool = False
+
+
+@dataclass
 class PortsConfig:
     """Cage egress port policy, split by protocol.
 
     Layered on a default-deny filter:FORWARD policy (always installed,
     no opt-out flag): every cage drops L4 traffic not explicitly allowed
-    here. Outbound ICMP echo-request is always permitted for diagnostics.
-    A separate ip6tables -P FORWARD DROP failsafe blocks all IPv6 forwarding.
+    here. Outbound ICMP echo-request is opt-in via ``ports.icmp.allow``
+    (default false). A separate ip6tables -P FORWARD DROP failsafe blocks
+    all IPv6 forwarding.
     """
     tcp: TcpPortsConfig = field(default_factory=TcpPortsConfig)
     udp: UdpPortsConfig = field(default_factory=UdpPortsConfig)
+    icmp: IcmpPortsConfig = field(default_factory=IcmpPortsConfig)
 
 
 @dataclass
@@ -826,7 +848,7 @@ def load_config(path: str) -> Config:
     pt_raw = raw.get("ports") or {}
     if not isinstance(pt_raw, dict):
         raise ValueError(
-            f"ports must be a mapping with 'tcp' and/or 'udp' keys "
+            f"ports must be a mapping with 'tcp', 'udp', and/or 'icmp' keys "
             f"(got: {pt_raw!r})"
         )
     pt = PortsConfig()
@@ -870,6 +892,21 @@ def load_config(path: str) -> Config:
                 f"(got: {raw_udp_allow!r})"
             )
         pt.udp.allow = list(raw_udp_allow)
+
+    icmp_raw = pt_raw.get("icmp") or {}
+    if not isinstance(icmp_raw, dict):
+        raise ValueError(
+            f"ports.icmp must be a mapping with an 'allow' boolean "
+            f"(got: {icmp_raw!r}). To allow outbound ping, use "
+            f"'ports.icmp.allow: true'"
+        )
+    if "allow" in icmp_raw:
+        raw_icmp_allow = icmp_raw["allow"]
+        if not isinstance(raw_icmp_allow, bool):
+            raise ValueError(
+                f"ports.icmp.allow must be a boolean (got: {raw_icmp_allow!r})"
+            )
+        pt.icmp.allow = raw_icmp_allow
 
     cfg.ports = pt
 

--- a/src/agentcage/data/containers/supervisor-egress.sh
+++ b/src/agentcage/data/containers/supervisor-egress.sh
@@ -80,11 +80,16 @@ fi
 INSPECTED_TCP_PORTS="${INSPECTED_TCP_PORTS-80 443}"
 PASSTHROUGH_TCP_PORTS="${PASSTHROUGH_TCP_PORTS-}"
 ALLOW_UDP_PORTS="${ALLOW_UDP_PORTS-}"
+# Outbound ICMP echo-request (`ping`) is OFF by default. Set ALLOW_ICMP=1
+# (from cage.yaml's ``ports.icmp.allow: true``) to install the FORWARD
+# accept rule. Unset → "0": a cage created before this knob, or the
+# smoke-test path with no env, gets the locked-down default.
+ALLOW_ICMP="${ALLOW_ICMP-0}"
 if [ -f /etc/agentcage/iptables.env ]; then
   # shellcheck disable=SC1091
   . /etc/agentcage/iptables.env
 fi
-log "step A: iptables setup (inspected=[$INSPECTED_TCP_PORTS] passthrough=[$PASSTHROUGH_TCP_PORTS] udp=[$ALLOW_UDP_PORTS])"
+log "step A: iptables setup (inspected=[$INSPECTED_TCP_PORTS] passthrough=[$PASSTHROUGH_TCP_PORTS] udp=[$ALLOW_UDP_PORTS] icmp=[$ALLOW_ICMP])"
 
 for port in $INSPECTED_TCP_PORTS; do
   # No ``-i <iface>`` selector: podman's CNI does NOT deterministically
@@ -108,8 +113,18 @@ iptables -P FORWARD DROP \
   || die "iptables FORWARD DROP policy failed" 11
 iptables -A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT \
   || die "iptables FORWARD established/related accept failed" 12
-iptables -A FORWARD -p icmp --icmp-type echo-request -j ACCEPT \
-  || die "iptables FORWARD icmp echo-request accept failed" 13
+# Outbound ICMP echo-request is opt-in (ports.icmp.allow). When disabled
+# the default-DROP FORWARD policy blocks it for every in-cage uid,
+# including --as-root (which has CAP_NET_RAW but no route to alter this
+# chain). PMTUD is unaffected either way — frag-needed errors are RELATED
+# to an existing flow and ride the ESTABLISHED,RELATED rule above.
+if [ "$ALLOW_ICMP" = "1" ]; then
+  iptables -A FORWARD -p icmp --icmp-type echo-request -j ACCEPT \
+    || die "iptables FORWARD icmp echo-request accept failed" 13
+  log "step A: ICMP echo-request egress ALLOWED (ports.icmp.allow)"
+else
+  log "step A: ICMP echo-request egress blocked by default-deny policy"
+fi
 
 for port in $PASSTHROUGH_TCP_PORTS; do
   iptables -A FORWARD -p tcp --dport "$port" -j ACCEPT \

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -559,6 +559,7 @@ def generate_quadlets(
         inspected_tcp_ports=_inspected_tcp,
         passthrough_tcp_ports=_passthrough_tcp,
         allow_udp_ports=_allow_udp,
+        allow_icmp=config.ports.icmp.allow,
     )
 
     # Nested containers support

--- a/src/agentcage/templates/egress.container.j2
+++ b/src/agentcage/templates/egress.container.j2
@@ -89,6 +89,11 @@ Sysctl=net.ipv4.ip_forward=1
 Environment="INSPECTED_TCP_PORTS={{ inspected_tcp_ports|join(' ') }}"
 Environment="PASSTHROUGH_TCP_PORTS={{ passthrough_tcp_ports|join(' ') }}"
 Environment="ALLOW_UDP_PORTS={{ allow_udp_ports|join(' ') }}"
+# Outbound ICMP echo-request (`ping`) is opt-in via cage.yaml's
+# ``ports.icmp.allow`` (default false → "0"). The supervisor installs the
+# FORWARD accept rule only when this is "1"; otherwise the default-deny
+# policy drops echo-request for every in-cage uid.
+Environment="ALLOW_ICMP={{ 1 if allow_icmp else 0 }}"
 # Bind mitmproxy's regular (forward) proxy to the egress's cage-net IP
 # only. The egress sits on TWO networks — its own ``{{ name }}-net``
 # (cage-facing) AND the default ``podman`` network (host-facing, used

--- a/tests/test_apple_container_egress_ports.py
+++ b/tests/test_apple_container_egress_ports.py
@@ -73,6 +73,35 @@ class TestGenerateUnitsPortPolicy:
         assert meta["passthrough_tcp_ports"] == [22]
         assert meta["allow_udp_ports"] == [123, 5353]
 
+    def test_icmp_off_by_default_persisted(self, tmp_path):
+        """A cage with no ``ports.icmp`` override persists allow_icmp=False."""
+        cfg = _config(tmp_path, """\
+            name: demo
+            container:
+              image: test:latest
+        """)
+        units = AppleContainerBackend().generate_units(
+            cfg, "/c.yaml", "/patches", "demo",
+        )
+        meta = json.loads(units["demo.json"])
+        assert meta["allow_icmp"] is False
+
+    def test_icmp_allow_persisted(self, tmp_path):
+        """ports.icmp.allow: true persists allow_icmp=True into metadata."""
+        cfg = _config(tmp_path, """\
+            name: demo
+            container:
+              image: test:latest
+            ports:
+              icmp:
+                allow: true
+        """)
+        units = AppleContainerBackend().generate_units(
+            cfg, "/c.yaml", "/patches", "demo",
+        )
+        meta = json.loads(units["demo.json"])
+        assert meta["allow_icmp"] is True
+
 
 # ── start(): metadata → egress run argv env ─────────────────
 
@@ -211,3 +240,28 @@ class TestStartEgressArgvPortEnv:
         assert _env_value(argv, "INSPECTED_TCP_PORTS") == ""
         assert _env_value(argv, "PASSTHROUGH_TCP_PORTS") == ""
         assert _env_value(argv, "ALLOW_UDP_PORTS") == "53"
+
+    def test_icmp_off_by_default_env(self, tmp_path):
+        """No allow_icmp in metadata → ALLOW_ICMP=0 (locked-down default,
+        matching a cage created before the knob existed)."""
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [80, 443],
+            "passthrough_tcp_ports": [],
+            "allow_udp_ports": [],
+        })
+        assert _env_value(argv, "ALLOW_ICMP") == "0"
+
+    def test_icmp_legacy_metadata_defaults_off(self, tmp_path):
+        """A pre-knob cage (no allow_icmp key at all) emits ALLOW_ICMP=0."""
+        argv = _start_with_meta(tmp_path, {})
+        assert _env_value(argv, "ALLOW_ICMP") == "0"
+
+    def test_icmp_allow_env_honored(self, tmp_path):
+        """allow_icmp=True in metadata → ALLOW_ICMP=1 on the egress argv."""
+        argv = _start_with_meta(tmp_path, {
+            "inspected_tcp_ports": [80, 443],
+            "passthrough_tcp_ports": [],
+            "allow_udp_ports": [],
+            "allow_icmp": True,
+        })
+        assert _env_value(argv, "ALLOW_ICMP") == "1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1174,6 +1174,55 @@ class TestPortsConfig:
         cfg = load_config(minimal_yaml)
         assert cfg.ports.udp.allow == []
 
+    def test_default_icmp_allow_is_false(self, minimal_yaml):
+        """ICMP echo-request (ping) is off by default — opt-in only."""
+        cfg = load_config(minimal_yaml)
+        assert cfg.ports.icmp.allow is False
+
+    def test_custom_icmp_allow_true(self, tmp_path):
+        """ports.icmp.allow: true opts the cage into outbound ping."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            ports:
+              icmp:
+                allow: true
+        """))
+        cfg = load_config(str(p))
+        assert cfg.ports.icmp.allow is True
+        validate_config(cfg)
+
+    def test_icmp_allow_non_bool_rejected(self, tmp_path):
+        """ports.icmp.allow must be a boolean, not a string/int (YAML
+        ``yes`` parses to bool; ``"yes"`` / 1 do not)."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            ports:
+              icmp:
+                allow: 1
+        """))
+        with pytest.raises(ValueError, match="ports.icmp.allow must be a boolean"):
+            load_config(str(p))
+
+    def test_icmp_not_a_mapping_rejected(self, tmp_path):
+        """ports.icmp must be a mapping with an 'allow' key, not a bare
+        boolean (a common mistake: ``ports.icmp: true``)."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            ports:
+              icmp: true
+        """))
+        with pytest.raises(ValueError, match="ports.icmp must be a mapping"):
+            load_config(str(p))
+
     def test_custom_tcp_allow(self, tmp_path):
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -134,6 +134,25 @@ class TestEgressQuadlet:
         assert 'Environment="INSPECTED_TCP_PORTS=80 443"' in content
         assert 'Environment="PASSTHROUGH_TCP_PORTS="' in content
         assert 'Environment="ALLOW_UDP_PORTS="' in content
+        # ICMP is off by default — the supervisor installs no echo-request rule.
+        assert 'Environment="ALLOW_ICMP=0"' in content
+
+    def test_egress_icmp_allow_opt_in(self, tmp_path):
+        """ports.icmp.allow: true emits ALLOW_ICMP=1 so the supervisor
+        installs the FORWARD echo-request ACCEPT rule."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            ports:
+              icmp:
+                allow: true
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/c.yaml", "/patches")
+        content = files["test-egress.container"]
+        assert 'Environment="ALLOW_ICMP=1"' in content
 
     def test_egress_port_policy_custom(self, tmp_path):
         """Operator-supplied ports.tcp.allow / passthrough / udp.allow


### PR DESCRIPTION
## Summary

Outbound ICMP echo-request (`ping`) was **unconditionally allowed** by the egress — `supervisor-egress.sh` always installed a `filter:FORWARD -p icmp --icmp-type echo-request ACCEPT` rule with no config knob.

A capability spike (`docs/spikes/2026-06-icmp-root-capability-spike.md`) confirmed the posture: `agentcage cage exec --as-root` holds `CAP_NET_RAW` and could `ping` out, while default uid-1000 sessions could not (no caps + `NoNewPrivs=1`).

This PR makes ICMP egress **opt-in** via a new `ports.icmp.allow` boolean (default `false`), matching the default-deny posture of every other protocol:

```yaml
ports:
  icmp:
    allow: true   # default false
```

When disabled (the default), the default-deny `FORWARD` policy drops outbound echo-request for **every** in-cage privilege level — including `--as-root`, which routes through the egress sibling and cannot alter its FORWARD chain (no `CAP_NET_ADMIN`, separate microVM).

## How it's wired

Plumbed identically to the existing TCP/UDP port policy:

| Layer | Change |
|---|---|
| `config.py` | new `IcmpPortsConfig` on `PortsConfig`; parse + validate `ports.icmp.allow` (bool) |
| `quadlets.py` | pass `allow_icmp` into the egress template render |
| `egress.container.j2` | emit `Environment="ALLOW_ICMP=0/1"` |
| `apple_container.py` | persist `allow_icmp` in metadata; emit `-e ALLOW_ICMP=…` on egress argv |
| `supervisor-egress.sh` | install the echo-request rule only when `ALLOW_ICMP=1` |

Legacy metadata (cages created before this knob) has no key → defaults off, matching the supervisor's locked-down default.

## Notes

- **PMTUD is unaffected.** ICMP `fragmentation-needed` errors are `RELATED` to an existing TCP flow and ride the `ESTABLISHED,RELATED` rule regardless of this knob.
- Docs updated (`docs/reference/ports.md`) and CHANGELOG entry added under `[Unreleased]`.

## ⚠️ Behavior change

Existing cages that rely on outbound `ping` lose it on their next `agentcage cage update` unless they add `ports.icmp.allow: true`.

## Test plan

- [x] `tests/test_config.py::TestPortsConfig` — default false, opt-in true, non-bool + non-mapping rejection
- [x] `tests/test_quadlets.py` — `ALLOW_ICMP=0` default / `=1` opt-in rendered
- [x] `tests/test_apple_container_egress_ports.py` — metadata persistence + `start()` argv env (incl. legacy-meta default-off)
- [x] `dash -n` + shellcheck clean on `supervisor-egress.sh`
- [x] Full suite: 1786 passed (the 12 failures are pre-existing on `master`, keychain/secret-env related, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)