### PR TITLE
fix(apple-container): don't pass --pull when Containerfile has a localhost base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cage create/update --pull` no longer fails when the cage's Containerfile builds on a `localhost/` base image.** Apple `container build --pull` re-resolves *every* `FROM` from a registry; a `localhost/` base (e.g. a two-stage scaffold whose cage image sits on a locally-built base) has no registry source, so BuildKit's resolver got `POSIXErrorCode 61 / Connection refused`. The apple-container backend now suppresses `--pull` for the staged-Containerfile build whenever any `FROM` references a `localhost/` ref — the same "never pull a local-only ref" philosophy already applied to the user image. `--no-cache` still forces a full rebuild, which is where a local base's freshness comes from. `--pull` is unchanged for genuinely-remote bases.
+
 ## [0.29.0] - 2026-06-30
 
 ### Added

--- a/src/agentcage/apple_container/scaffold.py
+++ b/src/agentcage/apple_container/scaffold.py
@@ -28,6 +28,42 @@ import click
 from agentcage.apple_container import cli as ac_cli
 
 
+def _base_image_refs(containerfile: Path) -> list[str]:
+    """Return the external base-image refs from a Containerfile's ``FROM``
+    lines, excluding intra-file multi-stage aliases and the ``scratch``
+    pseudo-base.
+
+    A ``FROM <ref> AS <name>`` defines a stage alias; a later ``FROM <name>``
+    that references it is not a registry pull, so such refs are dropped.
+    Leading build flags (``FROM --platform=... <ref>``) are skipped so the
+    real ref is found.
+
+    Used to decide whether ``--pull`` can be honored: a ``localhost/`` base has
+    no registry source, so passing ``--pull`` to ``container build`` makes
+    BuildKit try to fetch it and fail with ECONNREFUSED (POSIXErrorCode 61).
+    """
+    stage_aliases: set[str] = set()
+    refs: list[str] = []
+    try:
+        lines = containerfile.read_text().splitlines()
+    except OSError:
+        return refs
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        tokens = [t for t in line.split() if not t.startswith("--")]
+        if len(tokens) < 2 or tokens[0].upper() != "FROM":
+            continue
+        ref = tokens[1]
+        alias = tokens[3] if len(tokens) >= 4 and tokens[2].upper() == "AS" else None
+        if ref not in stage_aliases and ref.lower() != "scratch":
+            refs.append(ref)
+        if alias:
+            stage_aliases.add(alias)
+    return refs
+
+
 def build_image_from_staged(
     image: str,
     containerfile: Path,
@@ -49,6 +85,14 @@ def build_image_from_staged(
     does (untagged registry refs get a concrete tag), so ``--pull`` fetches a
     fresh base without mutating the frozen cage.yaml. ``no_cache`` / ``pull``
     map to ``container build --no-cache`` / ``--pull``.
+
+    ``--pull`` is suppressed when any ``FROM`` in the Containerfile references a
+    ``localhost/`` base (e.g. a two-stage scaffold whose cage image is built on
+    a locally-built base). Such a ref has no registry source, and Apple
+    ``container build --pull`` applies globally to every stage, so BuildKit
+    would try to fetch it and fail with ECONNREFUSED (POSIXErrorCode 61). The
+    local base's freshness comes from the ``--no-cache`` rebuild instead — the
+    same philosophy the backend applies to a ``localhost/`` user image.
     """
     from agentcage.registry import resolve_build_args
 
@@ -65,10 +109,19 @@ def build_image_from_staged(
         f"{' (no-cache)' if no_cache else ''} (apple-container)..."
     )
 
+    effective_pull = pull
+    if pull and any(r.startswith("localhost/") for r in _base_image_refs(containerfile)):
+        effective_pull = False
+        _echo(
+            "Skipping --pull: Containerfile has a local-only ('localhost/') "
+            "base image with no registry source; --no-cache still forces a "
+            "full rebuild."
+        )
+
     argv = ["build", "-t", image, "-f", str(containerfile)]
     if no_cache:
         argv.append("--no-cache")
-    if pull:
+    if effective_pull:
         argv.append("--pull")
     for k, v in resolved_args.items():
         argv += ["--build-arg", f"{k}={v}"]

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2805,6 +2805,68 @@ def test_build_image_from_staged_passes_flags_and_build_args(tmp_path):
     assert builds[0][-1] == str(tmp_path)  # context dir
 
 
+def test_build_image_from_staged_drops_pull_for_localhost_base(tmp_path):
+    """`--pull` is suppressed when a `FROM` references a `localhost/` base:
+    it has no registry source, and `container build --pull` applies globally,
+    so BuildKit would fail with ECONNREFUSED trying to fetch it. `--no-cache`
+    is still forwarded to force the rebuild."""
+    cf = tmp_path / "Containerfile"
+    cf.write_text("FROM localhost/agentcage-truelayer-base:latest\nRUN true\n")
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch("agentcage.registry.resolve_build_args", return_value=({}, [])):
+        ac_scaffold.build_image_from_staged(
+            "localhost/agentcage-truelayer-pi:latest", cf, tmp_path,
+            None, quiet=True, no_cache=True, pull=True,
+        )
+
+    builds = [a for a in calls if a[:1] == ["build"]]
+    assert builds, "image must be built from the staged Containerfile"
+    assert "--no-cache" in builds[0]
+    assert "--pull" not in builds[0]
+
+
+def test_build_image_from_staged_keeps_pull_for_remote_base(tmp_path):
+    """`--pull` is honored when every `FROM` is a genuinely-remote ref
+    (a real registry pull the operator asked for)."""
+    cf = tmp_path / "Containerfile"
+    cf.write_text("FROM docker.io/library/debian:bookworm\nRUN true\n")
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # noqa: ARG001
+        calls.append(argv)
+        return type("CP", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch.object(ac_cli, "run", side_effect=fake_run), \
+         patch("agentcage.registry.resolve_build_args", return_value=({}, [])):
+        ac_scaffold.build_image_from_staged(
+            "localhost/agentcage-scaffold-debian:latest", cf, tmp_path,
+            None, quiet=True, no_cache=False, pull=True,
+        )
+
+    builds = [a for a in calls if a[:1] == ["build"]]
+    assert builds
+    assert "--pull" in builds[0]
+
+
+def test_base_image_refs_ignores_multistage_aliases(tmp_path):
+    """A `FROM <alias>` that references an earlier `FROM ... AS <alias>` stage
+    is not a base ref; `--platform` flags and `scratch` are also excluded."""
+    cf = tmp_path / "Containerfile"
+    cf.write_text(
+        "FROM --platform=linux/arm64 docker.io/library/debian:bookworm AS build\n"
+        "RUN true\n"
+        "FROM build\n"
+        "FROM scratch\n"
+    )
+    assert ac_scaffold._base_image_refs(cf) == ["docker.io/library/debian:bookworm"]
+
+
 def test_build_artifacts_threads_no_cache_and_pull_to_all_builders(tmp_path):
     """`build_artifacts(no_cache=True, pull=True)` propagates both flags to
     the egress build, the staged-Containerfile build, and the wrapper build


### PR DESCRIPTION
## Problem

`agentcage cage update --pull` (and `cage create --pull`) fails for cages whose Containerfile builds on a locally-built base image:

```
Building localhost/agentcage-truelayer-pi:latest ... (no-cache) (apple-container)...
 => [resolver] fetching image...localhost/agentcage-truelayer-base:latest
Error: unknown: "POSIXErrorCode(rawValue: 61): Connection refused"
```

Apple `container build --pull` re-resolves **every** `FROM` from a registry. The cage's Containerfile starts with `FROM localhost/agentcage-truelayer-base:latest` — a local-only ref with no registry source — so BuildKit's resolver tries to fetch it and hits `ECONNREFUSED` (POSIXErrorCode 61).

The egress build in the same run succeeds because its base is `docker.io/mitmproxy/mitmproxy@...`, which is genuinely pullable.

The backend already knows this trap: `apple_container.py` deliberately never runs `container image pull` on a `localhost/` **user image** (`force_pull_remote = pull and not user_image.startswith("localhost/")`). But `--pull` was still passed verbatim into `container build`, where BuildKit applies it to the `localhost/` **base** in the Containerfile's `FROM`.

## Fix

In `build_image_from_staged`, suppress `--pull` when any `FROM` in the staged Containerfile references a `localhost/` base — mirroring the existing "never pull a local-only ref" philosophy. `--no-cache` still forces a full rebuild (where a local base's freshness comes from anyway); `--pull` is unchanged for genuinely-remote bases.

A small `_base_image_refs` helper parses `FROM` lines, correctly ignoring multi-stage aliases (`FROM x AS build` → `FROM build`), `--platform=` flags, and `scratch`.

## Tests

- `--pull` dropped for a `localhost/` base (with `--no-cache` still forwarded)
- `--pull` kept for a remote base
- `_base_image_refs` ignores multi-stage aliases, `--platform`, and `scratch`

All 133 tests in `test_apple_container.py` pass, including the pre-existing `--pull`/scaffold flag-threading tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)