### PR TITLE
feat(relays): reach an upstream no public CA signed, via upstream.ca_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Protocol relays can now reach an upstream whose certificate no public CA signed, via `upstream.ca_file`.** The relay built its upstream TLS context from the proxy container's system CA store with no override, so a relay could only ever point at a publicly-trusted mail host — a self-hosted server behind a private CA, or a local decrypting daemon like Proton Mail Bridge that mints its own self-signed certificate, was unreachable. `upstream.ca_file` is a path on the host (`~` and `$VARS` expanded); the CLI reads it at deploy time and hands the proxy the contents, because the relay runs inside the proxy container where a host path means nothing. proxy-config.yaml is rewritten on every deploy and restart path, so a regenerated certificate is picked up by `cage restart` with no config edit. A missing or non-PEM file fails the deploy rather than surfacing later as `certificate verify failed`. `upstream.ca_pem` accepts the same certificate inline for self-contained config; setting both is an error rather than a silent precedence rule. The certificate is **added** to the system store rather than replacing it, so one relay's private CA is never the reason another relay can't reach a normal mail host. `upstream.tls_servername` supplies the name checked against the certificate when the relay dials an IP literal that no certificate can name. Verification and hostname checking stay on in every configuration — there is deliberately no "skip verification" mode, since the relay hands the upstream real credentials. Any of these alongside `tls: false` is rejected at config load rather than silently ignored.
+
 ### Fixed
 
 - **`cage audit` no longer returns nothing when podman puts the egress on a file log driver.** The audit reader was hard-wired to `journalctl --user -u <cage>-egress`, but podman only selects the `journald` driver when it can actually write there — which requires a conmon built with journald support — and falls back to `k8s-file` silently otherwise. Under that fallback the proxy stayed healthy, kept detecting and recording, and `cage audit` printed an empty stream: silent audit loss, with nothing anywhere to indicate the trail had gone missing. The container backend now reads back the driver podman actually chose and reads `podman logs` when the journal never received the output, keeping `journalctl` (which spans container recreation) wherever journald is in use. `--since` is applied post-parse on this path, matching how apple-container's tail-based reader has always handled it. `cage logs` hits the same wall and now warns, naming the `podman logs` command to use, rather than printing a near-empty stream. Surfaced by e2e `1.4b`/`8.8b` failing on GitHub's runners after their image stopped preinstalling podman.
-
 ## [0.30.0] - 2026-07-19
 
 ### Changed

