### PR TITLE
[AGENTCAGE-182] feat(update): skip unchanged cage updates (no-op detection)

### DIFF
--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import os
 import shlex
 import shutil
@@ -298,10 +299,12 @@ class VmBackend:
     ) -> dict[str, str]:
         """Generate Lima YAML as the primary 'unit', plus quadlet files for inside the VM."""
         lima_yaml = generate_lima_config(config)
-        # Floor the cage's TimeoutStartSec for VM-mode cages. Mutates the
-        # in-memory config; the on-disk cage.yaml is untouched.
-        if config.container.timeout_start_sec < self.VM_MIN_TIMEOUT_START_SEC:
-            config.container.timeout_start_sec = self.VM_MIN_TIMEOUT_START_SEC
+        # Floor the cage's TimeoutStartSec for VM-mode cages on an effective
+        # copy. Keeping the caller's parsed config unchanged makes repeated
+        # unit generation deterministic (including update fingerprints).
+        effective_config = copy.deepcopy(config)
+        if effective_config.container.timeout_start_sec < self.VM_MIN_TIMEOUT_START_SEC:
+            effective_config.container.timeout_start_sec = self.VM_MIN_TIMEOUT_START_SEC
         # Store-aware Secret= emission (issue #262): the podman secret
         # store for VM cages lives INSIDE the guest, so it can only be
         # queried while the Lima instance is running (`secret set`/`rm`
