### PR TITLE
fix(secrets): store-aware Secret= emission so `secret rm` doesn't brick the next boot (#262)

### DIFF
--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -11,7 +11,7 @@ import click
 from agentcage import systemd
 from agentcage._timing import Phase
 from agentcage.config import Config
-from agentcage.podman import Podman
+from agentcage.podman import Podman, secret_env_names
 from agentcage.quadlets import generate_quadlets
 
 
@@ -98,6 +98,16 @@ class ContainerBackend:
         network_octet: int | None = None,
     ) -> dict[str, str]:
         rootless = self._podman.info().get("host", {}).get("security", {}).get("rootless", True)
+        # Store-aware Secret= emission (issue #262): pass the env-name set
+        # of secrets actually present in the podman store so a `secret
+        # rm`'d entry drops its quadlet directive instead of failing the
+        # next boot with an unresolvable Secret= (start-limit-hit). The
+        # info() call above already proved podman is reachable; on a
+        # query failure fall back to None (= legacy emit-everything).
+        try:
+            store_secrets = secret_env_names(self._podman, deploy_name)
+        except Exception:
+            store_secrets = None
         return generate_quadlets(
             config,
             config_host_path,
@@ -106,6 +116,7 @@ class ContainerBackend:
             rootless=rootless,
             used_octets=used_octets,
             network_octet=network_octet,
+            store_secrets=store_secrets,
         )
 
     def unit_dir(self) -> Path:

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -302,6 +302,25 @@ class VmBackend:
         # in-memory config; the on-disk cage.yaml is untouched.
         if config.container.timeout_start_sec < self.VM_MIN_TIMEOUT_START_SEC:
             config.container.timeout_start_sec = self.VM_MIN_TIMEOUT_START_SEC
+        # Store-aware Secret= emission (issue #262): the podman secret
+        # store for VM cages lives INSIDE the guest, so it can only be
+        # queried while the Lima instance is running (`secret set`/`rm`
+        # convergence, `cage update` on a live cage). When the guest is
+        # unreachable — initial create (the VM doesn't exist yet; values
+        # arrive via pending_secrets.json after first start) or a stopped
+        # VM — pass None to keep the legacy emit-everything behavior
+        # rather than dropping every directive against an empty view.
+        store_secrets = None
+        try:
+            inst = LimaInstance(deploy_name or config.name)
+            if inst.exists() and inst.is_running():
+                from agentcage.lima.podman import VmPodman
+                from agentcage.podman import secret_env_names
+                store_secrets = secret_env_names(
+                    VmPodman(deploy_name or config.name), deploy_name
+                )
+        except Exception:
+            store_secrets = None
         # Also generate quadlets (these will be installed inside the VM)
         quadlets = generate_quadlets(
             config,
@@ -310,6 +329,7 @@ class VmBackend:
             deploy_name,
             used_octets=used_octets,
             network_octet=network_octet,
+            store_secrets=store_secrets,
         )
         # Return both: Lima YAML and quadlets bundled together
         result: dict[str, str] = {"lima.yaml": lima_yaml}

--- a/src/agentcage/lima/podman.py
+++ b/src/agentcage/lima/podman.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from agentcage.lima.instance import LimaInstance
-from agentcage.podman import filter_secrets_by_prefix
+from agentcage.podman import _parse_secret_list, filter_secrets_by_prefix
 
 
 class VmPodman:
@@ -25,7 +25,28 @@ class VmPodman:
             ["podman", "secret", "ls", "--noheading", "--format", "{{.Name}}"],
             check=False,
         )
-        if r.returncode != 0 or not r.stdout.strip():
+        return _parse_secret_list(r, prefix)
+
+    def secret_list_strict(self, prefix: str = "") -> list[dict]:
+        """List secrets, raising on a guest ``podman secret ls`` failure.
+
+        Mirrors :meth:`agentcage.podman.Podman.secret_list_strict`: lets
+        the store-aware ``Secret=`` emission path (issue #262) fall back
+        to legacy emit-everything on a transient failure instead of
+        dropping every directive against an empty view. The VM backend
+        already guards the call with ``inst.is_running()`` so a stopped
+        guest never reaches here, but an in-flight failure still can.
+        """
+        r = self._inst.exec(
+            ["podman", "secret", "ls", "--noheading", "--format", "{{.Name}}"],
+            check=False,
+        )
+        if r.returncode != 0:
+            raise RuntimeError(
+                "podman secret ls failed in VM: "
+                f"{(r.stderr or r.stdout or '').strip()}"
+            )
+        if not r.stdout.strip():
             return []
         return filter_secrets_by_prefix(r.stdout.strip().splitlines(), prefix)
 

--- a/src/agentcage/podman.py
+++ b/src/agentcage/podman.py
@@ -18,6 +18,23 @@ def filter_secrets_by_prefix(lines: list[str], prefix: str) -> list[dict]:
     return secrets
 
 