--- a/docs/reference/protocol-relays.md
+++ b/docs/reference/protocol-relays.md
@@ -13,11 +13,57 @@ Credential brokers for non-HTTP protocols (IMAP, SMTP) that mirror what [secret 
 | `upstream.host` | `string` | yes | Real upstream server hostname. |
 | `upstream.port` | `int` | yes | Real upstream port (e.g. 993 for IMAPS, 465 for SMTPS). |
 | `upstream.tls` | `bool` | no | Whether to use TLS upstream. Default `true`. |
+| `upstream.ca_file` | `string` | no | Path on the **host** to a PEM certificate, added to the proxy's CA store for this upstream. For upstreams no public CA signs. Read at deploy time. Requires `tls: true`. |
+| `upstream.ca_pem` | `string` | no | The same certificate inline, for config that has to be self-contained. Mutually exclusive with `ca_file`. Requires `tls: true`. |
+| `upstream.tls_servername` | `string` | no | Name sent in SNI and checked against the upstream certificate, when it differs from `upstream.host`. Required when `host` is an IP literal. Requires `tls: true`. |
 | `auth.type` | `string` | yes | Auth scheme. `imap-login` for IMAP; `smtp-plain` for SMTP. |
 | `auth.user_source` | `string` | yes | Source for the username. Same scheme grammar as `secret_injection.source` (`env:`, `cmd:`, `systemd-creds:`, `podman:`). |
 | `auth.password_source` | `string` | yes | Source for the password, same grammar. |
 
 > **Note:** Secrets named in `auth.user_source` / `auth.password_source` are automatically stripped from the cage's `podman_secrets` and `env` blocks the same way `secret_injection.env` is — they exist only in the proxy.
+
+## Upstreams no public CA signs
+
+By default the relay verifies the upstream against the proxy container's system CA store, which is what a public mail host needs. Two kinds of upstream can't be reached that way:
+
+- a **self-hosted mail server** behind a private CA, and
+- a **local decrypting daemon** — Proton Mail Bridge, Hydroxide, a Gmail OAuth shim — which mints its own self-signed certificate at setup and listens on a container or loopback address.
+
+For these, point `upstream.ca_file` at the certificate on the host:
+
+```yaml
+protocol_relays:
+  - name: bridge-imap
+    type: imap
+    listen: "0.0.0.0:1243"
+    upstream:
+      host: 10.88.0.5          # the bridge daemon's container address
+      port: 1143
+      tls: true
+      tls_servername: bridge.local
+      ca_file: ~/.config/protonmail/bridge-v3/cert.pem
+    auth:
+      type: imap-login
+      user_source: "podman:BRIDGE_USER"
+      password_source: "podman:BRIDGE_PASSWORD"
+    policy:
+      readonly: true
+      folder_allowlist: [INBOX]
+```
+
+`~` and `$VARS` are expanded. `upstream.ca_pem` takes the same certificate inline instead, for config that has to be self-contained; setting both is an error rather than a silent precedence rule.
+
+Four properties worth being explicit about:
+
+**The path is read on the host, at deploy time.** The relay runs inside the proxy container, where a host path means nothing, so the CLI reads the file and hands the proxy the contents in `proxy-config.yaml`. That file is rewritten on every deploy and restart path, so a daemon that regenerates its certificate is picked up by `agentcage cage restart` with no config edit. Bind-mounting the file instead would pin an inode — a certificate that gets *replaced* rather than rewritten would be missed — and would need separate plumbing in each of the three backends.
+
+**A missing or non-PEM file fails the deploy.** Better a refused deploy than a relay that can't verify its upstream at 3am and reports only `certificate verify failed`.
+
+**The certificate is added to the system store, not substituted for it.** A relay with an extra anchor still trusts every public CA, so one relay's private certificate is never the reason another can't reach a normal mail host. The trade-off is that this is not pinning: a public CA that mis-issues for the same name still satisfies the check.
+
+**Verification and hostname checking stay on.** There is deliberately no "skip verification" knob: the relay hands the upstream real credentials, so an unverified upstream is an unauthenticated one. This is why `tls_servername` exists — when you point a relay at an IP literal, no certificate can name it, so add the certificate and supply the name it *does* carry. (If the certificate already has an IP SAN for the address you dial, you don't need the override.)
+
+Setting any of these alongside `tls: false` is a config error rather than a no-op: a CA sitting next to a plaintext connection reads as "verified" in review while verifying nothing.
 
 ## IMAP policy
 

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -310,6 +310,18 @@ class RelayUpstream:
     host: str
     port: int
     tls: bool = True
+    # Path to a PEM certificate on the host, added to the proxy's system
+    # CA store for this upstream. For upstreams no public CA signs: a
+    # private-CA mail server, or a local decrypting daemon like Proton
+    # Mail Bridge that mints its own self-signed certificate. Read at
+    # deploy time and delivered to the proxy as ``ca_pem``.
+    ca_file: str = ""
+    # The resolved inline form ``ca_file`` becomes, and what the relay
+    # actually loads. Accepted directly in config too.
+    ca_pem: str = ""
+    # Name presented in SNI and checked against the certificate, when it
+    # differs from ``host`` — required whenever ``host`` is an IP literal.
+    tls_servername: str = ""
 
 
 @dataclass
@@ -724,6 +736,9 @@ def load_config(path: str) -> Config:
             host=str(up_raw.get("host", "")),
             port=int(up_raw.get("port", 0) or 0),
             tls=bool(up_raw.get("tls", True)),
+            ca_file=str(up_raw.get("ca_file", "") or ""),
+            ca_pem=str(up_raw.get("ca_pem", "") or ""),
+            tls_servername=str(up_raw.get("tls_servername", "") or ""),
         )
         auth_raw = entry.get("auth") or {}
         auth = RelayAuth(

--- a/src/agentcage/data/proxy/relays/_tls.py
+++ b/src/agentcage/data/proxy/relays/_tls.py
@@ -1,0 +1,90 @@
+"""Upstream TLS policy shared by the IMAP and SMTP relays.
+
+Lives under ``data/proxy/relays/`` next to ``_validate`` for the same
+reason: both sides of the trust boundary import the same code. The CLI
+imports it as ``agentcage.data.proxy.relays._tls``; the proxy container
+imports it as ``relays._tls``.
+
+Stdlib only — the proxy environment does not have the CLI package on
+its path.
+
+Deliberately one module rather than a copy in each relay. The other
+small helpers (``_resolve_credential``, ``_ConnRateLimiter``) are
+duplicated across imap.py/smtp.py for code-shape parity, but a drifting
+copy of *this* one silently downgrades certificate verification on one
+protocol and not the other, which is exactly the class of bug that
+never shows up in a passing test run.
+"""
+
+from __future__ import annotations
+
+import ssl
+from typing import Optional
+
+
+def build_upstream_ssl_context(
+    *,
+    tls: bool,
+    ca_pem: str = "",
+) -> Optional[ssl.SSLContext]:
+    """Build the SSLContext for a relay's upstream connection.
+
+    Returns ``None`` when ``tls`` is false — the caller then connects in
+    plaintext.
+
+    The context always starts from the proxy container's system CA
+    store, which is what a public mail host needs (Migadu, Gmail,
+    Fastmail). ``ca_pem`` is *added* to that store, for upstreams it
+    cannot cover: a self-hosted mail server behind a private CA, or a
+    local decrypting daemon such as Proton Mail Bridge, which mints its
+    own self-signed certificate at setup time.
+
+    Additive, not exclusive: a relay configured with an extra anchor
+    still trusts every public CA. That keeps one relay's private
+    certificate from being a reason the next one can't reach a normal
+    upstream, and matches how ``SSL_CERT_FILE``-style configuration
+    behaves everywhere else. The cost is that ``ca_pem`` does not pin —
+    a public CA that mis-issues for the same name still satisfies the
+    check.
+
+    Verification and hostname checking stay on in every branch. There is
+    deliberately no "skip verification" mode: an unverified upstream is
+    an unauthenticated one, and the relay hands it real credentials.
+    When the upstream is addressed by IP (so its certificate name can
+    never match), add the certificate and name it with
+    ``tls_servername`` — see :func:`upstream_connect_kwargs`.
+    """
+    if not tls:
+        return None
+    ctx = ssl.create_default_context()
+    if ca_pem:
+        # load_verify_locations on a context that already loaded the
+        # system store appends to it — create_default_context() did that
+        # load, so this is strictly additive.
+        ctx.load_verify_locations(cadata=ca_pem)
+    return ctx
+
+
+def upstream_connect_kwargs(
+    *,
+    tls: bool,
+    ca_pem: str = "",
+    tls_servername: str = "",
+) -> dict:
+    """Return the TLS kwargs for ``asyncio.open_connection``.
+
+    ``tls_servername`` overrides the name presented in SNI and checked
+    against the certificate, which the caller needs when ``upstream.host``
+    is an IP literal: a certificate cannot be issued for an address the
+    operator picked out of a container subnet, and IP-address SANs are
+    rare in self-signed output.
+
+    Omitted entirely when there is no TLS context, because
+    ``asyncio.open_connection`` rejects ``server_hostname`` on a
+    plaintext connection instead of ignoring it.
+    """
+    ctx = build_upstream_ssl_context(tls=tls, ca_pem=ca_pem)
+    kwargs: dict = {"ssl": ctx}
+    if ctx is not None and tls_servername:
+        kwargs["server_hostname"] = tls_servername
+    return kwargs

--- a/src/agentcage/data/proxy/relays/_validate.py
+++ b/src/agentcage/data/proxy/relays/_validate.py
@@ -69,6 +69,56 @@ def validate_relay_entry(
             f"port in [1, 65535]"
         )
 
+    tls = bool(upstream.get("tls", True))
+    ca_file = upstream.get("ca_file", "") or ""
+    if not isinstance(ca_file, str):
+        raise ValueError(
+            f"protocol_relays[{name}].upstream.ca_file must be a path "
+            f"string (got {type(ca_file).__name__})"
+        )
+    ca_pem = upstream.get("ca_pem", "") or ""
+    if not isinstance(ca_pem, str):
+        raise ValueError(
+            f"protocol_relays[{name}].upstream.ca_pem must be a PEM "
+            f"string (got {type(ca_pem).__name__})"
+        )
+    if ca_pem and "-----BEGIN CERTIFICATE-----" not in ca_pem:
+        raise ValueError(
+            f"protocol_relays[{name}].upstream.ca_pem does not look like "
+            f"PEM — expected a '-----BEGIN CERTIFICATE-----' block. To "
+            f"point at a file on disk, use upstream.ca_file."
+        )
+    # ca_file is the operator-facing form; the CLI reads it and hands the
+    # proxy the resolved ca_pem. Both set at once is ambiguous about
+    # which one wins, so say so instead of picking silently.
+    if ca_file and ca_pem:
+        raise ValueError(
+            f"protocol_relays[{name}].upstream sets both ca_file and "
+            f"ca_pem; use one. ca_file is read at deploy time and becomes "
+            f"ca_pem in the proxy's config."
+        )
+    servername = upstream.get("tls_servername", "") or ""
+    if not isinstance(servername, str):
+        raise ValueError(
+            f"protocol_relays[{name}].upstream.tls_servername must be a "
+            f"string (got {type(servername).__name__})"
+        )
+    # These only mean something on a TLS connection. Silently ignoring
+    # them on a plaintext upstream would read as "the certificate is
+    # verified" in a config review when nothing is verified at all.
+    if not tls:
+        for key, value in (
+            ("ca_file", ca_file),
+            ("ca_pem", ca_pem),
+            ("tls_servername", servername),
+        ):
+            if value:
+                raise ValueError(
+                    f"protocol_relays[{name}].upstream.{key} requires "
+                    f"upstream.tls: true (got tls: false, which connects "
+                    f"in plaintext and verifies nothing)"
+                )
+
     auth = entry.get("auth") or {}
     if not isinstance(auth, dict):
         raise ValueError(f"protocol_relays[{name}].auth must be a mapping")

--- a/src/agentcage/data/proxy/relays/imap.py
+++ b/src/agentcage/data/proxy/relays/imap.py
@@ -26,6 +26,8 @@ import ssl
 import time
 from typing import Callable, Optional
 
+from relays._tls import upstream_connect_kwargs
+
 log = logging.getLogger("agentcage.relays.imap")
 
 
@@ -129,6 +131,12 @@ class _RelayConfig:
         self.upstream_host: str = str(upstream.get("host") or "")
         self.upstream_port: int = int(upstream.get("port") or 0)
         self.upstream_tls: bool = bool(upstream.get("tls", True))
+        # Pinned PEM + SNI/hostname override for upstreams no public CA
+        # signs (private CA, Proton Mail Bridge). See relays._tls.
+        self.upstream_ca_pem: str = str(upstream.get("ca_pem") or "")
+        self.upstream_tls_servername: str = str(
+            upstream.get("tls_servername") or ""
+        )
         auth = entry.get("auth") or {}
         self.user_source: str = str(auth.get("user_source") or "")
         self.password_source: str = str(auth.get("password_source") or "")
@@ -261,14 +269,15 @@ class ImapRelay:
         client_reader: asyncio.StreamReader,
         client_writer: asyncio.StreamWriter,
     ) -> None:
-        ssl_ctx = (
-            ssl.create_default_context() if self._cfg.upstream_tls else None
-        )
         try:
             upstream_reader, upstream_writer = await asyncio.open_connection(
                 self._cfg.upstream_host,
                 self._cfg.upstream_port,
-                ssl=ssl_ctx,
+                **upstream_connect_kwargs(
+                    tls=self._cfg.upstream_tls,
+                    ca_pem=self._cfg.upstream_ca_pem,
+                    tls_servername=self._cfg.upstream_tls_servername,
+                ),
             )
         except (OSError, ssl.SSLError) as e:
             log.warning(

--- a/src/agentcage/data/proxy/relays/smtp.py
+++ b/src/agentcage/data/proxy/relays/smtp.py
@@ -44,7 +44,6 @@ import asyncio
 import logging
 import os
 import re
-import ssl
 import time
 from base64 import b64encode
 from email import message_from_bytes
@@ -53,6 +52,7 @@ from typing import Callable, Optional
 
 from inspectors.base import InspectionContext, InspectionResult, Inspector
 from inspectors.util import shannon_entropy
+from relays._tls import upstream_connect_kwargs
 
 log = logging.getLogger("agentcage.relays.smtp")
 
@@ -129,6 +129,12 @@ class _SmtpConfig:
         self.upstream_host: str = str(upstream.get("host") or "")
         self.upstream_port: int = int(upstream.get("port") or 0)
         self.upstream_tls: bool = bool(upstream.get("tls", True))
+        # Pinned PEM + SNI/hostname override for upstreams no public CA
+        # signs (private CA, Proton Mail Bridge). See relays._tls.
+        self.upstream_ca_pem: str = str(upstream.get("ca_pem") or "")
+        self.upstream_tls_servername: str = str(
+            upstream.get("tls_servername") or ""
+        )
 
         auth = entry.get("auth") or {}
         self.auth_type: str = str(auth.get("type") or "smtp-plain")
@@ -896,13 +902,14 @@ class SmtpRelay:
         return None
 
     async def _connect_upstream(self) -> "_UpstreamSmtp":
-        ssl_ctx = (
-            ssl.create_default_context() if self._cfg.upstream_tls else None
-        )
         reader, writer = await asyncio.open_connection(
             self._cfg.upstream_host,
             self._cfg.upstream_port,
-            ssl=ssl_ctx,
+            **upstream_connect_kwargs(
+                tls=self._cfg.upstream_tls,
+                ca_pem=self._cfg.upstream_ca_pem,
+                tls_servername=self._cfg.upstream_tls_servername,
+            ),
         )
         upstream = _UpstreamSmtp(
             reader, writer, self._cfg.name, self._user, self._password,

--- a/src/agentcage/state.py
+++ b/src/agentcage/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import shutil
@@ -157,11 +158,60 @@ def save_proxy_config(name: str) -> str:
     """
     raw = load_raw_config(name)
     proxy_cfg = {k: v for k, v in raw.items() if k in _PROXY_KEYS}
+    # deepcopy: the ca_file -> ca_pem rewrite must not leak back into the
+    # in-memory raw config (and from there into a cage.yaml rewrite),
+    # which would replace the operator's path with a wall of PEM.
+    proxy_cfg = resolve_relay_ca_files(copy.deepcopy(proxy_cfg))
     p = _deploy_dir(name) / "proxy-config.yaml"
     with open(p, "w") as f:
         yaml.safe_dump(proxy_cfg, f, default_flow_style=False, sort_keys=False)
     save_placeholders_env(name)
     return str(p)
+
+
+def resolve_relay_ca_files(proxy_cfg: dict) -> dict:
+    """Read each relay's ``upstream.ca_file`` and inline it as ``ca_pem``.
+
+    The relay runs inside the proxy container, where a host path means
+    nothing. Rather than bind-mount the file — which pins an inode, so a
+    daemon that *replaces* its certificate on reinstall would be missed
+    anyway, and which needs separate plumbing in the container, vm, and
+    apple-container backends — the CLI reads it here and hands the proxy
+    the contents. proxy-config.yaml is rewritten on every deploy and
+    restart path, so a rotated certificate is picked up by
+    ``cage restart`` with no config edit.
+
+    Mutates and returns *proxy_cfg*. Raises ``ValueError`` with an
+    actionable message if a declared file is missing or unreadable —
+    failing at deploy beats a relay that cannot verify its upstream at
+    3am and says only "certificate verify failed".
+    """
+    for relay in proxy_cfg.get("protocol_relays") or []:
+        if not isinstance(relay, dict):
+            continue
+        upstream = relay.get("upstream")
+        if not isinstance(upstream, dict):
+            continue
+        ca_file = upstream.pop("ca_file", "") or ""
+        if not ca_file:
+            continue
+        path = Path(os.path.expanduser(os.path.expandvars(str(ca_file))))
+        try:
+            pem = path.read_text()
+        except OSError as e:
+            raise ValueError(
+                f"protocol_relays[{relay.get('name', '?')}]."
+                f"upstream.ca_file: cannot read {str(path)!r}: "
+                f"{e.strerror or e}"
+            ) from e
+        if "-----BEGIN CERTIFICATE-----" not in pem:
+            raise ValueError(
+                f"protocol_relays[{relay.get('name', '?')}]."
+                f"upstream.ca_file: {str(path)!r} holds no PEM certificate "
+                f"(expected a '-----BEGIN CERTIFICATE-----' block)"
+            )
+        upstream["ca_pem"] = pem
+    return proxy_cfg
 
 
 def cage_env_dir(name: str) -> Path:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -305,6 +305,70 @@ class TestProtocolRelaysParser:
         assert relay.policy.readonly is True
         assert relay.policy.folder_allowlist == ["INBOX", "Sent"]
         assert relay.policy.conn_rate_limit == "30/min"
+        # Opt-in: an unset ca_file/ca_pem means just the proxy's system
+        # CA store, which is what a public mail host needs.
+        assert relay.upstream.ca_file == ""
+        assert relay.upstream.ca_pem == ""
+        assert relay.upstream.tls_servername == ""
+
+    def test_parses_upstream_ca_file(self, tmp_path):
+        """The operator-facing form: a path plus an SNI override, for an
+        upstream no public CA signs."""
+        p = self._yaml(tmp_path, textwrap.dedent("""\
+            protocol_relays:
+              - name: bridge-imap
+                type: imap
+                listen: "0.0.0.0:1243"
+                upstream:
+                  host: 10.88.0.5
+                  port: 1143
+                  tls: true
+                  tls_servername: bridge.local
+                  ca_file: ~/.config/protonmail/bridge-v3/cert.pem
+                auth:
+                  type: imap-login
+                  user_source: "systemd-creds:MIGADU_USER"
+                  password_source: "systemd-creds:MIGADU_PASSWORD"
+        """).replace("\n", "\n            "))
+        cfg = load_config(str(p))
+        relay = cfg.protocol_relays[0]
+        assert relay.upstream.ca_file == (
+            "~/.config/protonmail/bridge-v3/cert.pem"
+        )
+        # Left unexpanded here on purpose: expansion belongs at deploy,
+        # where state.resolve_relay_ca_files reads the file.
+        assert relay.upstream.ca_pem == ""
+        assert relay.upstream.tls_servername == "bridge.local"
+
+    def test_parses_inline_upstream_certificate(self, tmp_path):
+        """Inline PEM + SNI override for an upstream no public CA signs."""
+        p = self._yaml(tmp_path, textwrap.dedent("""\
+            protocol_relays:
+              - name: bridge-imap
+                type: imap
+                listen: "0.0.0.0:1243"
+                upstream:
+                  host: 10.88.0.5
+                  port: 1143
+                  tls: true
+                  tls_servername: bridge.local
+                  ca_pem: |
+                    -----BEGIN CERTIFICATE-----
+                    MIIBfakeexamplecertificatebody
+                    -----END CERTIFICATE-----
+                auth:
+                  type: imap-login
+                  user_source: "systemd-creds:MIGADU_USER"
+                  password_source: "systemd-creds:MIGADU_PASSWORD"
+        """).replace("\n", "\n            "))
+        cfg = load_config(str(p))
+        relay = cfg.protocol_relays[0]
+        assert relay.upstream.host == "10.88.0.5"
+        assert relay.upstream.tls_servername == "bridge.local"
+        assert relay.upstream.ca_pem.startswith("-----BEGIN CERTIFICATE-----")
+        assert relay.upstream.ca_pem.rstrip().endswith(
+            "-----END CERTIFICATE-----"
+        )
 
     def test_strips_relay_secrets_from_podman_and_env(self, tmp_path):
         p = self._yaml(tmp_path, textwrap.dedent("""\

--- a/tests/test_protocol_relays.py
+++ b/tests/test_protocol_relays.py
@@ -907,6 +907,75 @@ class TestSharedValidation:
             "upstream": {"host": "imap.example.com", "port": 993},
         })  # no exception
 
+    def _entry(self, **upstream) -> dict:
+        entry = {
+            "name": "r", "type": "imap", "listen": "127.0.0.1:1143",
+            "upstream": {"host": "imap.example.com", "port": 993},
+        }
+        entry["upstream"].update(upstream)
+        return entry
+
+    def test_validate_rejects_ca_pem_that_is_a_path(self):
+        """The commonest mistake: `ca_pem: /certs/bridge.pem`. The error
+        points at ca_file rather than letting a path be loaded as PEM and
+        fail at connect time instead of config time.
+        """
+        from relays._validate import validate_relay_entry
+        with pytest.raises(ValueError, match="does not look like"):
+            validate_relay_entry(self._entry(ca_pem="/certs/bridge.pem"))
+
+    def test_validate_rejects_non_string_ca_pem(self):
+        from relays._validate import validate_relay_entry
+        with pytest.raises(ValueError, match="must be a PEM string"):
+            validate_relay_entry(self._entry(ca_pem=["cert"]))
+
+    def test_validate_rejects_pin_on_plaintext_upstream(self):
+        """A CA next to `tls: false` reads as "verified" in review but
+        verifies nothing — reject rather than silently ignore.
+        """
+        from relays._validate import validate_relay_entry
+        pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+        with pytest.raises(ValueError, match="requires upstream.tls: true"):
+            validate_relay_entry(self._entry(tls=False, ca_pem=pem))
+
+    def test_validate_rejects_servername_on_plaintext_upstream(self):
+        from relays._validate import validate_relay_entry
+        with pytest.raises(ValueError, match="requires upstream.tls: true"):
+            validate_relay_entry(
+                self._entry(tls=False, tls_servername="bridge.local")
+            )
+
+    def test_validate_rejects_non_string_ca_file(self):
+        from relays._validate import validate_relay_entry
+        with pytest.raises(ValueError, match="must be a path string"):
+            validate_relay_entry(self._entry(ca_file=["/certs/x.pem"]))
+
+    def test_validate_rejects_ca_file_and_ca_pem_together(self):
+        """Ambiguous about which wins — say so rather than pick silently."""
+        from relays._validate import validate_relay_entry
+        pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+        with pytest.raises(ValueError, match="both ca_file and ca_pem"):
+            validate_relay_entry(self._entry(ca_file="/c.pem", ca_pem=pem))
+
+    def test_validate_rejects_ca_file_on_plaintext_upstream(self):
+        from relays._validate import validate_relay_entry
+        with pytest.raises(ValueError, match="requires upstream.tls: true"):
+            validate_relay_entry(self._entry(tls=False, ca_file="/c.pem"))
+
+    def test_validate_passes_upstream_with_ca_file(self):
+        from relays._validate import validate_relay_entry
+        validate_relay_entry(
+            self._entry(ca_file="/certs/bridge.pem",
+                        tls_servername="bridge.local")
+        )  # no exception
+
+    def test_validate_passes_upstream_with_extra_ca(self):
+        from relays._validate import validate_relay_entry
+        pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+        validate_relay_entry(
+            self._entry(ca_pem=pem, tls_servername="bridge.local")
+        )  # no exception
+
 
 
 # ── A2: idle timeout in pre-bridge phase ────────────────

--- a/tests/test_relay_upstream_tls.py
+++ b/tests/test_relay_upstream_tls.py
@@ -1,0 +1,419 @@
+"""Upstream TLS policy for protocol relays: extra CA + SNI override.
+
+``test_protocol_relays.py`` deliberately bypasses TLS (``tls: false``)
+so it can assert on plaintext command flow. These tests do the opposite:
+a real handshake against a self-signed upstream, because the thing under
+test *is* certificate verification — a mocked SSLContext would only
+prove we called Python.
+
+The certificate is minted in-process (no fixture files) and issued for
+``bridge.local`` while the fake upstream listens on 127.0.0.1. That is
+the exact shape of the case this feature exists for: a relay pointed at
+an IP literal whose certificate can never name it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import ipaddress
+import ssl
+from contextlib import asynccontextmanager
+from typing import Optional
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from relays._tls import build_upstream_ssl_context, upstream_connect_kwargs
+from relays.imap import ImapRelay
+from relays.smtp import SmtpRelay
+
+
+# ── Self-signed certificate minting ──────────────────────
+
+
+def _make_self_signed(common_name: str, tmp_path, *, with_ip_san: bool = False):
+    """Mint a self-signed cert/key pair. Returns (pem, certfile, keyfile).
+
+    Self-signed and CA-flagged, matching what a local decrypting daemon
+    generates at setup: the leaf is its own trust anchor, which is
+    precisely what ``ca_pem`` adds to the store.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    sans: list[x509.GeneralName] = [x509.DNSName(common_name)]
+    if with_ip_san:
+        sans.append(x509.IPAddress(ipaddress.ip_address("127.0.0.1")))
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName(sans), critical=False)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+        .sign(key, hashes.SHA256())
+    )
+    certfile = tmp_path / f"{common_name}.crt"
+    keyfile = tmp_path / f"{common_name}.key"
+    pem = cert.public_bytes(serialization.Encoding.PEM)
+    certfile.write_bytes(pem)
+    keyfile.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return pem.decode(), str(certfile), str(keyfile)
+
+
+# ── Fake TLS upstream + relay harness ────────────────────
+
+
+@asynccontextmanager
+async def _tls_upstream(certfile: str, keyfile: str):
+    """Fake IMAP upstream behind TLS that accepts any LOGIN."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile, keyfile)
+
+    async def _handle(reader, writer):
+        try:
+            writer.write(b"* OK [CAPABILITY IMAP4rev1] fake tls upstream\r\n")
+            await writer.drain()
+            line = await reader.readline()
+            if not line:
+                return
+            tag = line.split(b" ", 1)[0]
+            writer.write(tag + b" OK [CAPABILITY IMAP4rev1] logged in\r\n")
+            await writer.drain()
+            await reader.read()
+        except (ConnectionResetError, ssl.SSLError, asyncio.IncompleteReadError):
+            pass
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0, ssl=ctx)
+    try:
+        yield server.sockets[0].getsockname()[1]
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@asynccontextmanager
+async def _running_relay(entry: dict, audit: Optional[list] = None):
+    relay = ImapRelay(
+        entry, audit_log=(audit.append if audit is not None else None)
+    )
+    await relay.start()
+    try:
+        yield relay._server.sockets[0].getsockname()[1]
+    finally:
+        await relay.stop()
+
+
+async def _greeting(port: int) -> bytes:
+    """Connect as the cage would and read the relay's opening line."""
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        return await asyncio.wait_for(reader.readline(), timeout=10)
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+def _relay_entry(upstream_port: int, **upstream) -> dict:
+    entry = {
+        "name": "extra-ca-imap",
+        "type": "imap",
+        "listen": "127.0.0.1:0",
+        "upstream": {"host": "127.0.0.1", "port": upstream_port, "tls": True},
+        "auth": {
+            "type": "imap-login",
+            "user_source": "env:TEST_TLS_IMAP_USER",
+            "password_source": "env:TEST_TLS_IMAP_PASS",
+        },
+    }
+    entry["upstream"].update(upstream)
+    return entry
+
+
+def _run(coro):
+    """Helper for non-async tests."""
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _imap_creds(monkeypatch):
+    monkeypatch.setenv("TEST_TLS_IMAP_USER", "real-user@example.com")
+    monkeypatch.setenv("TEST_TLS_IMAP_PASS", "real-app-password")
+
+
+# ── Context construction ─────────────────────────────────
+
+
+class TestContextConstruction:
+    def test_no_tls_returns_no_context(self):
+        assert build_upstream_ssl_context(tls=False) is None
+        assert upstream_connect_kwargs(tls=False) == {"ssl": None}
+
+    def test_servername_omitted_on_plaintext(self):
+        """asyncio rejects server_hostname without ssl — never emit it."""
+        kwargs = upstream_connect_kwargs(
+            tls=False, tls_servername="bridge.local"
+        )
+        assert "server_hostname" not in kwargs
+
+    def test_servername_passed_through_on_tls(self):
+        kwargs = upstream_connect_kwargs(
+            tls=True, tls_servername="bridge.local"
+        )
+        assert kwargs["server_hostname"] == "bridge.local"
+
+    def test_default_context_verifies_and_checks_hostname(self):
+        ctx = build_upstream_ssl_context(tls=True)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+
+    def test_ca_pem_keeps_verification_on(self, tmp_path):
+        pem, _, _ = _make_self_signed("bridge.local", tmp_path)
+        ctx = build_upstream_ssl_context(tls=True, ca_pem=pem)
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+
+    def test_ca_pem_extends_the_system_store(self, tmp_path):
+        """Additive: the extra anchor joins the public CAs, it doesn't
+        replace them. One relay's private certificate must not be the
+        reason the next relay can't reach a normal mail host.
+
+        Written as a delta rather than an absolute count so it holds on
+        hosts with an empty or unenumerable CA bundle — the 3.13/3.14 CI
+        runners report zero system anchors.
+        """
+        pem, _, _ = _make_self_signed("bridge.local", tmp_path)
+        system = build_upstream_ssl_context(tls=True)
+        extended = build_upstream_ssl_context(tls=True, ca_pem=pem)
+
+        assert len(extended.get_ca_certs()) == len(system.get_ca_certs()) + 1
+        subjects = [c["subject"] for c in extended.get_ca_certs()]
+        assert ((("commonName", "bridge.local"),),) in subjects
+
+
+# ── End-to-end against a self-signed upstream ────────────
+
+
+class TestExtraCaUpstream:
+    def test_extra_ca_connects_to_self_signed_upstream(self, tmp_path):
+        pem, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+
+        async def _go():
+            async with _tls_upstream(certfile, keyfile) as up_port:
+                entry = _relay_entry(
+                    up_port, ca_pem=pem, tls_servername="bridge.local"
+                )
+                async with _running_relay(entry) as port:
+                    assert (await _greeting(port)).startswith(b"* PREAUTH")
+
+        _run(_go())
+
+    def test_self_signed_upstream_rejected_without_extra_ca(self, tmp_path):
+        """The default path must still fail closed on an unknown CA."""
+        _, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+        audit: list[dict] = []
+
+        async def _go():
+            async with _tls_upstream(certfile, keyfile) as up_port:
+                entry = _relay_entry(up_port, tls_servername="bridge.local")
+                async with _running_relay(entry, audit) as port:
+                    assert (await _greeting(port)).startswith(b"* BYE")
+
+        _run(_go())
+
+        failures = [
+            e for e in audit if e["kind"] == "imap_upstream_unreachable"
+        ]
+        assert len(failures) == 1
+        assert "certificate verify failed" in failures[0]["error"]
+
+    def test_pin_without_servername_fails_hostname_check(self, tmp_path):
+        """Pinning the cert is not enough when the relay dials an IP.
+
+        The cert names ``bridge.local``; the relay connects to 127.0.0.1
+        and checks *that* name unless ``tls_servername`` overrides it.
+        Hostname verification stays on, so this must fail rather than
+        quietly pass because the chain happened to be trusted.
+        """
+        pem, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+        audit: list[dict] = []
+
+        async def _go():
+            async with _tls_upstream(certfile, keyfile) as up_port:
+                async with _running_relay(
+                    _relay_entry(up_port, ca_pem=pem), audit
+                ) as port:
+                    assert (await _greeting(port)).startswith(b"* BYE")
+
+        _run(_go())
+
+        failures = [
+            e for e in audit if e["kind"] == "imap_upstream_unreachable"
+        ]
+        assert len(failures) == 1
+        # OpenSSL words this as "IP address mismatch" when the dialed
+        # host is an address rather than a name — the anchor was accepted,
+        # the name check is what rejected it.
+        assert "not valid for '127.0.0.1'" in failures[0]["error"]
+
+    def test_ip_san_cert_needs_no_servername_override(self, tmp_path):
+        """An IP-SAN cert verifies against the dialed address directly."""
+        pem, certfile, keyfile = _make_self_signed(
+            "bridge.local", tmp_path, with_ip_san=True
+        )
+
+        async def _go():
+            async with _tls_upstream(certfile, keyfile) as up_port:
+                async with _running_relay(
+                    _relay_entry(up_port, ca_pem=pem)
+                ) as port:
+                    assert (await _greeting(port)).startswith(b"* PREAUTH")
+
+        _run(_go())
+
+    def test_unrelated_ca_does_not_satisfy_verification(self, tmp_path):
+        """Adding *a* certificate doesn't trust *any* certificate — an
+        anchor for a different key must still fail verification."""
+        _, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+        other_pem, _, _ = _make_self_signed("impostor.local", tmp_path)
+        audit: list[dict] = []
+
+        async def _go():
+            async with _tls_upstream(certfile, keyfile) as up_port:
+                entry = _relay_entry(
+                    up_port, ca_pem=other_pem, tls_servername="bridge.local"
+                )
+                async with _running_relay(entry, audit) as port:
+                    assert (await _greeting(port)).startswith(b"* BYE")
+
+        _run(_go())
+
+        failures = [
+            e for e in audit if e["kind"] == "imap_upstream_unreachable"
+        ]
+        assert len(failures) == 1
+        assert "certificate verify failed" in failures[0]["error"]
+
+
+# ── SMTP parity ──────────────────────────────────────────
+
+
+@asynccontextmanager
+async def _tls_smtp_upstream(certfile: str, keyfile: str):
+    """Fake submission host behind TLS: greeting, EHLO, AUTH PLAIN."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile, keyfile)
+
+    async def _handle(reader, writer):
+        try:
+            writer.write(b"220 fake.upstream ESMTP\r\n")
+            await writer.drain()
+            while True:
+                line = await reader.readline()
+                if not line:
+                    return
+                upper = line.upper()
+                if upper.startswith(b"EHLO") or upper.startswith(b"HELO"):
+                    writer.write(b"250-fake.upstream\r\n250 AUTH PLAIN\r\n")
+                elif upper.startswith(b"AUTH"):
+                    writer.write(b"235 2.7.0 authenticated\r\n")
+                elif upper.startswith(b"QUIT"):
+                    writer.write(b"221 bye\r\n")
+                    await writer.drain()
+                    return
+                else:
+                    writer.write(b"250 ok\r\n")
+                await writer.drain()
+        except (ConnectionResetError, ssl.SSLError):
+            pass
+        finally:
+            try:
+                writer.close()
+            except Exception:
+                pass
+
+    server = await asyncio.start_server(_handle, "127.0.0.1", 0, ssl=ctx)
+    try:
+        yield server.sockets[0].getsockname()[1]
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def _smtp_relay_entry(upstream_port: int, **upstream) -> dict:
+    entry = {
+        "name": "extra-ca-smtp",
+        "type": "smtp",
+        "listen": "127.0.0.1:0",
+        "upstream": {"host": "127.0.0.1", "port": upstream_port, "tls": True},
+        "auth": {
+            "type": "smtp-plain",
+            "user_source": "env:TEST_TLS_IMAP_USER",
+            "password_source": "env:TEST_TLS_IMAP_PASS",
+        },
+    }
+    entry["upstream"].update(upstream)
+    return entry
+
+
+class TestSmtpRelayParity:
+    """The SMTP relay reads the same two keys through the same helper.
+
+    Covered separately from the IMAP tests because a typo in either
+    ``_SmtpConfig`` field name would leave the shared helper correct and
+    the SMTP relay silently falling back to the system CA store.
+    """
+
+    def test_extra_ca_connects_to_self_signed_upstream(self, tmp_path):
+        pem, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+
+        async def _go():
+            async with _tls_smtp_upstream(certfile, keyfile) as up_port:
+                relay = SmtpRelay(
+                    _smtp_relay_entry(
+                        up_port, ca_pem=pem, tls_servername="bridge.local"
+                    )
+                )
+                upstream = await relay._connect_upstream()
+                assert upstream is not None
+                # Release it, or the fake server's handler sits in
+                # readline() forever and wait_closed() never returns.
+                await upstream.close()
+
+        _run(_go())
+
+    def test_self_signed_upstream_rejected_without_extra_ca(self, tmp_path):
+        _, certfile, keyfile = _make_self_signed("bridge.local", tmp_path)
+
+        async def _go():
+            async with _tls_smtp_upstream(certfile, keyfile) as up_port:
+                relay = SmtpRelay(
+                    _smtp_relay_entry(up_port, tls_servername="bridge.local")
+                )
+                with pytest.raises(ssl.SSLCertVerificationError):
+                    await relay._connect_upstream()
+
+        _run(_go())

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -152,6 +152,117 @@ class TestSaveProxyConfig:
         assert proxy_cfg["protocol_relays"][0]["name"] == "migadu-imap"
 
 
+class TestResolveRelayCaFiles:
+    """`upstream.ca_file` is a host path; the relay runs in the proxy
+    container. The CLI reads it at deploy time and hands the proxy the
+    contents, so a rotated certificate is picked up by `cage restart`
+    with no config edit and no per-backend bind-mount plumbing."""
+
+    PEM = (
+        "-----BEGIN CERTIFICATE-----\n"
+        "MIIBfakeexamplecertificatebody\n"
+        "-----END CERTIFICATE-----\n"
+    )
+
+    def _cfg(self, ca_file) -> dict:
+        return {
+            "protocol_relays": [{
+                "name": "bridge-imap",
+                "type": "imap",
+                "upstream": {"host": "10.88.0.5", "port": 1143,
+                             "tls": True, "ca_file": str(ca_file)},
+            }]
+        }
+
+    def test_reads_the_file_into_ca_pem(self, tmp_path, _patch_state_dirs):
+        state = _patch_state_dirs
+        cert = tmp_path / "bridge.pem"
+        cert.write_text(self.PEM)
+
+        out = state.resolve_relay_ca_files(self._cfg(cert))
+        upstream = out["protocol_relays"][0]["upstream"]
+
+        assert upstream["ca_pem"] == self.PEM
+        # The path is consumed, not forwarded: it would be meaningless
+        # inside the proxy container and invites a stale second source.
+        assert "ca_file" not in upstream
+
+    def test_expands_user_and_vars(self, tmp_path, _patch_state_dirs, monkeypatch):
+        state = _patch_state_dirs
+        cert = tmp_path / "bridge.pem"
+        cert.write_text(self.PEM)
+        monkeypatch.setenv("CERT_HOME", str(tmp_path))
+
+        out = state.resolve_relay_ca_files(self._cfg("$CERT_HOME/bridge.pem"))
+        assert out["protocol_relays"][0]["upstream"]["ca_pem"] == self.PEM
+
+    def test_missing_file_fails_at_deploy(self, tmp_path, _patch_state_dirs):
+        """Better a refused deploy than a relay that can't verify its
+        upstream at 3am and says only 'certificate verify failed'."""
+        state = _patch_state_dirs
+        with pytest.raises(ValueError, match="cannot read"):
+            state.resolve_relay_ca_files(self._cfg(tmp_path / "absent.pem"))
+
+    def test_non_pem_file_fails_at_deploy(self, tmp_path, _patch_state_dirs):
+        state = _patch_state_dirs
+        junk = tmp_path / "notacert.pem"
+        junk.write_text("this is not a certificate\n")
+        with pytest.raises(ValueError, match="no PEM certificate"):
+            state.resolve_relay_ca_files(self._cfg(junk))
+
+    def test_relays_without_ca_file_are_untouched(self, _patch_state_dirs):
+        state = _patch_state_dirs
+        cfg = {"protocol_relays": [
+            {"name": "migadu-imap",
+             "upstream": {"host": "imap.migadu.com", "port": 993}},
+        ]}
+        assert state.resolve_relay_ca_files(cfg) == cfg
+
+    def test_does_not_mutate_the_stored_cage_config(
+        self, tmp_path, _patch_state_dirs
+    ):
+        """The rewrite must not leak back into cage.yaml — the operator
+        wrote a path and should keep seeing a path, not a wall of PEM."""
+        state = _patch_state_dirs
+        cert = tmp_path / "bridge.pem"
+        cert.write_text(self.PEM)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(textwrap.dedent(f"""\
+            name: myapp
+            container:
+              image: node:22-slim
+            domains:
+              allow:
+                - example.com
+            protocol_relays:
+              - name: bridge-imap
+                type: imap
+                listen: "0.0.0.0:1243"
+                upstream:
+                  host: 10.88.0.5
+                  port: 1143
+                  tls: true
+                  ca_file: "{cert}"
+                auth:
+                  type: imap-login
+                  user_source: "podman:BRIDGE_USER"
+                  password_source: "podman:BRIDGE_PASSWORD"
+        """))
+        state.save_deployment("myapp", str(cfg))
+        proxy_path = state.save_proxy_config("myapp")
+
+        with open(proxy_path) as f:
+            proxy_cfg = yaml.safe_load(f)
+        relay_upstream = proxy_cfg["protocol_relays"][0]["upstream"]
+        assert relay_upstream["ca_pem"] == self.PEM
+        assert "ca_file" not in relay_upstream
+
+        stored = state.load_raw_config("myapp")
+        stored_upstream = stored["protocol_relays"][0]["upstream"]
+        assert stored_upstream["ca_file"] == str(cert)
+        assert "ca_pem" not in stored_upstream
+
+
 class TestSaveDnsAllowlist:
     """save_dns_allowlist writes dnsmasq's --servers-file format from cage.yaml."""
 


