### PR TITLE
chore(release): 0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-07-07
+
 ### Fixed
 
 - **`cage create/update --pull` no longer fails when the cage's Containerfile builds on a `localhost/` base image.** Apple `container build --pull` re-resolves *every* `FROM` from a registry; a `localhost/` base (e.g. a two-stage scaffold whose cage image sits on a locally-built base) has no registry source, so BuildKit's resolver got `POSIXErrorCode 61 / Connection refused`. The apple-container backend now suppresses `--pull` for the staged-Containerfile build whenever any `FROM` references a `localhost/` ref — the same "never pull a local-only ref" philosophy already applied to the user image. `--no-cache` still forces a full rebuild, which is where a local base's freshness comes from. `--pull` is unchanged for genuinely-remote bases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.29.0"
+version = "0.29.1"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.29.0"
+version = "0.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release 0.29.1.

Bumps `pyproject.toml` / `uv.lock` to 0.29.1 and dates the CHANGELOG section.

### Fixed
- `cage create/update --pull` no longer fails when the cage's Containerfile builds on a `localhost/` base image (#292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)