+def secret_env_names(podman_like, deploy_name: str) -> set[str]:
+    """Env-name set (deploy prefix stripped) of store entries for a cage.
+
+    *podman_like* is any object with the ``secret_list(prefix=...)``
+    interface (host :class:`Podman` or the VM-routed ``VmPodman``).
+    Secrets are stored as ``{deploy_name}.{ENV}`` when a deploy name is
+    set, bare ``ENV`` otherwise; callers of
+    :func:`agentcage.quadlets.generate_quadlets` want the env-name set
+    for the store-aware ``Secret=`` gate (issue #262).
+    """
+    prefix = f"{deploy_name}." if deploy_name else ""
+    names = [s["Name"] for s in podman_like.secret_list(prefix=prefix)]
+    if prefix:
+        return {n[len(prefix):] for n in names}
+    return set(names)
+
+
 def _podman_cmd() -> list[str]:
     """Return the base command for running podman.
 

--- a/src/agentcage/podman.py
+++ b/src/agentcage/podman.py
@@ -18,6 +18,19 @@ def filter_secrets_by_prefix(lines: list[str], prefix: str) -> list[dict]:
     return secrets
 
 
+def _parse_secret_list(r, prefix: str = "") -> list[dict]:
+    """Lenient parse of a ``podman secret ls`` result: ``[]`` on failure
+    or empty output. Used by the lenient :meth:`Podman.secret_list` /
+    :meth:`VmPodman.secret_list` so ``cage show`` / ``secret list`` /
+    ``destroy_resources`` survive a transient podman hiccup. The store-
+    aware path (issue #262) uses the raising ``secret_list_strict``
+    variants instead.
+    """
+    if r.returncode != 0 or not r.stdout.strip():
+        return []
+    return filter_secrets_by_prefix(r.stdout.strip().splitlines(), prefix)
+
+
 def secret_env_names(podman_like, deploy_name: str) -> set[str]:
     """Env-name set (deploy prefix stripped) of store entries for a cage.
 
@@ -29,7 +42,16 @@ def secret_env_names(podman_like, deploy_name: str) -> set[str]:
     for the store-aware ``Secret=`` gate (issue #262).
     """
     prefix = f"{deploy_name}." if deploy_name else ""
-    names = [s["Name"] for s in podman_like.secret_list(prefix=prefix)]
+    # Use the strict variant when available so a transient podman failure
+    # propagates as an exception (the caller's try/except falls back to
+    # ``None`` = legacy emit-everything) instead of an empty set, which
+    # would drop every Secret= directive. Lenient wrappers fall through
+    # to secret_list().
+    list_fn = (
+        getattr(podman_like, "secret_list_strict", None)
+        or podman_like.secret_list
+    )
+    names = [s["Name"] for s in list_fn(prefix=prefix)]
     if prefix:
         return {n[len(prefix):] for n in names}
     return set(names)
@@ -194,13 +216,43 @@ class Podman:
         return json.loads(r.stdout)[0]
 
     def secret_list(self, prefix: str = "") -> list[dict]:
-        """List podman secrets, optionally filtered by name prefix."""
+        """List podman secrets, optionally filtered by name prefix.
+
+        Lenient: returns ``[]`` on a non-zero exit so ``cage show`` /
+        ``secret list`` / ``destroy_resources`` survive a transient
+        podman hiccup. The store-aware ``Secret=`` emission path
+        (issue #262) uses the raising :meth:`secret_list_strict` instead.
+        """
         r = subprocess.run(
             [*_podman_cmd(), "secret", "ls", "--noheading",
              "--format", "{{.Name}}"],
             capture_output=True, text=True,
         )
-        if r.returncode != 0 or not r.stdout.strip():
+        return _parse_secret_list(r, prefix)
+
+    def secret_list_strict(self, prefix: str = "") -> list[dict]:
+        """List secrets, raising on a ``podman secret ls`` failure.
+
+        Unlike :meth:`secret_list`, which returns ``[]`` on a non-zero
+        exit (the lenient behavior ``cage show`` / ``secret list`` /
+        ``destroy_resources`` rely on so a transient podman hiccup never
+        crashes them), this raises ``RuntimeError`` so the store-aware
+        ``Secret=`` emission path (issue #262) can distinguish a
+        genuinely-empty store from an unqueryable one and fall back to
+        the legacy emit-everything behavior instead of dropping every
+        directive against an empty view.
+        """
+        r = subprocess.run(
+            [*_podman_cmd(), "secret", "ls", "--noheading",
+             "--format", "{{.Name}}"],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            raise RuntimeError(
+                "podman secret ls failed: "
+                f"{(r.stderr or r.stdout or '').strip()}"
+            )
+        if not r.stdout.strip():
             return []
         return filter_secrets_by_prefix(r.stdout.strip().splitlines(), prefix)
 

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -308,9 +308,9 @@ def generate_quadlets(
             stopped). When a set is given, ``Secret=`` emission becomes
             *store-aware* (issue #262): a store-backed reference whose
             entry is absent — and that will not be materialized before
-            container start by a decrypt ``ExecStartPre`` (``.cred`` blob /
-            ``systemd-creds:`` source) or by the start path's
-            ``resolve_and_populate`` (``env:`` / ``cmd:`` source) — is
+            container start by a decrypt ``ExecStartPre`` (present ``.cred``
+            blob, including ``systemd-creds:`` sources) or by the start
+            path's ``resolve_and_populate`` (``env:`` / ``cmd:`` source) — is
             skipped instead of rendered as an unresolvable directive that
             fails the next boot with ``start-limit-hit``. ``None`` keeps
             the legacy emit-everything behavior.
@@ -416,13 +416,13 @@ def generate_quadlets(
         Always true when *store_secrets* is None (store state unknown —
         keep the legacy behavior). Otherwise true when the entry is in
         the store now, or a pre-start channel materializes it: the
-        decrypt ExecStartPre (``systemd-creds:`` source / ``.cred``
-        blob) or the start path's resolve_and_populate (``env:`` /
-        ``cmd:`` source).
+        decrypt ExecStartPre (present ``.cred`` blob, including
+        ``systemd-creds:`` sources) or the start path's
+        resolve_and_populate (``env:`` / ``cmd:`` source).
         """
         if store_secrets is None:
             return True
-        if has_cred_file or scheme in ("systemd-creds", "env", "cmd"):
+        if has_cred_file or scheme in ("env", "cmd"):
             return True
         return env_name in store_secrets
 

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -285,6 +285,7 @@ def generate_quadlets(
     rootless: bool = True,
     used_octets: set[int] | None = None,
     network_octet: int | None = None,
+    store_secrets: set[str] | None = None,
 ) -> dict[str, str]:
     """Return {filename: content} for all 5 quadlet files.
 
@@ -301,6 +302,18 @@ def generate_quadlets(
             podman network is created once at cage-create time and re-deriving
             a different octet on update would generate quadlets whose static
             IPs don't fall in the existing ``<name>-net`` subnet.
+        store_secrets: Env-name set (deploy prefix stripped) of secrets
+            currently present in the podman secret store, or ``None`` when
+            the store cannot be queried (e.g. VM backend with the guest
+            stopped). When a set is given, ``Secret=`` emission becomes
+            *store-aware* (issue #262): a store-backed reference whose
+            entry is absent — and that will not be materialized before
+            container start by a decrypt ``ExecStartPre`` (``.cred`` blob /
+            ``systemd-creds:`` source) or by the start path's
+            ``resolve_and_populate`` (``env:`` / ``cmd:`` source) — is
+            skipped instead of rendered as an unresolvable directive that
+            fails the next boot with ``start-limit-hit``. ``None`` keeps
+            the legacy emit-everything behavior.
     """
     env = _make_env()
     name = config.name
@@ -395,11 +408,36 @@ def generate_quadlets(
     # the proxy container starts.
     from agentcage import state as _state_mod
     _state_creds_dir = _state_mod.deployment_dir(deploy_name or name) / "creds"
+
+    def _boot_resolvable(env_name: str, scheme: str, has_cred_file: bool) -> bool:
+        """True when a ``Secret=`` reference to *env_name* will resolve
+        at container start (issue #262 store-aware gate).
+
+        Always true when *store_secrets* is None (store state unknown —
+        keep the legacy behavior). Otherwise true when the entry is in
+        the store now, or a pre-start channel materializes it: the
+        decrypt ExecStartPre (``systemd-creds:`` source / ``.cred``
+        blob) or the start path's resolve_and_populate (``env:`` /
+        ``cmd:`` source).
+        """
+        if store_secrets is None:
+            return True
+        if has_cred_file or scheme in ("systemd-creds", "env", "cmd"):
+            return True
+        return env_name in store_secrets
+
     proxy_secrets = []
     creds_secrets = []
     for r in config.secret_injection:
         scheme = (r.source or "").partition(":")[0]
         has_cred_file = (_state_creds_dir / f"{r.env}.cred").exists()
+        if not _boot_resolvable(r.env, scheme, has_cred_file):
+            # `secret rm` removed the store entry but the declared rule
+            # stays in cage.yaml — rendering the directive anyway would
+            # make the next egress boot fail with an unresolvable
+            # `Secret=`. Skip it; the next `secret set` re-converges the
+            # units and the line comes back.
+            continue
         if scheme == "systemd-creds" or has_cred_file:
             creds_secrets.append(r.env)
         proxy_secrets.append(r.env)
@@ -416,9 +454,23 @@ def generate_quadlets(
             if not arg or arg in proxy_secrets:
                 continue
             has_cred_file = (_state_creds_dir / f"{arg}.cred").exists()
+            if not _boot_resolvable(arg, scheme, has_cred_file):
+                continue
             if scheme == "systemd-creds" or has_cred_file:
                 creds_secrets.append(arg)
             proxy_secrets.append(arg)
+
+    # Direct podman_secrets on the cage container hit the same boot
+    # failure when their store entry was `secret rm`'d — gate them with
+    # the same store-aware rule (no source: concept here; a .cred blob
+    # is materialized by the egress decrypt ExecStartPre, which runs
+    # before the cage starts).
+    cage_podman_secrets = [
+        s for s in cc.podman_secrets
+        if _boot_resolvable(
+            s, "", (_state_creds_dir / f"{s}.cred").exists()
+        )
+    ]
 
     # Parse ports into structured forwards for proxy reverse mode
     inbound_forwards = []
@@ -606,7 +658,7 @@ def generate_quadlets(
         volumes=expanded_volumes,
         named_volumes=cc.named_volumes,
         tmpfs=cc.tmpfs,
-        podman_secrets=cc.podman_secrets,
+        podman_secrets=cage_podman_secrets,
         placeholders_env_path=placeholders_env_path,
         cage_env_dir=cage_env_dir,
         env=expanded_env,

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -255,6 +255,46 @@ e2e_timer_start
 agentcage secret rm "$CAGE" MY_API_KEY >/dev/null 2>&1 || true
 e2e_pass "3.5" "Remove secret"
 
+# 3.5b: Converged egress quadlet must not reference the removed store
+# entry (issue #262) — `secret rm` re-converges units store-aware, so
+# the dangling `Secret=<cage>.MY_API_KEY` line is dropped.
+e2e_timer_start
+QUADLET="$HOME/.config/containers/systemd/${CAGE}-egress.container"
+if [ -f "$QUADLET" ] && ! grep -q "Secret=${CAGE}.MY_API_KEY" "$QUADLET"; then
+  e2e_pass "3.5b" "Quadlet drops Secret= for removed entry"
+else
+  e2e_fail "3.5b" "Quadlet drops Secret= for removed entry" \
+    "dangling Secret=${CAGE}.MY_API_KEY still in $QUADLET"
+fi
+
+# 3.5c: Cage still BOOTS after the rm (issue #262) — the gap that hid
+# the start-limit-hit failure: nothing re-checked the secrets cage's
+# health after phase 3.5. A dangling Secret= makes podman fail the
+# egress with `no secret with name or ID ...` on the next start.
+e2e_timer_start
+systemctl --user reset-failed "${CAGE}-egress" >/dev/null 2>&1 || true
+agentcage cage restart "$CAGE" >/dev/null 2>&1 || true
+if wait_ready "$BASE" 90; then
+  e2e_pass "3.5c" "Cage boots after secret rm (no start-limit-hit)"
+else
+  e2e_fail "3.5c" "Cage boots after secret rm (no start-limit-hit)" \
+    "cage did not come back after restart following secret rm"
+  dump_cage_diagnostics "$CAGE" "3.5c failure"
+fi
+repatch_mock "$CAGE" httpbin.org || true
+
+# 3.5d: `secret set` re-adds the Secret= line — units track store
+# reality in both directions (rm drops, set re-adds).
+e2e_timer_start
+echo "revived-value" | agentcage secret set "$CAGE" MY_API_KEY >/dev/null 2>&1 || true
+if grep -q "Secret=${CAGE}.MY_API_KEY" "$QUADLET" 2>/dev/null; then
+  e2e_pass "3.5d" "secret set re-adds Secret= line"
+else
+  e2e_fail "3.5d" "secret set re-adds Secret= line" \
+    "Secret=${CAGE}.MY_API_KEY not back in $QUADLET after set"
+fi
+agentcage secret rm "$CAGE" MY_API_KEY >/dev/null 2>&1 || true
+
 # 3.6: Missing secret warning
 e2e_timer_start
 OUTPUT=$(agentcage secret list "$CAGE" 2>&1) || true

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -31,22 +31,31 @@ def _make_config(name: str = "testcage") -> Config:
 class TestSecretEnvNames:
     def test_strips_deploy_prefix(self):
         podman = MagicMock()
-        podman.secret_list.return_value = [
+        podman.secret_list_strict.return_value = [
             {"Name": "myapp.API_KEY"}, {"Name": "myapp.TOKEN"},
         ]
         assert secret_env_names(podman, "myapp") == {"API_KEY", "TOKEN"}
-        podman.secret_list.assert_called_once_with(prefix="myapp.")
+        podman.secret_list_strict.assert_called_once_with(prefix="myapp.")
 
     def test_bare_names_without_deploy_name(self):
         podman = MagicMock()
-        podman.secret_list.return_value = [{"Name": "API_KEY"}]
+        podman.secret_list_strict.return_value = [{"Name": "API_KEY"}]
         assert secret_env_names(podman, "") == {"API_KEY"}
-        podman.secret_list.assert_called_once_with(prefix="")
+        podman.secret_list_strict.assert_called_once_with(prefix="")
 
     def test_empty_store(self):
         podman = MagicMock()
-        podman.secret_list.return_value = []
+        podman.secret_list_strict.return_value = []
         assert secret_env_names(podman, "myapp") == set()
+
+    def test_falls_back_to_lenient_secret_list(self):
+        """A podman-like object without secret_list_strict (e.g. a legacy
+        stub) falls back to secret_list."""
+        podman = MagicMock()
+        del podman.secret_list_strict
+        podman.secret_list.return_value = [{"Name": "myapp.KEY"}]
+        assert secret_env_names(podman, "myapp") == {"KEY"}
+        podman.secret_list.assert_called_once_with(prefix="myapp.")
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +162,8 @@ class TestGenerateUnits:
         listed = [{"Name": "test.API_KEY"}, {"Name": "test.OTHER"}]
 
         with patch.object(backend._podman, "info", return_value=info_data), \
-             patch.object(backend._podman, "secret_list", return_value=listed) as mock_ls, \
+             patch.object(backend._podman, "secret_list_strict",
+                          return_value=listed) as mock_ls, \
              patch("agentcage.backends.container.generate_quadlets",
                    return_value={}) as mock_gen:
             backend.generate_units(
@@ -170,7 +180,7 @@ class TestGenerateUnits:
         info_data = {"host": {"security": {"rootless": True}}}
 
         with patch.object(backend._podman, "info", return_value=info_data), \
-             patch.object(backend._podman, "secret_list",
+             patch.object(backend._podman, "secret_list_strict",
                           side_effect=RuntimeError("podman down")), \
              patch("agentcage.backends.container.generate_quadlets",
                    return_value={}) as mock_gen:

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -9,6 +9,7 @@ import pytest
 
 from agentcage.backends.container import ContainerBackend
 from agentcage.config import Config, ContainerConfig
+from agentcage.podman import secret_env_names
 
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,31 @@ def _make_config(name: str = "testcage") -> Config:
     cfg.container = ContainerConfig()
     cfg.container.image = "localhost/test:latest"
     return cfg
+
+
+# ---------------------------------------------------------------------------
+# secret_env_names (agentcage.podman helper — issue #262)
+# ---------------------------------------------------------------------------
+
+class TestSecretEnvNames:
+    def test_strips_deploy_prefix(self):
+        podman = MagicMock()
+        podman.secret_list.return_value = [
+            {"Name": "myapp.API_KEY"}, {"Name": "myapp.TOKEN"},
+        ]
+        assert secret_env_names(podman, "myapp") == {"API_KEY", "TOKEN"}
+        podman.secret_list.assert_called_once_with(prefix="myapp.")
+
+    def test_bare_names_without_deploy_name(self):
+        podman = MagicMock()
+        podman.secret_list.return_value = [{"Name": "API_KEY"}]
+        assert secret_env_names(podman, "") == {"API_KEY"}
+        podman.secret_list.assert_called_once_with(prefix="")
+
+    def test_empty_store(self):
+        podman = MagicMock()
+        podman.secret_list.return_value = []
+        assert secret_env_names(podman, "myapp") == set()
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +131,7 @@ class TestGenerateUnits:
         info_data = {"host": {"security": {"rootless": True}}}
 
         with patch.object(backend._podman, "info", return_value=info_data), \
+             patch.object(backend._podman, "secret_list", return_value=[]), \
              patch("agentcage.backends.container.generate_quadlets", return_value={
                  "test-cage.container": "[Container]\nImage=test",
                  "test-egress.container": "[Container]\nImage=egress",
@@ -116,6 +143,42 @@ class TestGenerateUnits:
         assert "test-cage.container" in units
         assert "test-egress.container" in units
         mock_gen.assert_called_once()
+
+    def test_passes_store_secret_env_names(self):
+        """Issue #262: generate_units must pass the env-name set of the
+        cage's store entries so quadlet generation can skip Secret=
+        directives that would not resolve at boot (`secret rm` leftovers)."""
+        backend = ContainerBackend()
+        info_data = {"host": {"security": {"rootless": True}}}
+        listed = [{"Name": "test.API_KEY"}, {"Name": "test.OTHER"}]
+
+        with patch.object(backend._podman, "info", return_value=info_data), \
+             patch.object(backend._podman, "secret_list", return_value=listed) as mock_ls, \
+             patch("agentcage.backends.container.generate_quadlets",
+                   return_value={}) as mock_gen:
+            backend.generate_units(
+                _make_config(), "/c.yaml", "/patches", "test"
+            )
+
+        mock_ls.assert_called_once_with(prefix="test.")
+        assert mock_gen.call_args.kwargs["store_secrets"] == {"API_KEY", "OTHER"}
+
+    def test_store_query_failure_falls_back_to_none(self):
+        """A store query failure must not drop Secret= lines — pass None
+        (legacy emit-all) instead of an empty set."""
+        backend = ContainerBackend()
+        info_data = {"host": {"security": {"rootless": True}}}
+
+        with patch.object(backend._podman, "info", return_value=info_data), \
+             patch.object(backend._podman, "secret_list",
+                          side_effect=RuntimeError("podman down")), \
+             patch("agentcage.backends.container.generate_quadlets",
+                   return_value={}) as mock_gen:
+            backend.generate_units(
+                _make_config(), "/c.yaml", "/patches", "test"
+            )
+
+        assert mock_gen.call_args.kwargs["store_secrets"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -265,12 +265,35 @@ class TestSecretList:
             result = p.secret_list()
         assert result == []
 
-    def test_command_failure(self):
+    def test_command_failure_lenient(self):
+        """secret_list is lenient: a transient podman failure returns []
+        (cage show / secret list / destroy_resources rely on this so a
+        daemon hiccup never crashes them). The store-aware path uses
+        secret_list_strict instead."""
         p = Podman()
         with patch("agentcage.podman.subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=1, stdout="")
-            result = p.secret_list()
-        assert result == []
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="daemon unavailable"
+            )
+            assert p.secret_list() == []
+
+    def test_strict_raises_on_failure(self):
+        """secret_list_strict raises so the store-aware Secret= gate can
+        distinguish a transient failure from a genuinely empty store and
+        fall back to legacy emit-everything (issue #262)."""
+        p = Podman()
+        with patch("agentcage.podman.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="daemon unavailable"
+            )
+            with pytest.raises(RuntimeError, match="podman secret ls failed"):
+                p.secret_list_strict()
+
+    def test_strict_empty_on_success(self):
+        p = Podman()
+        with patch("agentcage.podman.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            assert p.secret_list_strict() == []
 
 
 class TestSecretRead:

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -531,6 +531,206 @@ class TestEgressQuadlet:
         assert '--name "API_KEY"' in decrypt_line
 
 
+class TestStoreAwareSecretEmission:
+    """Issue #262: `secret rm` removes the podman store entry but the
+    declared secret_injection rule stays in cage.yaml — blindly rendering
+    `Secret=<cage>.<KEY>` makes the next egress boot fail with
+    `no secret with name or ID ...` → start-limit-hit. With
+    ``store_secrets`` passed (the env-name set actually present in the
+    store), generation must skip store-backed references whose entry is
+    absent — unless a pre-start channel materializes them (`.cred` blob /
+    `systemd-creds:` decrypt ExecStartPre, or `env:`/`cmd:` resolution on
+    the start path). ``store_secrets=None`` keeps legacy emit-all."""
+
+    def _cfg(self, tmp_path, body: str):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent(body))
+        return load_config(str(p))
+
+    def test_missing_store_entry_drops_secret_line(self, tmp_path):
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: API_KEY
+                placeholder: "{{API_KEY}}"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets=set(),
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.API_KEY" not in content
+
+    def test_present_store_entry_keeps_secret_line(self, tmp_path):
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: API_KEY
+                placeholder: "{{API_KEY}}"
+              - env: GONE_KEY
+                placeholder: "{{GONE_KEY}}"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets={"API_KEY"},
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
+        assert "Secret=myapp.GONE_KEY" not in content
+
+    def test_none_store_keeps_legacy_emit_all(self, tmp_path):
+        """Store state unknown (VM guest stopped, store unqueryable) →
+        emit everything, exactly as before the fix."""
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: API_KEY
+                placeholder: "{{API_KEY}}"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
+
+    def test_env_and_cmd_sources_survive_empty_store(self, tmp_path):
+        """env:/cmd: sources are resolved into the store by the start
+        path's resolve_and_populate before units launch — their Secret=
+        lines must stay even when the store is empty at generation."""
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: ENV_KEY
+                placeholder: "{{ENV_KEY}}"
+                source: "env:MY_VAR"
+              - env: CMD_KEY
+                placeholder: "{{CMD_KEY}}"
+                source: "cmd:echo hi"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets=set(),
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.ENV_KEY,type=env,target=ENV_KEY" in content
+        assert "Secret=myapp.CMD_KEY,type=env,target=CMD_KEY" in content
+
+    def test_systemd_creds_source_survives_empty_store(self, tmp_path):
+        """systemd-creds: rules get a decrypt ExecStartPre that creates
+        the store entry before the container starts — keep the line."""
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: API_KEY
+                placeholder: "{{API_KEY}}"
+                source: "systemd-creds:"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets=set(),
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
+        assert "systemd-creds" in content and "decrypt" in content
+
+    def test_cred_blob_survives_empty_store(self, tmp_path, patch_state_dirs):
+        """A .cred blob (auto-encrypted `secret set` on a systemd-creds
+        host) is materialized by the decrypt ExecStartPre — keep the
+        line even without an explicit source: and an empty store."""
+        state = patch_state_dirs
+        creds_dir = state.deployment_dir("myapp") / "creds"
+        creds_dir.mkdir(parents=True)
+        (creds_dir / "API_KEY.cred").write_bytes(b"blob")
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: API_KEY
+                placeholder: "{{API_KEY}}"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets=set(),
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
+
+    def test_relay_credentials_gated_by_store(self, tmp_path):
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            protocol_relays:
+              - name: migadu-imap
+                type: imap
+                listen: "127.0.0.1:1143"
+                upstream:
+                  host: imap.migadu.com
+                  port: 993
+                auth:
+                  type: imap-login
+                  user_source: "podman:MIGADU_USER"
+                  password_source: "podman:MIGADU_PASSWORD"
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets={"MIGADU_USER"},
+        )
+        content = files["test-egress.container"]
+        assert "Secret=myapp.MIGADU_USER,type=env,target=MIGADU_USER" in content
+        assert "Secret=myapp.MIGADU_PASSWORD" not in content
+
+    def test_cage_podman_secrets_gated_by_store(self, tmp_path):
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+              podman_secrets:
+                - KEEP_ME
+                - RM_ME
+        """)
+        files = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="myapp",
+            store_secrets={"KEEP_ME"},
+        )
+        content = files["test-cage.container"]
+        assert "Secret=myapp.KEEP_ME,type=env,target=KEEP_ME" in content
+        assert "Secret=myapp.RM_ME" not in content
+
+    def test_rm_then_set_round_trip(self, tmp_path):
+        """The converge cycle: rm drops the line, the next set re-adds
+        it — units always track store reality."""
+        cfg = self._cfg(tmp_path, """\
+            name: test
+            container:
+              image: test:latest
+            secret_injection:
+              - env: BRAND_KEY
+                placeholder: "{{BRAND_KEY}}"
+        """)
+        after_rm = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="optest",
+            store_secrets=set(),
+        )["test-egress.container"]
+        assert "Secret=optest.BRAND_KEY" not in after_rm
+        after_set = generate_quadlets(
+            cfg, "/c.yaml", "/patches", deploy_name="optest",
+            store_secrets={"BRAND_KEY"},
+        )["test-egress.container"]
+        assert "Secret=optest.BRAND_KEY,type=env,target=BRAND_KEY" in after_set
+
+
 class TestVmLocalEgressConfigPaths:
     """VM backend: the egress quadlet must bind-mount a VM-local copy of
     proxy-config.yaml and dns-allowlist.conf — NOT the host path under

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -538,9 +538,10 @@ class TestStoreAwareSecretEmission:
     `no secret with name or ID ...` → start-limit-hit. With
     ``store_secrets`` passed (the env-name set actually present in the
     store), generation must skip store-backed references whose entry is
-    absent — unless a pre-start channel materializes them (`.cred` blob /
-    `systemd-creds:` decrypt ExecStartPre, or `env:`/`cmd:` resolution on
-    the start path). ``store_secrets=None`` keeps legacy emit-all."""
+    absent — unless a pre-start channel materializes them (a present
+    `.cred` blob, including `systemd-creds:` decrypt ExecStartPre, or
+    `env:`/`cmd:` resolution on the start path). ``store_secrets=None``
+    keeps legacy emit-all."""
 
     def _cfg(self, tmp_path, body: str):
         p = tmp_path / "config.yaml"
@@ -623,9 +624,10 @@ class TestStoreAwareSecretEmission:
         assert "Secret=myapp.ENV_KEY,type=env,target=ENV_KEY" in content
         assert "Secret=myapp.CMD_KEY,type=env,target=CMD_KEY" in content
 
-    def test_systemd_creds_source_survives_empty_store(self, tmp_path):
-        """systemd-creds: rules get a decrypt ExecStartPre that creates
-        the store entry before the container starts — keep the line."""
+    def test_systemd_creds_source_without_blob_is_dropped(self, tmp_path):
+        """After `secret rm` the .cred blob is gone too. An explicit
+        systemd-creds: rule must not keep an unresolvable Secret= / decrypt
+        ExecStartPre solely because of its scheme."""
         cfg = self._cfg(tmp_path, """\
             name: test
             container:
@@ -640,13 +642,14 @@ class TestStoreAwareSecretEmission:
             store_secrets=set(),
         )
         content = files["test-egress.container"]
-        assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
-        assert "systemd-creds" in content and "decrypt" in content
+        assert "Secret=myapp.API_KEY" not in content
+        assert "systemd-creds" not in content
 
     def test_cred_blob_survives_empty_store(self, tmp_path, patch_state_dirs):
         """A .cred blob (auto-encrypted `secret set` on a systemd-creds
-        host) is materialized by the decrypt ExecStartPre — keep the
-        line even without an explicit source: and an empty store."""
+        host, or an explicit systemd-creds: source with a stored blob) is
+        materialized by the decrypt ExecStartPre — keep the line even
+        without a store entry."""
         state = patch_state_dirs
         creds_dir = state.deployment_dir("myapp") / "creds"
         creds_dir.mkdir(parents=True)
@@ -665,6 +668,7 @@ class TestStoreAwareSecretEmission:
         )
         content = files["test-egress.container"]
         assert "Secret=myapp.API_KEY,type=env,target=API_KEY" in content
+        assert "systemd-creds" in content and "decrypt" in content
 
     def test_relay_credentials_gated_by_store(self, tmp_path):
         cfg = self._cfg(tmp_path, """\

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -164,12 +164,54 @@ class TestGenerateUnits:
             "testcage",
             used_octets=None,
             network_octet=None,
+            store_secrets=None,
         )
 
         assert "lima.yaml" in units
         assert units["lima.yaml"] == "lima: yaml content"
         assert "quadlets/testcage-cage.container" in units
         assert "quadlets/testcage-net.network" in units
+
+    def test_store_secrets_queried_from_running_guest(self):
+        """Issue #262: for VM cages the podman secret store lives inside
+        the guest — when the Lima instance is running, generate_units
+        must pass the guest store's env-name set so `secret rm` leftovers
+        drop their Secret= directive."""
+        backend = VmBackend()
+        config = _make_config()
+        inst = MagicMock()
+        inst.exists.return_value = True
+        inst.is_running.return_value = True
+        vm_podman = MagicMock()
+        vm_podman.secret_list.return_value = [{"Name": "testcage.API_KEY"}]
+
+        with patch("agentcage.backends.vm.generate_lima_config", return_value="y"), \
+             patch("agentcage.backends.vm.LimaInstance", return_value=inst), \
+             patch("agentcage.lima.podman.VmPodman", return_value=vm_podman), \
+             patch("agentcage.backends.vm.generate_quadlets",
+                   return_value={}) as mock_q:
+            backend.generate_units(config, "", "", "testcage")
+
+        vm_podman.secret_list.assert_called_once_with(prefix="testcage.")
+        assert mock_q.call_args.kwargs["store_secrets"] == {"API_KEY"}
+
+    def test_store_secrets_none_when_guest_stopped(self):
+        """Guest not running → store unqueryable → None (legacy emit-all;
+        also the initial-create path where pending secrets land only
+        after the VM first starts)."""
+        backend = VmBackend()
+        config = _make_config()
+        inst = MagicMock()
+        inst.exists.return_value = True
+        inst.is_running.return_value = False
+
+        with patch("agentcage.backends.vm.generate_lima_config", return_value="y"), \
+             patch("agentcage.backends.vm.LimaInstance", return_value=inst), \
+             patch("agentcage.backends.vm.generate_quadlets",
+                   return_value={}) as mock_q:
+            backend.generate_units(config, "", "", "testcage")
+
+        assert mock_q.call_args.kwargs["store_secrets"] is None
 
     def test_quadlet_keys_prefixed_correctly(self):
         backend = VmBackend()

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -183,7 +183,7 @@ class TestGenerateUnits:
         inst.exists.return_value = True
         inst.is_running.return_value = True
         vm_podman = MagicMock()
-        vm_podman.secret_list.return_value = [{"Name": "testcage.API_KEY"}]
+        vm_podman.secret_list_strict.return_value = [{"Name": "testcage.API_KEY"}]
 
         with patch("agentcage.backends.vm.generate_lima_config", return_value="y"), \
              patch("agentcage.backends.vm.LimaInstance", return_value=inst), \
@@ -192,7 +192,7 @@ class TestGenerateUnits:
                    return_value={}) as mock_q:
             backend.generate_units(config, "", "", "testcage")
 
-        vm_podman.secret_list.assert_called_once_with(prefix="testcage.")
+        vm_podman.secret_list_strict.assert_called_once_with(prefix="testcage.")
         assert mock_q.call_args.kwargs["store_secrets"] == {"API_KEY"}
 
     def test_store_secrets_none_when_guest_stopped(self):
@@ -207,6 +207,27 @@ class TestGenerateUnits:
 
         with patch("agentcage.backends.vm.generate_lima_config", return_value="y"), \
              patch("agentcage.backends.vm.LimaInstance", return_value=inst), \
+             patch("agentcage.backends.vm.generate_quadlets",
+                   return_value={}) as mock_q:
+            backend.generate_units(config, "", "", "testcage")
+
+        assert mock_q.call_args.kwargs["store_secrets"] is None
+
+    def test_store_secrets_none_when_guest_query_fails(self):
+        """Guest running but `podman secret ls` fails → None (legacy
+        emit-all), NOT an empty set, which would drop every Secret= line
+        (issue #262)."""
+        backend = VmBackend()
+        config = _make_config()
+        inst = MagicMock()
+        inst.exists.return_value = True
+        inst.is_running.return_value = True
+        vm_podman = MagicMock()
+        vm_podman.secret_list_strict.side_effect = RuntimeError("guest podman down")
+
+        with patch("agentcage.backends.vm.generate_lima_config", return_value="y"), \
+             patch("agentcage.backends.vm.LimaInstance", return_value=inst), \
+             patch("agentcage.lima.podman.VmPodman", return_value=vm_podman), \
              patch("agentcage.backends.vm.generate_quadlets",
                    return_value={}) as mock_q:
             backend.generate_units(config, "", "", "testcage")


### PR DESCRIPTION
Closes #262.

## Problem

\`agentcage secret rm <cage> <KEY>\` removes the podman store entry (and the systemd-creds \`.cred\` blob) but leaves the declared \`secret_injection\` rule in \`cage.yaml\`. Regenerated quadlets therefore keep rendering:

\`\`\`ini
Secret=<cage>.<KEY>,type=env,target=<KEY>
\`\`\`

…and the next egress start fails to resolve it:

\`\`\`
podman: no secret with name or ID "optest.BRAND_KEY"
optest-egress.service: Failed with result 'start-limit-hit'.
\`\`\`

Egress stays down until the value is re-set. The e2e never caught it because phase 3.5 swallowed the exit code and nothing re-checked the secrets cage's health afterwards.

## Fix

Make \`Secret=\` emission **store-aware** at generation time. \`generate_quadlets()\` takes a \`store_secrets\` set (env-names present in the store) and skips a directive only when the entry is absent **and** nothing materializes it before container start:

- \`.cred\` blob / \`systemd-creds:\` source → the decrypt \`ExecStartPre\` populates the store first — keep the line.
- \`env:\` / \`cmd:\` source → the start path's \`resolve_and_populate\` populates it — keep the line.
- otherwise, absent from the store → **skip** (would be unresolvable).

\`store_secrets=None\` preserves the legacy emit-everything behavior (fail-safe when the store can't be queried). The same gate covers protocol-relay credentials and the cage container's direct \`podman_secrets\`, which hit the identical boot failure.

Since \`secret set\`/\`rm\` converge quadlets on every invocation (#261), the units now always track store reality: **rm drops the line, the next set re-adds it.**

### Backends supply the store view

- **container**: query host podman (reachability already proven by the \`info()\` call); on query failure pass \`None\` = legacy emit-all.
- **vm**: the store lives *inside the guest* — query via \`VmPodman\` only while the Lima instance is running; otherwise \`None\` (also the initial-create path, where pending secrets land after the VM first starts). This is the VM wrinkle the issue flagged as the reason it wasn't bolted onto 0.23.0.

### e2e — closes the gap that hid this

Phase 3 now asserts, after \`secret rm\`:
- **3.5b** the converged egress quadlet drops the dangling \`Secret=\` line
- **3.5c** the cage still **boots** after the rm (no \`start-limit-hit\`)
- **3.5d** \`secret set\` re-adds the line

## Notes for reviewers

- Unit suite green locally (\`1854 passed, 14 skipped\`), including new \`TestStoreAwareSecretEmission\` (quadlets), backend store-query tests, and \`secret_env_names\` helper tests.
- The e2e phase (3.5b–d) needs a real podman+systemd host to exercise — validated only with \`bash -n\` here.