### PR DESCRIPTION
> Stacked on #299 (the audit-reader fix), so this PR's diff is just the relay change. Merge #299 first.

## Why

Protocol relays build their upstream TLS context from a bare `ssl.create_default_context()` with no override (`relays/imap.py`, `relays/smtp.py`), so a relay can only ever point at a **publicly-trusted** mail host. Two real upstreams are unreachable today:

- a **self-hosted mail server** behind a private CA, and
- a **local decrypting daemon** — Proton Mail Bridge, Hydroxide, a Gmail shim — which mints its own self-signed certificate at setup and listens on a container or loopback address.

Bridge-style daemons are the motivating case: they're the *only* way to get IMAP/SMTP out of a provider that has none, and the relay is otherwise exactly the right place to hold their credentials.

## What

| key | meaning |
|---|---|
| `ca_file` | path on the **host** to a PEM certificate (`~` / `$VARS` expanded) |
| `ca_pem` | the same certificate inline, for self-contained config |
| `tls_servername` | name sent in SNI and checked against the cert, when it differs from `upstream.host` |

```yaml
upstream:
  host: 10.88.0.5          # bridge daemon's container address
  port: 1143
  tls: true
  tls_servername: bridge.local
  ca_file: ~/.config/protonmail/bridge-v3/cert.pem
```

