### PR TITLE
fix(audit): read the audit trail from wherever podman actually logged it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cage audit` no longer returns nothing when podman puts the egress on a file log driver.** The audit reader was hard-wired to `journalctl --user -u <cage>-egress`, but podman only selects the `journald` driver when it can actually write there — which requires a conmon built with journald support — and falls back to `k8s-file` silently otherwise. Under that fallback the proxy stayed healthy, kept detecting and recording, and `cage audit` printed an empty stream: silent audit loss, with nothing anywhere to indicate the trail had gone missing. The container backend now reads back the driver podman actually chose and reads `podman logs` when the journal never received the output, keeping `journalctl` (which spans container recreation) wherever journald is in use. `--since` is applied post-parse on this path, matching how apple-container's tail-based reader has always handled it. `cage logs` hits the same wall and now warns, naming the `podman logs` command to use, rather than printing a near-empty stream. Surfaced by e2e `1.4b`/`8.8b` failing on GitHub's runners after their image stopped preinstalling podman.
+
 ## [0.30.0] - 2026-07-19
 
 ### Changed

--- a/src/agentcage/backends/container.py
+++ b/src/agentcage/backends/container.py
@@ -11,7 +11,7 @@ import click
 from agentcage import systemd
 from agentcage._timing import Phase
 from agentcage.config import Config
-from agentcage.podman import Podman, secret_env_names
+from agentcage.podman import Podman, _podman_cmd, secret_env_names
 from agentcage.quadlets import generate_quadlets
 
 
@@ -319,6 +319,39 @@ class ContainerBackend:
             argv += ["-n", str(lines)]
         return argv
 
+    # Log drivers that keep container output in a file podman owns
+    # rather than in the systemd journal. `journalctl -u <unit>` shows
+    # nothing for these.
+    _FILE_LOG_DRIVERS = frozenset({"k8s-file", "json-file"})
+
+    def container_log_driver(self, container: str) -> str:
+        """Resolved podman log driver for *container*, ``""`` if unknown.
+
+        Podman selects ``journald`` only when it can actually write there
+        — which needs a conmon built with journald support — and falls
+        back to ``k8s-file`` silently otherwise. The choice is made per
+        container at run time, so it can only be read back, not derived
+        from config.
+        """
+        try:
+            info = self._podman.container_inspect(container)
+        except Exception:
+            return ""
+        log_cfg = (info.get("HostConfig") or {}).get("LogConfig") or {}
+        return str(log_cfg.get("Type") or "").lower()
+
+    def audit_reads_journal(self, name: str) -> bool:
+        """Whether this cage's audit stream is readable from the journal.
+
+        ``False`` means the egress landed on a file-based driver and the
+        audit trail has to be read back through ``podman logs`` instead.
+        An unreadable container (destroyed, never started) reports
+        ``True``: the journal is then the only place history could still
+        live.
+        """
+        driver = self.container_log_driver(f"{name}-egress")
+        return driver not in self._FILE_LOG_DRIVERS
+
     def audit_argv(
         self,
         name: str,
@@ -326,16 +359,44 @@ class ContainerBackend:
         since: str | None = None,
         follow: bool = False,
     ) -> list[str]:
-        """``journalctl`` for the egress unit. Audit JSON lines are
-        emitted by the mitmproxy addon to stderr (= journal stream).
+        """Read the egress's audit stream.
+
+        Audit JSON lines are emitted by the mitmproxy addon to stderr;
         dnsmasq audit lines flow through the same stream (the supervisor
-        wraps both processes under tini/PID 1)."""
-        argv = ["journalctl", "--user",
-                "-u", f"{name}-egress", "-o", "cat"]
-        if since:
-            argv += ["--since", since]
+        wraps both processes under tini/PID 1). Where that stderr *lands*
+        depends on the log driver podman picked, so the source is chosen
+        to match:
+
+        * ``journald`` — ``journalctl`` on the unit. Preferred: it spans
+          container recreation, so `cage restart` doesn't truncate the
+          audit history.
+        * ``k8s-file`` / ``json-file`` — ``podman logs``, the only reader
+          for output the journal never received. Bounded to the current
+          container generation, which is all that driver retains anyway.
+
+        Reading the wrong one is silent: the proxy looks healthy and
+        `cage audit` simply prints nothing.
+        """
+        if self.audit_reads_journal(name):
+            argv = ["journalctl", "--user",
+                    "-u", f"{name}-egress", "-o", "cat"]
+            if since:
+                argv += ["--since", since]
+            if follow:
+                argv.append("-f")
+            else:
+                argv += ["-n", "10000"]  # over-read; many lines aren't audit
+            return argv
+
+        # `podman logs` has no journalctl-compatible time syntax (it takes
+        # Go durations / RFC3339, not "10 minutes ago"), so `since` is not
+        # forwarded. The CLI applies AuditFilter.since post-parse on every
+        # backend, which covers this path exactly as it covers
+        # apple-container's tail.
+        argv = [*_podman_cmd(), "logs"]
         if follow:
             argv.append("-f")
         else:
-            argv += ["-n", "10000"]  # over-read; many lines aren't audit
+            argv += ["--tail", "10000"]
+        argv.append(f"{name}-egress")
         return argv

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -2471,6 +2471,19 @@ def _apple_container_capture_path(name: str) -> Path:
     return AppleContainerBackend().logs_dir(name) / "capture.jsonl"
 
 
+# The proxy addon writes audit JSON to *stderr*. `journalctl` merges both
+# container streams into its stdout, but `podman logs` preserves the
+# separation — container stderr comes back on podman's stderr. Reading only
+# stdout there yields an empty audit trail from a reader that exited 0, so
+# both streams are merged for every audit reader. Non-JSON noise (a
+# journalctl warning, a podman error) is dropped by extract_audit_json.
+_AUDIT_POPEN_KWARGS = {
+    "stdout": subprocess.PIPE,
+    "stderr": subprocess.STDOUT,
+    "text": True,
+}
+
+
 def _build_audit_journal_cmd(
     name: str, cfg, *, since: str | None = None, follow: bool = False,
 ) -> list[str]:
@@ -2494,7 +2507,7 @@ def _build_audit_journal_cmd(
 def _audit_batch(name, cfg, filt, lines, since, as_json, no_color):
     """Read historical audit entries, filter, and output."""
     cmd = _build_audit_journal_cmd(name, cfg, since=since)
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(cmd, **_AUDIT_POPEN_KWARGS)
     entries = []
     try:
         for raw_line in proc.stdout:
@@ -2523,7 +2536,7 @@ def _audit_batch(name, cfg, filt, lines, since, as_json, no_color):
 def _audit_follow(name, cfg, filt, as_json, no_color):
     """Stream audit entries in real time."""
     cmd = _build_audit_journal_cmd(name, cfg, follow=True)
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(cmd, **_AUDIT_POPEN_KWARGS)
 
     if not as_json:
         click.echo(format_table_header())
@@ -2548,7 +2561,7 @@ def _audit_follow(name, cfg, filt, as_json, no_color):
 def _audit_summary(name, cfg, filt, since):
     """Compute and display summary statistics."""
     cmd = _build_audit_journal_cmd(name, cfg, since=since)
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+    proc = subprocess.Popen(cmd, **_AUDIT_POPEN_KWARGS)
     entries = []
     try:
         for raw_line in proc.stdout:

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -2030,7 +2030,30 @@ def _classify_line(service: str, line: str) -> str:
 
 
 def _logs_container(name, services, lines, no_follow, min_level=None, since=None):
-    """Exec into journalctl with one -u per host-level service unit."""
+    """Exec into journalctl with one -u per host-level service unit.
+
+    Only sees container output while podman is on the journald log
+    driver. Under a file driver the output never reaches the journal, so
+    warn instead of printing a near-empty stream and letting the operator
+    conclude the cage is quiet — `podman logs` is the reader there, and it
+    takes one container at a time.
+    """
+    from agentcage.backends.container import ContainerBackend
+    backend = ContainerBackend()
+    file_backed = [
+        svc for svc in services
+        if backend.container_log_driver(f"{name}-{svc}")
+        in backend._FILE_LOG_DRIVERS
+    ]
+    if file_backed:
+        click.echo(
+            f"warning: {', '.join(f'{name}-{s}' for s in file_backed)} "
+            f"log to a file driver, not the journal — output below will be "
+            f"incomplete. Read it with: "
+            f"podman logs {name}-{file_backed[0]}",
+            err=True,
+        )
+
     units = [f"{name}-{svc}" for svc in services]
     cmd = ["journalctl", "--user"]
     for u in units:
@@ -2611,21 +2634,25 @@ def cage_audit(name, decisions, directions, hosts, inspectors, severity,
             )
             sys.exit(1)
 
-        # apple-container's tail-based audit_argv has no native time index,
-        # so honor --since by post-parse filtering (parity with the
-        # journalctl --since the container/vm backends apply natively).
-        # parse_since (reused from har.py) supports the same 1h/30m/7d/ISO
-        # formats as _normalize_since does for journalctl.
-        if since:
-            from agentcage.har import parse_since
-            since_dt = parse_since(since)
-            if since_dt is None:
-                click.echo(
-                    f"error: could not parse --since '{since}' "
-                    f"(use 1h, 30m, 7d, or an ISO date)",
-                    err=True,
-                )
-                sys.exit(1)
+    # Post-parse time filtering, applied on every backend rather than
+    # only where the reader lacks a native time index.
+    #
+    # apple-container's tail has never had one. The container backend has
+    # one only while its egress is on the journald log driver: when podman
+    # falls back to a file driver, `cage audit` reads `podman logs`, whose
+    # time syntax is not journalctl's, so --since is not forwarded there.
+    # Filtering here covers both, and is a harmless no-op where journalctl
+    # already excluded the same entries.
+    if since:
+        from agentcage.har import parse_since
+        since_dt = parse_since(since)
+        if since_dt is None:
+            click.echo(
+                f"error: could not parse --since '{since}' "
+                f"(use 1h, 30m, 7d, or an ISO date)",
+                err=True,
+            )
+            sys.exit(1)
 
     filt = AuditFilter(
         decisions=list(decisions),

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -457,3 +457,61 @@ class TestExecArgv:
         assert argv == [
             "podman", "exec", "-u", "1000:1000", "foo-egress", "cat", "/etc/hosts",
         ]
+
+
+class TestAuditSourceSelection:
+    """Where `cage audit` reads from depends on the driver podman picked.
+
+    Podman only uses `journald` when it can actually write there — which
+    needs a conmon built with journald support — and falls back to
+    `k8s-file` silently otherwise. Reading the wrong source is invisible:
+    the proxy stays healthy and `cage audit` just prints nothing.
+    """
+
+    def _backend(self, driver: str | None):
+        backend = ContainerBackend()
+        inspect = MagicMock()
+        if driver is None:
+            inspect.side_effect = RuntimeError("no such container")
+        else:
+            inspect.return_value = {"HostConfig": {"LogConfig": {"Type": driver}}}
+        backend._podman.container_inspect = inspect
+        return backend
+
+    def test_journald_driver_reads_the_journal(self):
+        argv = self._backend("journald").audit_argv("mycage")
+        assert argv[0] == "journalctl"
+        assert "-u" in argv and "mycage-egress" in argv
+
+    @pytest.mark.parametrize("driver", ["k8s-file", "json-file", "K8s-File"])
+    def test_file_drivers_read_podman_logs(self, driver):
+        argv = self._backend(driver).audit_argv("mycage")
+        assert "journalctl" not in argv
+        assert "logs" in argv
+        assert argv[-3:] == ["--tail", "10000", "mycage-egress"]
+
+    def test_unreadable_container_falls_back_to_the_journal(self):
+        """A destroyed cage has no container to inspect, but the journal
+        may still hold its history — `podman logs` certainly won't."""
+        argv = self._backend(None).audit_argv("mycage")
+        assert argv[0] == "journalctl"
+
+    def test_follow_maps_onto_each_reader(self):
+        assert "-f" in self._backend("journald").audit_argv("c", follow=True)
+        assert "-f" in self._backend("k8s-file").audit_argv("c", follow=True)
+
+    def test_since_is_native_only_on_the_journal_reader(self):
+        """podman logs takes Go durations / RFC3339, not journalctl's
+        "10 minutes ago", so --since is dropped there and the CLI applies
+        AuditFilter.since post-parse instead."""
+        journal = self._backend("journald").audit_argv("c", since="10 minutes ago")
+        assert "--since" in journal
+
+        podman = self._backend("k8s-file").audit_argv("c", since="10 minutes ago")
+        assert "--since" not in podman
+        assert "10 minutes ago" not in podman
+
+    def test_audit_reads_journal_predicate(self):
+        assert self._backend("journald").audit_reads_journal("c") is True
+        assert self._backend("k8s-file").audit_reads_journal("c") is False
+        assert self._backend(None).audit_reads_journal("c") is True


### PR DESCRIPTION
All checks green. Two independent faults, both of which silently emptied the audit trail.

## Fault 1 — the reader looks in the wrong place

`cage audit` reads `journalctl --user -u <cage>-egress` (`backends/container.py:322`). Podman selects the `journald` log driver only when it can actually write there — which requires a conmon built with journald support — and **falls back to `k8s-file` silently** otherwise. Under that fallback the container's stderr goes to a file podman owns and the journal never receives it.

## Fault 2 — the reader only reads half the stream

The proxy addon writes audit JSON to **stderr**. `journalctl` merges both container streams into its own stdout, so `Popen(stdout=PIPE)` worked by accident. `podman logs` preserves the separation and returns container stderr on *its* stderr — so fixing fault 1 alone still produced an empty audit trail from a process that exited 0. Verified against a live journald-driver egress:

```
podman logs --tail 300 jacque-egress 2>/dev/null | grep -c '^{'   ->  0
podman logs --tail 300 jacque-egress 2>&1        | grep -c '^{'   -> 44
```

For a tool whose job is recording what the cage did, an audit trail that goes missing with no error is the worst available failure mode. This was never CI-only: any host whose conmon lacks journald support has had a silently empty audit trail.

## Evidence it's pre-existing, not from a code change

Failing on master since ~2026-08-11 with nothing in the repo changing — GitHub's runner image stopped preinstalling podman. Confirmed by re-running [the last green run](https://github.com/agentcage/agentcage/actions/runs/31115989505) (same commit, green 2026-08-06 with `1.4b` at 168ms): it now fails both `1.4b` and `8.8b`. Instrumented run on this branch:

```
-- podman version --                                   5.8.4
-- egress log driver --                                k8s-file
-- journalctl --user -u basic-egress: JSON lines --    0
-- journalctl --user -u basic-egress: total lines --   3
-- podman logs basic-egress: JSON lines --             10
-- podman logs basic-egress: anthropic_key hits --     2
```

Detection was working the whole time.

## The fix

The container backend reads back the driver podman actually chose and picks the matching source:

- **journald** → `journalctl` (preferred: spans container recreation, so `cage restart` doesn't truncate audit history)
- **k8s-file / json-file** → `podman logs`, the only reader for output the journal never received
- **container not inspectable** (destroyed, never started) → `journalctl`, the only place history could still live

Both streams are merged for every audit reader. Non-JSON noise (a journalctl warning, a podman error) is dropped by `extract_audit_json` anyway.

`podman logs` has no journalctl-compatible time syntax (Go durations / RFC3339, not `"10 minutes ago"`), so `--since` isn't forwarded there. The CLI now applies `AuditFilter.since` post-parse on *every* backend rather than only apple-container — covering this path, and a no-op where journalctl already filtered.

`cage logs` hits the same wall and now warns, naming the `podman logs` command to use, instead of printing a near-empty stream that reads as "the cage is quiet".

## What I tried first, and why it isn't here

Pinning `LogDriver=journald` in the quadlets — cleaner in principle, and it would fix `cage logs` multi-service too. Not viable: conmon on those runners is built *without* journald support, so the container fails to start outright:

```
conmon <error>: Include journald in compilation path to log to systemd journal
Error: conmon failed: exit status 1
Failed to start basic-egress.service
```

The silent fallback exists precisely because that conmon build is common, so the reader has to accommodate it rather than legislate against it. (That attempt is why this branch was force-pushed.)

## Verification

E2E on this branch: **65 passed**, `1.4b` back to 241ms, phase 8 green. Unit suite `1877 passed` across 3.12/3.13/3.14. New `TestAuditSourceSelection` in `tests/test_container_backend.py` covers the driver→reader mapping (journald / k8s-file / json-file / uninspectable), `--follow` on both readers, and that `--since` is native only on the journal reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)