### PR TITLE
fix(e2e): match retitled openclaw-gateway process in phase 8.4

### DIFF
--- a/tests/e2e/phase8_openclaw.md
+++ b/tests/e2e/phase8_openclaw.md
@@ -113,11 +113,14 @@ regression that this phase is blind to.
 Things phase 8's logic *assumes* about the environment — if any of
 these stop holding, assertions could pass for the wrong reason.
 
-- **setproctitle renames survive.** 8.4 relies on `pgrep -f '^openclaw$'`
-  matching exactly the openclaw process's cmdline. If openclaw stops
-  renaming argv[0] and instead runs as `node openclaw.mjs gateway`, the
-  pgrep returns empty and 8.4 bails with "could not find openclaw
-  process" — a *correct* failure, but the message will mislead.
+- **setproctitle renames survive.** 8.4 relies on
+  `pgrep -f '^openclaw($|-gateway)'` matching the openclaw process's
+  cmdline — upstream retitled it from `openclaw` to `openclaw-gateway`
+  (padded argv) in the 2026-07 images, which is why the pattern accepts
+  both. If openclaw stops renaming argv[0] and instead runs as
+  `node openclaw.mjs gateway`, the pgrep returns empty and 8.4 bails
+  with "could not find openclaw process" — a *correct* failure, but the
+  message will mislead.
 - **commands.restart defaults to true.** 8.4 sends an external SIGUSR1
   via `pkill`. openclaw's handler (see `isRestartEnabled` in
   `dist/commands.flags-*.js`) authorizes the restart unless config sets

--- a/tests/e2e/phase8_openclaw.sh
+++ b/tests/e2e/phase8_openclaw.sh
@@ -177,7 +177,8 @@ else
 fi
 
 # 8.4: self-restart on SIGUSR1 (log-line witness + readiness probe).
-# Openclaw 2026.5+ runs as a single "openclaw" process and handles SIGUSR1
+# Openclaw 2026.5+ runs as a single retitled process — "openclaw" until
+# the 2026-07 images, "openclaw-gateway" since — and handles SIGUSR1
 # with an in-process restart in containers (deliberate — keeps PID 1
 # alive). The PID never changes; the gateway tears down its server,
 # reinitializes, and starts listening again. We witness this via two
@@ -189,7 +190,7 @@ fi
 e2e_timer_start
 # `pgrep` exits 1 on no-match — wrap in `|| true` so `set -e` doesn't
 # kill the phase before we can report 8.4 as a failure.
-OPENCLAW_PID=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw$' 2>/dev/null | head -1 || true)
+OPENCLAW_PID=$(podman exec "${CAGE}-cage" pgrep -f '^openclaw($|-gateway)' 2>/dev/null | head -1 || true)
 if [ -z "$OPENCLAW_PID" ]; then
   e2e_fail "8.4" "self-restart SIGUSR1" "could not find openclaw process before signal"
 else
@@ -197,7 +198,7 @@ else
   # the signal. Avoids matching a "received SIGUSR1" from an earlier
   # restart in the same container.
   LOG_BEFORE=$(podman logs "${CAGE}-cage" 2>&1 | wc -l | tr -d ' ')
-  podman exec "${CAGE}-cage" pkill -USR1 -f '^openclaw$' 2>/dev/null || true
+  podman exec "${CAGE}-cage" pkill -USR1 -f '^openclaw($|-gateway)' 2>/dev/null || true
   RESTART_LOGGED=""
   for _ in $(seq 1 30); do
     sleep 1


### PR DESCRIPTION
## Summary

The openclaw regression canary (phase 8, test 8.4) broke when upstream rebuilt `ghcr.io/openclaw/openclaw:latest` on 2026-07-13: the gateway now retitles its process to `openclaw-gateway` (padded argv) instead of `openclaw`, so `pgrep -f '^openclaw$'` found nothing and 8.4 bailed with *could not find openclaw process before signal*. Master's last green run predates the image rebuild (2026-07-08).

Fix: match both titles with `^openclaw($|-gateway)` in the pgrep/pkill calls, and update the phase-8 doc's assumptions section (which explicitly called out this failure mode).

Verified against the new image directly (docker run + probe):
- `pgrep -f '^openclaw($|-gateway)'` matches the gateway process.
- SIGUSR1 still logs `received SIGUSR1; restarting` and the in-process restart keeps the PID alive — the rest of 8.4's witness logic is unchanged.

Unblocks #282 (its OpenClaw E2E check fails on this, unrelated to its own changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)