## Design notes worth reviewing

**`ca_file` is read host-side, not bind-mounted.** The relay runs inside the proxy container, where a host path means nothing, so the CLI reads the file when it writes `proxy-config.yaml` and hands the proxy the contents. That file is rewritten on every deploy and restart path, so a daemon that regenerates its certificate is picked up by `cage restart` with no config edit.

Bind-mounting was the obvious alternative and is worse on both counts: a file bind-mount pins an inode, so a certificate that gets *replaced* rather than rewritten in place — which is what a bridge reinstall does — would be missed anyway; and the mount would need separate plumbing in the container quadlet, `apple_container.py`, and the VM backend's single-file staging workaround (`quadlets.py:360`).

A missing or non-PEM file **fails the deploy**, rather than surfacing at 3am as `certificate verify failed`. `ca_file` and `ca_pem` together is an error, not a silent precedence rule. The rewrite is done on a deepcopy so the operator's `cage.yaml` keeps showing a path, not a wall of PEM.

**Additive, not pinning.** `create_default_context()` then `load_verify_locations(cadata=...)`, so the extra anchor joins the public CAs. One relay's private certificate is never the reason another relay can't reach a normal mail host. The trade-off, stated plainly in the docs: this does not pin, so a public CA mis-issuing for the same name still satisfies the check.

