### PR TITLE
chore(release): 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-29
+
 ### Added
 
 - **`ports.icmp.allow` knob gates outbound ICMP echo-request (`ping`).** A new boolean under `ports:` controls whether the egress installs the `filter:FORWARD -p icmp --icmp-type echo-request ACCEPT` rule. It is plumbed through both backends identically to the existing TCP/UDP port policy (`config.py` → `quadlets._effective_port_policy` siblings → `egress.container.j2` / apple-container metadata → `ALLOW_ICMP` env → `supervisor-egress.sh`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.27.1"
+version = "0.28.0"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.27.1"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release 0.28.0.

Bumps `pyproject.toml` / `uv.lock` to 0.28.0 and rolls the `[Unreleased]` CHANGELOG section into `[0.28.0] - 2026-06-29`.

### Headline
- **`ports.icmp.allow` knob — outbound ICMP (`ping`) is now off by default** (#290). Minor bump rather than patch because this changes the default egress posture: existing cages lose outbound `ping` on their next `agentcage cage update` unless they set `ports.icmp.allow: true`. See the CHANGELOG `Changed` entry for the migration note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)