### PR TITLE
chore(release): 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-19
+
 ### Changed
 
 - **The `secrets` inspector now defaults to `flag` on HTTP egress (was an unconditional hard block).** A leaked-credential pattern in an outbound HTTP request is now recorded in the audit log and forwarded rather than blocked with a 403. **Protocol relays (SMTP) still default to `block`** — an email body is a deliberate, operator-invisible exfil channel — and an explicit `secrets.action` in config overrides both defaults everywhere. Operators who relied on the old hard-block behavior on HTTP should set `secrets: { action: block }`. Unrecognized `action` values fall back to `flag`.
+
+### Fixed
+
+- **`agentcage secret rm` no longer bricks the next boot.** Removing a secret deleted the podman store entry but regenerated quadlets kept rendering `Secret=<cage>.<KEY>,type=env`, so the next egress start failed with `no secret with name or ID …` (start-limit-hit) until the value was re-set. `Secret=` emission is now store-aware at generation time: a directive is skipped only when the store entry is absent and nothing materializes it before container start. The same gate covers protocol-relay credentials and the cage container's direct `podman_secrets`.
 
 ## [0.29.1] - 2026-07-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentcage"
-version = "0.29.1"
+version = "0.30.0"
 requires-python = ">=3.12"
 description = "Defense-in-depth proxy sandbox for AI agents"
 authors = [{name = "Luca Martinetti"}]

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agentcage"
-version = "0.29.1"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut 0.30.0.

- **Changed**: `secrets` inspector defaults to `flag` on HTTP egress, `block` on SMTP relays (#282) — see the changelog migration note.
- **Fixed**: store-aware `Secret=` emission so `secret rm` doesn't brick the next boot (#294 / #262) — this entry was missing from the changelog, added here.

Note: 0.29.1's release commit (#293) merged but was never tagged/published — no `v0.29.1` tag, PyPI and GitHub releases stop at 0.29.0. This release supersedes it; the 0.29.1 changelog section is already in place.

After merge: tag the squash commit `v0.30.0` and push — publish.yml (PyPI trusted publishing + `gh release create`) fires on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)