**No `verify: false`.** Verification and hostname checking stay on in every branch — the relay hands the upstream real credentials, so an unverified upstream is an unauthenticated one. `tls_servername` covers the IP-literal case instead. Easy to add an escape hatch if you'd rather have one.

**One shared `_tls.py`**, breaking the copy-per-relay parity that `_resolve_credential` and `_ConnRateLimiter` follow — a drifting copy would silently downgrade verification on one protocol and not the other.

## Tests

`tests/test_relay_upstream_tls.py` (13) does **real TLS handshakes** against an in-process self-signed upstream — the thing under test is certificate verification, so a mock would only prove we called Python. Covers: the extra CA connects; an unknown self-signed upstream still **fails closed**; an *unrelated* CA doesn't satisfy verification; the hostname check still fires when `tls_servername` is omitted on an IP dial; IP-SAN certs need no override; and SMTP parity separately, so a typo in either `_SmtpConfig` field can't hide behind a correct shared helper. The additive assertion is written as a delta (`system + 1`) rather than an absolute count, because the 3.13/3.14 runners report zero system anchors — that bit me on the first push of this branch.

`tests/test_state.py::TestResolveRelayCaFiles` (6) covers the deploy-time read: `~`/`$VAR` expansion, missing file, non-PEM file, relays without `ca_file` untouched, and that the stored `cage.yaml` still holds the path while `proxy-config.yaml` holds the PEM.

Plus validation cases in `test_protocol_relays.py` and config round-trips in `test_config.py`. Full suite **1907 passed** on 3.12 and 3.14 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)