@@ -323,7 +326,7 @@ class VmBackend:
             store_secrets = None
         # Also generate quadlets (these will be installed inside the VM)
         quadlets = generate_quadlets(
-            config,
+            effective_config,
             config_host_path,
             patches_host_dir,
             deploy_name,

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -13,6 +13,7 @@ import sys
 import time
 import tarfile
 import tempfile
+from dataclasses import asdict
 from pathlib import Path
 
 import click
@@ -40,6 +41,7 @@ from agentcage.services import (
     suggest_alt_port as _suggest_alt_port,
     check_port_availability as _check_port_availability,
     ensure_patches as _ensure_patches,
+    write_resolv_files as _write_resolv_files,
     build_container_image as _build_container_image_svc,
     build_and_deploy as _build_and_deploy,
     destroy_cage as _destroy_cage,
@@ -291,6 +293,180 @@ def _build_container_image(cfg, config_dir: Path, podman: Podman,
     """CLI wrapper that passes click.echo to the service layer."""
     _build_container_image_svc(cfg, config_dir, podman, echo=click.echo,
                                no_cache=no_cache, pull=pull)
+
+
+def _containerfile_image_refs(cfg, state_dir: Path,
+                              resolved_args: dict[str, str]) -> set[str]:
+    """Return concrete image references used by a staged Containerfile."""
+    containerfile = cfg.container.build.containerfile
+    if not containerfile:
+        return set()
+    path = Path(containerfile)
+    if not path.is_absolute():
+        path = state_dir / path
+    try:
+        content = path.read_text()
+    except OSError:
+        return set()
+
+    args = dict(resolved_args)
+    for line in content.splitlines():
+        match = re.match(r"\s*ARG\s+([A-Za-z_][A-Za-z0-9_]*)(?:=(\S+))?", line)
+        if match and match.group(1) not in args and match.group(2):
+            args[match.group(1)] = match.group(2)
+
+    refs: set[str] = set()
+    stages: set[str] = set()
+    variable = re.compile(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))")
+    for line in content.splitlines():
+        match = re.match(r"\s*FROM\s+(?:--\S+\s+)?(\S+)(?:\s+AS\s+(\S+))?", line, re.I)
+        if not match:
+            continue
+        ref = variable.sub(
+            lambda item: args.get(item.group(1) or item.group(2), item.group(0)),
+            match.group(1),
+        )
+        if ref.lower() != "scratch" and ref not in stages and "$" not in ref:
+            refs.add(ref)
+        if match.group(2):
+            stages.add(match.group(2))
+    return refs
+
+
+def _image_identity(inspect: object) -> str:
+    """Extract a stable content identity from Podman/Apple inspect output."""
+    if not isinstance(inspect, dict):
+        return "unavailable"
+    for key in ("RepoDigests", "repoDigests"):
+        values = inspect.get(key)
+        if isinstance(values, list) and values:
+            return json.dumps(sorted(str(value) for value in values))
+    for key in ("Digest", "digest", "Id", "ID", "id"):
+        value = inspect.get(key)
+        if value:
+            return str(value)
+    return "unavailable"
+
+
+def _resolved_update_config(cfg) -> tuple[dict, dict[str, str]]:
+    """Return effective values after config/default/scaffold resolution.
+
+    Existing cages own a frozen copy of their scaffold config and build
+    context, so update must not consult the live scaffold registry here. The
+    dataclass is the fully parsed/defaulted form that every backend renders.
+    Image-valued build args are resolved to content identities separately.
+    """
+    resolved_args = dict(cfg.container.build.args)
+    return asdict(cfg), resolved_args
+
+
+def _update_image_digests(cfg, name: str, podman: Podman,
+                          resolved_args: dict[str, str], *,
+                          refresh: bool) -> dict[str, str]:
+    """Refresh and inspect every image that can affect the deployment."""
+    state_dir = state.deployment_dir(name)
+    refs = {cfg.container.image}
+    # A configured image is either the direct upstream (no Containerfile) or
+    # the local build target. Never pull a build target over the image we just
+    # built; refresh its concrete FROM references instead.
+    upstream_refs = _containerfile_image_refs(cfg, state_dir, resolved_args)
+    containerfile_name = cfg.container.build.containerfile or ""
+    containerfile_path = Path(containerfile_name) if containerfile_name else None
+    if containerfile_path is not None and not containerfile_path.is_absolute():
+        containerfile_path = state_dir / containerfile_path
+    if not containerfile_name or containerfile_path is None \
+            or not containerfile_path.is_file():
+        # Missing staged files fail later in the build, but retain the legacy
+        # best-effort pull (and make mocked/programmatic update paths useful).
+        upstream_refs.add(cfg.container.image)
+    refs.update(upstream_refs)
+    if cfg.isolation in ("container", "vm"):
+        refs.add(f"agentcage-egress:{version('agentcage')}")
+
+    inspector = podman
+    can_refresh = True
+    if cfg.isolation == "vm":
+        inst = LimaInstance(name)
+        can_refresh = inst.is_running()
+        if can_refresh:
+            from agentcage.lima.podman import VmPodman
+            inspector = VmPodman(name)  # type: ignore[assignment]
+    elif cfg.isolation == "apple-container":
+        from agentcage.apple_container import cli as ac_cli
+        from agentcage.backends.apple_container import _egress_image_name
+        refs.add(_egress_image_name())
+        identities: dict[str, str] = {}
+        for ref in sorted(refs):
+            if not ref:
+                continue
+            if refresh and ref in upstream_refs \
+                    and not ref.startswith("localhost/"):
+                ac_cli.run(["image", "pull", ref], check=False, capture_output=False)
+            identities[ref] = _image_identity(ac_cli.image_inspect(ref))
+        return identities
+
+    identities = {}
+    for ref in sorted(refs):
+        if not ref:
+            continue
+        if refresh and can_refresh and ref in upstream_refs \
+                and not ref.startswith("localhost/"):
+            inspector.pull(ref)
+        try:
+            identities[ref] = _image_identity(inspector.image_inspect(ref))
+        except Exception:
+            identities[ref] = "unavailable"
+    if not can_refresh:
+        identities["__image_check__"] = "vm-stopped"
+    return identities
+
+
+def _update_fingerprint(cfg, name: str, backend, podman: Podman,
+                        config_host_path: str, network_octet: int | None, *,
+                        refresh_images: bool,
+                        units: dict[str, str] | None = None) -> tuple[dict, dict[str, str]]:
+    """Compute the current update fingerprint and generated unit output."""
+    from agentcage.fingerprint import compute_fingerprint, scaffold_context_version
+    from agentcage.quadlets import cage_network_addrs, collect_used_octets
+
+    resolved, resolved_args = _resolved_update_config(cfg)
+    if units is None:
+        patches_work = _ensure_patches(podman)
+        addrs = cage_network_addrs(
+            cfg.name,
+            used_octets=collect_used_octets(exclude=name),
+            network_octet=network_octet,
+        )
+        _write_resolv_files(
+            patches_work, cfg.name, addrs["ip_egress"], cfg.dns_servers,
+        )
+        units = backend.generate_units(
+            cfg,
+            config_host_path,
+            patches_work,
+            name,
+            used_octets=collect_used_octets(exclude=name),
+            network_octet=network_octet,
+        )
+    if not isinstance(units, dict):
+        units = {}
+
+    image_digests = _update_image_digests(
+        cfg, name, podman, resolved_args, refresh=refresh_images,
+    )
+    raw = state.load_raw_config(name)
+    context_version = scaffold_context_version(
+        state.deployment_dir(name), cfg.container.build.containerfile,
+    )
+    scaffold = (state.load_metadata(name) or {}).get("scaffold", "")
+    fingerprint = compute_fingerprint(
+        raw,
+        resolved_config=resolved,
+        units=units,
+        image_digests=image_digests,
+        scaffold_version=f"{scaffold}:{context_version}",
+    )
+    return fingerprint, units
 
 
 # Entries in a Containerfile's directory that are agentcage config, not
@@ -916,8 +1092,10 @@ def cage_create(config_pos: str | None, config_path: str | None, secrets: tuple,
               help="Force re-pull of the base image from the registry "
                    "(--pull=always). Combine with --no-cache for a fully "
                    "clean rebuild.")
+@click.option("--force", is_flag=True,
+              help="Rebuild and restart even when inputs are unchanged.")
 def cage_update(name: str | None, config_path: str | None,
-                no_cache: bool, pull: bool):
+                no_cache: bool, pull: bool, force: bool):
     """Rebuild and restart an existing cage.
 
     NAME is optional when ``-c`` is given — the cage to update is taken
@@ -1039,10 +1217,39 @@ def cage_update(name: str | None, config_path: str | None,
             click.echo(f"  agentcage secret set {name} {key}", err=True)
         sys.exit(1)
 
+    # Generate the exact units and resolve current image identities before
+    # stopping anything. This keeps a no-op update non-disruptive. Cheap
+    # bookkeeping above (config staging, metadata, derived proxy/DNS files,
+    # validation, and secret checks) still runs on every invocation.
+    from agentcage.quadlets import collect_used_octets as _collect_update
+    _existing_meta = state.load_metadata(name) or {}
+    _existing_octet = _existing_meta.get("network_octet")
+    backend = _ensure_backend_ready(cfg)
+    current_fingerprint, fingerprint_units = _update_fingerprint(
+        cfg,
+        name,
+        backend,
+        podman,
+        config_host_path,
+        _existing_octet,
+        refresh_images=True,
+    )
+    from agentcage.fingerprint import fingerprint_matches
+    stored_fingerprint = state.load_fingerprint(name)
+    running = all(
+        backend.is_running(name, service)
+        for service in backend.service_names(name)
+    )
+    if not (force or no_cache or pull) and running \
+            and fingerprint_matches(stored_fingerprint, current_fingerprint):
+        click.echo(
+            f"cage '{name}' already up to date (use --force to rebuild anyway)"
+        )
+        return
+
     # Stop existing services before port check — the running cage's own
     # ports would otherwise be detected as conflicts.
     click.echo("Stopping services...")
-    backend = get_backend(cfg)
     backend.stop(name)
 
     # Check port availability (after stop so the cage's own ports are free).
@@ -1071,16 +1278,6 @@ def cage_update(name: str | None, config_path: str | None,
         config_dir = Path(config_path).parent if config_path else state.deployment_dir(name)
         _build_container_image(cfg, config_dir, podman, no_cache=no_cache, pull=pull)
 
-    # Pull image on host (container mode) — VM mode pulls inside the VM
-    if cfg.isolation == "container":
-        click.echo(f"Pulling {cfg.container.image}...")
-        if not podman.pull(cfg.container.image):
-            click.echo(
-                f"warning: pull failed for {cfg.container.image} "
-                f"(local image or no network — continuing with cached image)",
-                err=True,
-            )
-
     # Preserve the cage's existing network octet across updates. The podman
     # network was created at cage-create time with the originally-assigned
     # subnet; re-deriving from the hash here (which can land on a different
@@ -1090,13 +1287,7 @@ def cage_update(name: str | None, config_path: str | None,
     #   "requested static ip 10.89.X.10 not in any subnet on network <name>-net"
     # See: https://github.com/agentcage/agentcage/issues/... (cage update
     # regenerated quadlets with a fresh octet on single-cage systems).
-    from agentcage.quadlets import collect_used_octets as _collect_update
-    _existing_meta = state.load_metadata(name) or {}
-    _existing_octet = _existing_meta.get("network_octet")
-    # Bring up the backend substrate (apple-container's apiserver dies on
-    # reboot) and gate on prerequisites before the rebuild/restart.
-    _ensure_backend_ready(cfg)
-    _build_and_deploy(
+    deployed_units = _build_and_deploy(
         cfg,
         config_host_path,
         name,
@@ -1106,6 +1297,23 @@ def cage_update(name: str | None, config_path: str | None,
         no_cache=no_cache,
         pull=pull,
     )
+
+    # Only record a fingerprint after the complete build/install/start path
+    # succeeds. Re-inspect image identities because a Containerfile build may
+    # have changed the target image after the preflight snapshot.
+    if not isinstance(deployed_units, dict):
+        deployed_units = fingerprint_units
+    successful_fingerprint, _ = _update_fingerprint(
+        cfg,
+        name,
+        backend,
+        podman,
+        config_host_path,
+        _existing_octet,
+        refresh_images=False,
+        units=deployed_units,
+    )
+    state.save_fingerprint(name, successful_fingerprint)
     click.echo(f"Updated cage '{name}'")
 
     if cfg.help:

--- a/src/agentcage/fingerprint.py
+++ b/src/agentcage/fingerprint.py
@@ -1,0 +1,123 @@
+"""Stable deployment fingerprints used by ``cage update`` no-op detection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+FINGERPRINT_VERSION = 1
+
+
+def stable_json(value: Any) -> str:
+    """Serialize JSON-compatible *value* deterministically."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _sha256(value: str | bytes) -> str:
+    if isinstance(value, str):
+        value = value.encode()
+    return hashlib.sha256(value).hexdigest()
+
+
+def normalize_cage_yaml(cage_yaml: str | Mapping[str, Any]) -> str:
+    """Return a canonical JSON form of a cage configuration.
+
+    Parsing YAML before serializing means comments, whitespace, and mapping-key
+    order do not affect the result. Sequence order remains significant because
+    it can affect generated container arguments and policy evaluation.
+    """
+    if isinstance(cage_yaml, str):
+        value = yaml.safe_load(cage_yaml) or {}
+    else:
+        value = dict(cage_yaml)
+    return stable_json(value)
+
+
+def compute_fingerprint(
+    cage_yaml: str | Mapping[str, Any],
+    *,
+    resolved_config: Mapping[str, Any],
+    units: Mapping[str, str],
+    image_digests: Mapping[str, str],
+    scaffold_version: str,
+) -> dict[str, Any]:
+    """Compute a versioned fingerprint from resolved deployment inputs.
+
+    The component hashes make ``fingerprint.json`` useful for diagnostics while
+    the top-level hash provides a single stable comparison value.
+    """
+    normalized_yaml = normalize_cage_yaml(cage_yaml)
+    components = {
+        "cage_yaml": _sha256(normalized_yaml),
+        "resolved_config": _sha256(stable_json(dict(resolved_config))),
+        "units": _sha256(stable_json(dict(units))),
+        "image_digests": _sha256(stable_json(dict(image_digests))),
+        "scaffold_version": _sha256(scaffold_version),
+    }
+    payload = {"version": FINGERPRINT_VERSION, "components": components}
+    return {
+        **payload,
+        "fingerprint": _sha256(stable_json(payload)),
+    }
+
+
+def fingerprint_matches(stored: object, current: Mapping[str, Any]) -> bool:
+    """Return whether two supported, well-formed fingerprints match."""
+    return (
+        isinstance(stored, dict)
+        and stored.get("version") == FINGERPRINT_VERSION
+        and stored.get("fingerprint") == current.get("fingerprint")
+    )
+
+
+_STATE_ARTIFACTS = frozenset({
+    "cage.yaml",
+    "metadata.json",
+    "fingerprint.json",
+    "proxy-config.yaml",
+    "dns-allowlist.conf",
+    "pending_secrets.json",
+    "cage-env",
+    "creds",
+})
+
+
+def scaffold_context_version(state_dir: Path, containerfile: str) -> str:
+    """Hash the frozen build context staged for an existing scaffold cage.
+
+    VM updates copy this context into the guest before rebuilding, while the
+    other backends build it directly. Derived deployment state is excluded so
+    writing a fingerprint cannot invalidate itself.
+    """
+    if not containerfile:
+        return ""
+
+    root = state_dir.resolve()
+    containerfile_path = Path(containerfile)
+    if containerfile_path.is_absolute():
+        root = containerfile_path.resolve().parent
+    if not root.is_dir():
+        return "missing"
+
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root)
+        if relative.parts and relative.parts[0] in _STATE_ARTIFACTS:
+            continue
+        if not path.is_file():
+            continue
+        digest.update(relative.as_posix().encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()

--- a/src/agentcage/lima/podman.py
+++ b/src/agentcage/lima/podman.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from agentcage.lima.instance import LimaInstance
 from agentcage.podman import _parse_secret_list, filter_secrets_by_prefix
 
@@ -19,6 +21,16 @@ class VmPodman:
 
     def __init__(self, cage_name: str) -> None:
         self._inst = LimaInstance(cage_name)
+
+    def pull(self, image: str) -> bool:
+        """Pull an image in the guest, returning whether it succeeded."""
+        result = self._inst.exec(["podman", "pull", image], check=False)
+        return result.returncode == 0
+
+    def image_inspect(self, image: str) -> dict:
+        """Inspect an image in the guest using Podman's JSON format."""
+        result = self._inst.exec(["podman", "image", "inspect", image])
+        return json.loads(result.stdout)[0]
 
     def secret_list(self, prefix: str = "") -> list[dict]:
         r = self._inst.exec(

--- a/src/agentcage/services.py
+++ b/src/agentcage/services.py
@@ -341,6 +341,7 @@ def build_and_deploy(
     state.save_metadata(deploy_name, meta)
 
     backend.start(cfg.name, quiet=quiet)
+    return units
 
 
 def current_placeholders(name: str) -> list[tuple[str, str]]:

--- a/src/agentcage/state.py
+++ b/src/agentcage/state.py
@@ -145,6 +145,28 @@ def load_metadata(name: str) -> dict:
         return json.load(f)
 
 
+def save_fingerprint(name: str, fingerprint: dict) -> None:
+    """Atomically persist the last successful update fingerprint."""
+    d = _deploy_dir(name)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "fingerprint.json"
+    temporary = d / "fingerprint.json.tmp"
+    temporary.write_text(json.dumps(fingerprint, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def load_fingerprint(name: str) -> dict | None:
+    """Load a deployment fingerprint, treating missing/corrupt state as stale."""
+    path = _deploy_dir(name) / "fingerprint.json"
+    if not path.is_file():
+        return None
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
 def save_proxy_config(name: str) -> str:
     """Write a proxy-specific config subset and return its path.
 

--- a/tests/test_cage_cli.py
+++ b/tests/test_cage_cli.py
@@ -253,6 +253,74 @@ class TestCageUpdate:
         assert save_calls, "save_deployment was not called"
         assert save_calls[0].args[0] == "inferred-from-config"
 
+    @patch("agentcage.cli._update_fingerprint")
+    @patch("agentcage.cli._build_and_deploy", return_value={})
+    @patch("agentcage.cli._check_port_availability", return_value=[])
+    @patch("agentcage.cli._check_secrets", return_value=[])
+    @patch("agentcage.cli.get_backend")
+    @patch("agentcage.cli.Podman")
+    @patch("agentcage.cli.state")
+    def test_unchanged_second_update_skips_and_force_rebuilds(
+        self, mock_state, MockPodman, mock_backend, _check_secrets,
+        _check_ports, build_deploy, update_fingerprint, tmp_path,
+    ):
+        """A successful fingerprint is reused; --force bypasses the match."""
+        from agentcage.config import Config, ContainerConfig, BuildConfig
+
+        fingerprint = {
+            "version": 1,
+            "fingerprint": "same-inputs",
+            "components": {},
+        }
+        update_fingerprint.return_value = (fingerprint, {})
+        mock_state.deployment_exists.return_value = True
+        mock_state.deployment_dir.return_value = tmp_path
+        mock_state.save_proxy_config.return_value = "/fake/proxy.yaml"
+        mock_state.load_metadata.return_value = {
+            "agentcage_version": "0.32.0",
+            "network_octet": 123,
+        }
+        mock_state.load_raw_config.return_value = {
+            "name": "test",
+            "container": {"image": "test:latest"},
+        }
+        mock_state.load_deployment_config.return_value = Config(
+            name="test",
+            isolation="container",
+            container=ContainerConfig(
+                image="test:latest",
+                build=BuildConfig(containerfile=None, args={}),
+            ),
+        )
+        backend = mock_backend.return_value
+        backend.service_names.return_value = ["cage", "egress"]
+        backend.is_running.return_value = True
+
+        # No pre-existing fingerprint: backwards-compatible full update.
+        mock_state.load_fingerprint.return_value = None
+        first = _runner().invoke(main, ["cage", "update", "test"])
+        assert first.exit_code == 0, first.output
+        assert build_deploy.call_count == 1
+        mock_state.save_fingerprint.assert_called_with("test", fingerprint)
+
+        # The next invocation sees the fingerprint written above and returns
+        # before stop/build/restart.
+        mock_state.load_fingerprint.return_value = fingerprint
+        backend.stop.reset_mock()
+        second = _runner().invoke(main, ["cage", "update", "test"])
+        assert second.exit_code == 0, second.output
+        assert "cage 'test' already up to date (use --force to rebuild anyway)" \
+            in second.output
+        assert build_deploy.call_count == 1
+        backend.stop.assert_not_called()
+
+        forced = _runner().invoke(
+            main, ["cage", "update", "test", "--force"],
+        )
+        assert forced.exit_code == 0, forced.output
+        assert build_deploy.call_count == 2
+        assert backend.stop.called
+
     @patch("agentcage.cli._build_and_deploy")
     @patch("agentcage.cli._check_port_availability", return_value=[])
     @patch("agentcage.cli.get_backend")

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,68 @@
+"""Tests for stable deployment fingerprint computation."""
+
+from __future__ import annotations
+
+from agentcage.fingerprint import compute_fingerprint
+
+
+BASE_YAML = """\
+# operator comment
+name: demo
+container:
+  image: example/app:latest
+  env:
+    B: two
+    A: one
+"""
+
+
+def _fingerprint(
+    cage_yaml: str = BASE_YAML,
+    *,
+    image_digest: str = "sha256:image-one",
+    quadlet: str = "[Container]\nImage=example/app:latest\n",
+    scaffold_version: str = "scaffold-v1",
+):
+    return compute_fingerprint(
+        cage_yaml,
+        resolved_config={
+            "name": "demo",
+            "container": {"image": "example/app:latest"},
+        },
+        units={"demo-cage.container": quadlet},
+        image_digests={"example/app:latest": image_digest},
+        scaffold_version=scaffold_version,
+    )
+
+
+def test_identical_inputs_have_same_fingerprint():
+    assert _fingerprint() == _fingerprint()
+
+
+def test_yaml_comments_whitespace_and_mapping_order_are_ignored():
+    reordered = """\
+container: # an inline comment is irrelevant
+  env: {A: one, B: two}
+  image: example/app:latest
+
+name: demo
+"""
+    assert _fingerprint()["fingerprint"] == _fingerprint(reordered)["fingerprint"]
+
+
+def test_changed_image_digest_changes_fingerprint():
+    assert _fingerprint()["fingerprint"] != _fingerprint(
+        image_digest="sha256:image-two"
+    )["fingerprint"]
+
+
+def test_changed_quadlet_changes_fingerprint():
+    assert _fingerprint()["fingerprint"] != _fingerprint(
+        quadlet="[Container]\nImage=example/app:v2\n"
+    )["fingerprint"]
+
+
+def test_changed_scaffold_version_changes_fingerprint():
+    assert _fingerprint()["fingerprint"] != _fingerprint(
+        scaffold_version="scaffold-v2"
+    )["fingerprint"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -98,6 +98,21 @@ class TestSaveAndLoadDeployment:
             state.load_deployment_config("nonexistent")
 
 
+class TestFingerprintState:
+    def test_round_trip_and_corrupt_file_falls_back_to_stale(
+        self, _patch_state_dirs,
+    ):
+        state = _patch_state_dirs
+        fingerprint = {"version": 1, "fingerprint": "abc"}
+
+        state.save_fingerprint("demo", fingerprint)
+        assert state.load_fingerprint("demo") == fingerprint
+
+        path = state.deployment_dir("demo") / "fingerprint.json"
+        path.write_text("not json")
+        assert state.load_fingerprint("demo") is None
+
+
 class TestSaveProxyConfig:
     """save_proxy_config should only keep _PROXY_KEYS."""
 


### PR DESCRIPTION
## What

Implements #182 — `cage update` now skips the rebuild + restart when nothing changed, with a `--force` escape hatch to rebuild anyway.

Today `cage update` runs a full rebuild + restart on every invocation even when neither `cage.yaml` nor the upstream image changed (~27s container / ~30s VM warm for a no-op). This adds stable deployment fingerprinting so a second update with unchanged inputs is a no-op.

## How

- **New `src/agentcage/fingerprint.py`** — computes a stable fingerprint over the resolved cage config: normalized `cage.yaml` (reordering/comments/whitespace-insensitive), scaffold-resolved build args, generated quadlets/units, resolved image digests, and the scaffold version. Serialized canonically and hashed with sha256.
- **`cage update` (cli.py)** — computes the fingerprint at the start of the run; if it matches the stored one and `--force` is not set, skips the rebuild/restart and prints `cage '<name>' already up to date (use --force to rebuild anyway)`. Only the rebuild/restart is skipped; bookkeeping that legitimately needs to run still runs.
- **`--force` flag** — bypasses the skip.
- **`state.py`** — atomic persistence of `fingerprint.json` in the existing per-cage deployment dir. No stored fingerprint (pre-existing cages / first run) → normal update + write fingerprint; never skips on first run (backwards compatible).
- **Image-digest inspection** wired through `backends/vm.py` and `lima/podman.py` so a `:latest` advance upstream counts as a change on both container and VM backends.

## Coverage

- Normalized `cage.yaml`: reordering, comments, whitespace → same fingerprint.
- Changed image digest / generated quadlet / scaffold version → different fingerprint.
- Second `cage update` with unchanged inputs is a no-op; `--force` rebuilds anyway.
- VM (Lima) rebuild path covered.
- Full suite green.

Closes #182.