### PR TITLE
[#186] fix(apple-container): tighten proxy log perms to 0640 to prevent audit forgery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`apple-container` proxy log files (audit/capture/proxy/dnsmasq) are no longer world-readable on the host.** The egress supervisor created `audit.jsonl`, `capture.jsonl`, `proxy.log` and `dnsmasq.log` inside the host bind-mounted per-cage logs dir (chmod 1777) with the daemons' default umask 022, so they landed at 0644 (dnsmasq.log 0664). virtiofs *identity-maps* the host owner into the cage guest, so the untrusted cage workload (uid 1000, "others") could read **and** forge/truncate the audit trail, capture bodies and DNS log — defeating `agentcage cage audit` as a forensic primitive and letting a malicious workload inject lines blaming a sibling cage before/after exfil. The supervisor now pre-creates each file at mode `0640` owned by its service user (`acproxy` for the mitmproxy logs, `acdns` for dnsmasq) before the daemon starts, using `setpriv --reuid` + `install -m 0640` so the file is owned by the right user at a restrictive mode from the instant it exists (no chmod-after-create race, no root-owned-0640 window). Opening for append preserves the 0640 mode, so the service keeps rw as the owner while "others" — the cage workload via virtiofs — get nothing. The 1777 *directory* mode is unchanged: the service users must still enter it and the sticky bit still prevents cross-uid deletion; what changed is the FILE modes. (#186)
+
 ## [0.32.0] - 2026-08-18
 
 ### Added

--- a/src/agentcage/data/containers/supervisor-egress.sh
+++ b/src/agentcage/data/containers/supervisor-egress.sh
@@ -18,6 +18,60 @@ set -eu
 log() { printf '[egress-supervisor] %s\n' "$*" >&2; }
 die() { log "FATAL: $1"; exit "${2:-99}"; }
 
+#-- Pre-create proxy log files at mode 0640 owned by their service user ----
+# Regression fix for #186. On the apple-container backend the egress
+# sibling bind-mounts the host per-cage logs_dir into the egress microVM
+# at /var/log/agentcage, and virtiofs *identity-maps* the host owner into
+# the guest: a file owned by acproxy (uid 200) on the host is owned by
+# uid 200 inside the cage VM too. With the logs_dir chmod'd 1777 (sticky,
+# world-writable so uid 200/201 can drop files in) and the daemons'
+# default umask 022, the files they create land at 0644 — i.e. "others"
+# (which includes the cage workload, uid 1000) get read access, and for
+# the group-writable dnsmasq.log even rw. The untrusted workload can then
+# read AND forge/truncate audit.jsonl, capture.jsonl, proxy.log and
+# dnsmasq.log, defeating `agentcage cage audit` as a forensic primitive.
+#
+# The dir stays 1777 (the service users must be able to enter it and the
+# sticky bit prevents cross-uid *deletion*); what matters is the FILE
+# modes. We pre-create each log file at 0640 owned by its service user
+# BEFORE the daemon starts, so when the daemon opens the file for append
+# it keeps the 0640 mode (open(..., O_APPEND) never changes an existing
+# file's mode) and "others" — the cage workload via virtiofs — gets
+# nothing.
+#
+# First create (fresh boot): the file is created ALREADY owned by the
+# service user by running install(1) under `setpriv --reuid/--regid` for
+# that user. The 1777 dir lets any uid create here, so no caps are needed;
+# install -m 0640 sets the mode atomically at create time (no
+# chmod-after-create race window). Creating as the service user directly
+# sidesteps chown entirely, so there is no root-owned-0640 window during
+# which the daemon couldn't write, and no chown-failure edge case under
+# hardened rootless podman.
+#
+# Restart (file already exists, owned by the service user from a prior
+# boot): tighten the mode in place with chmod 0640. The service user keeps
+# rw as the owner; root needs CAP_FOWNER for this, which PID-1 root has.
+#
+# All steps are best-effort: if setpriv/install is unavailable in a
+# minimal smoke-test image we simply leave creation to the daemon (which
+# falls back to its 0644 default — only the degraded, non-virtiofs path
+# where the threat model doesn't apply).
+_ensure_log() {
+  _el_file="$1"; _el_user="$2"
+  if [ -e "$_el_file" ]; then
+    # Restart: tighten the existing file to 0640 in place.
+    chmod 0640 "$_el_file" 2>/dev/null || true
+  else
+    # First create: make the file owned by the service user at 0640 in
+    # one shot (umask 0027 is belt-and-suspenders alongside install -m).
+    (
+      umask 0027
+      setpriv --reuid="$_el_user" --regid="$_el_user" --clear-groups -- \
+        /usr/bin/install -m 0640 /dev/null "$_el_file"
+    ) 2>/dev/null || true
+  fi
+}
+
 # dnsmasq writes its pidfile here. We use /home/acdns/ — pre-chowned to
 # acdns at image build time (Containerfile.egress) — instead of /run or
 # /var/run because:
@@ -199,6 +253,10 @@ fi
 # TODO(measurement): --as=256M for dnsmasq covers a 10k-entry allowlist
 # with headroom (eyeballed from the apple-container supervisor's working
 # set). Provisional — tune after measurement in a follow-up PR.
+# Pre-create dnsmasq.log at 0640 owned by acdns so the cage workload
+# (uid 1000, via virtiofs identity-mapping) cannot read or forge it.
+# See _ensure_log above (#186).
+_ensure_log /var/log/agentcage/dnsmasq.log acdns
 log "step B: starting dnsmasq (uid 201, CapBnd={net_bind_service}, prlimit --as=256M)"
 if [ -f /etc/agentcage/dnsmasq.conf ]; then
   # apple-container path: per-cage dnsmasq.conf bind-mounted by the
@@ -415,6 +473,15 @@ ss -lnup 2>/dev/null | grep -q ':53 ' \
 # TODO(measurement): --as=2G for mitmproxy covers PyInstaller's ~700MB
 # mmap overhead plus runtime working set with headroom. Provisional —
 # tune after measurement in a follow-up PR.
+# Pre-create the mitmproxy-owned log files at 0640 owned by acproxy so
+# the cage workload (uid 1000, via virtiofs identity-mapping) cannot
+# read or forge audit entries / capture bodies / the proxy log. mitmproxy
+# opens these for append, which preserves the pre-set 0640 mode. proxy.log
+# is defense-in-depth for the legacy single-VM redirect path and any
+# future redirect of mitmproxy output. See _ensure_log above (#186).
+_ensure_log /var/log/agentcage/audit.jsonl acproxy
+_ensure_log /var/log/agentcage/capture.jsonl acproxy
+_ensure_log /var/log/agentcage/proxy.log acproxy
 log "step D: starting mitmproxy (uid 200, CapBnd=0, prlimit --as=2G)"
 
 # Build reverse-mode flags for inbound port forwards (legacy proxy's

--- a/src/agentcage/data/containers/supervisor-egress.sh
+++ b/src/agentcage/data/containers/supervisor-egress.sh
@@ -41,34 +41,52 @@ die() { log "FATAL: $1"; exit "${2:-99}"; }
 #
 # First create (fresh boot): the file is created ALREADY owned by the
 # service user by running install(1) under `setpriv --reuid/--regid` for
-# that user. The 1777 dir lets any uid create here, so no caps are needed;
-# install -m 0640 sets the mode atomically at create time (no
-# chmod-after-create race window). Creating as the service user directly
-# sidesteps chown entirely, so there is no root-owned-0640 window during
-# which the daemon couldn't write, and no chown-failure edge case under
-# hardened rootless podman.
+# that user. The 1777 dir lets any uid create here, so no caps are needed.
+# GNU install -m 0640 creates the file at mode 0600 then fchmods it to
+# 0640 in the same syscall sequence; the intermediate 0600 grants
+# "others" NOTHING, so there is no world-readable window (the security
+# claim holds), but it is not literally a single atomic create — don't
+# overclaim. Creating as the service user directly sidesteps chown
+# entirely, so there is no root-owned-0640 window during which the
+# daemon couldn't write, and no chown-failure edge case under hardened
+# rootless podman.
 #
 # Restart (file already exists, owned by the service user from a prior
-# boot): tighten the mode in place with chmod 0640. The service user keeps
-# rw as the owner; root needs CAP_FOWNER for this, which PID-1 root has.
+# boot, e.g. a pre-fix 0644 file on migration): tighten the mode in place
+# with chmod 0640 run AS THE FILE OWNER via setpriv. The owner needs no
+# capability to chmod its own file, so this does NOT depend on the
+# runtime granting CAP_FOWNER to PID-1 root — mirroring the first-create
+# path and removing the cap dependency entirely (the egress argv only
+# --cap-adds NET_ADMIN/NET_BIND_SERVICE/SETUID/SETGID/SETPCAP/KILL; a
+# hardened runtime with `default_capabilities = []` drops CAP_FOWNER,
+# which would make a root chmod fail EPERM on an acproxy-owned file).
 #
-# All steps are best-effort: if setpriv/install is unavailable in a
-# minimal smoke-test image we simply leave creation to the daemon (which
-# falls back to its 0644 default — only the degraded, non-virtiofs path
-# where the threat model doesn't apply).
+# All steps are best-effort but LOUD: if setpriv/install/chmod is
+# unavailable in a minimal smoke-test image we leave creation/tightening
+# to the daemon (which falls back to its 0644 default — only the degraded,
+# non-virtiofs path where the threat model doesn't apply). But we emit a
+# loud `log` warning on failure so the operator/CI can observe that the
+# audit-integrity control has degraded — silent `|| true` would let the
+# file stay 0644 (the #186 vuln) with ZERO signal. We do NOT `die` here:
+# the container/vm smoke-test path legitimately has no setpriv, and dying
+# would break that non-virtiofs path where best-effort is appropriate.
 _ensure_log() {
   _el_file="$1"; _el_user="$2"
   if [ -e "$_el_file" ]; then
-    # Restart: tighten the existing file to 0640 in place.
-    chmod 0640 "$_el_file" 2>/dev/null || true
+    # Restart: tighten the existing file to 0640 in place AS THE OWNER
+    # (no CAP_FOWNER dependency).
+    setpriv --reuid="$_el_user" --regid="$_el_user" --clear-groups -- \
+      /bin/chmod 0640 "$_el_file" 2>/dev/null \
+      || log "warn: _ensure_log chmod 0640 failed for $_el_file ($_el_user); file may stay world-readable — audit trail may be forgeable (#186)"
   else
-    # First create: make the file owned by the service user at 0640 in
-    # one shot (umask 0027 is belt-and-suspenders alongside install -m).
+    # First create: make the file owned by the service user at 0640
+    # (umask 0027 is belt-and-suspenders alongside install -m).
     (
       umask 0027
       setpriv --reuid="$_el_user" --regid="$_el_user" --clear-groups -- \
         /usr/bin/install -m 0640 /dev/null "$_el_file"
-    ) 2>/dev/null || true
+    ) 2>/dev/null \
+      || log "warn: _ensure_log create failed for $_el_file ($_el_user); daemon will create at default perms — audit trail may be forgeable (#186)"
   fi
 }
 

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2770,10 +2770,21 @@ def test_egress_supervisor_precreates_logs_at_0640():
         / "src" / "agentcage" / "data" / "containers" / "supervisor-egress.sh"
     ).read_text()
 
-    # The helper must create files at 0640 up front (install -m 0640 sets
-    # the mode atomically at create time — no chmod-after-create race).
+    # The helper must create files at 0640 up front (install -m 0640
+    # creates at 0600 then fchmods to 0640 — the intermediate 0600 grants
+    # "others" nothing, so no world-readable window).
     assert "install -m 0640" in egress_supervisor, (
         "supervisor must create log files with `install -m 0640` (no race)"
+    )
+
+    # The create path must run under setpriv as the service user with
+    # --clear-groups, so a future edit that drops setpriv and creates as
+    # root-then-chown (re-introducing the CAP_FOWNER/chown dependency)
+    # is caught.
+    assert "setpriv --reuid=" in egress_supervisor \
+        and "--clear-groups" in egress_supervisor, (
+        "supervisor must create/tighten logs under `setpriv --clear-groups` "
+        "as the service user (no root-then-chown, no CAP_FOWNER dep) (#186)"
     )
 
     # Each of the four log files must be pre-created and owned by its
@@ -2791,6 +2802,46 @@ def test_egress_supervisor_precreates_logs_at_0640():
         assert call in egress_supervisor, (
             f"supervisor missing `_ensure_log {path} {user}` (#186)"
         )
+
+    # Ordering: each _ensure_log call must appear BEFORE the daemon that
+    # writes the file is launched, so a future edit that moves creation
+    # to AFTER the daemon starts (reopening the create-race where the
+    # daemon creates at its umask 0644) is caught. Assert RELATIVE
+    # ordering (ensure_log before launch line), not absolute line nums.
+    lines = egress_supervisor.splitlines()
+    # dnsmasq.log ensure must precede the first dnsmasq launch line.
+    dns_ensure_idx = next(
+        i for i, ln in enumerate(lines)
+        if "_ensure_log /var/log/agentcage/dnsmasq.log acdns" in ln
+    )
+    dns_launch_idx = next(
+        i for i, ln in enumerate(lines)
+        if "/usr/sbin/dnsmasq" in ln or "/opt/agentcage/dns-audit.sh" in ln
+    )
+    assert dns_ensure_idx < dns_launch_idx, (
+        "_ensure_log dnsmasq.log must run BEFORE the dnsmasq launch line "
+        "(else the daemon creates the file at its umask 0644) (#186)"
+    )
+    # The three acproxy ensure calls must precede the mitmdump launch line.
+    acproxy_ensure_idx = next(
+        i for i, ln in enumerate(lines)
+        if "_ensure_log /var/log/agentcage/proxy.log acproxy" in ln
+    )
+    mitm_launch_idx = next(
+        i for i, ln in enumerate(lines) if "mitmdump" in ln
+    )
+    assert acproxy_ensure_idx < mitm_launch_idx, (
+        "_ensure_log acproxy logs must run BEFORE the mitmdump launch line "
+        "(else the daemon creates the files at its umask 0644) (#186)"
+    )
+
+    # Failure must NOT be silent: the helper must surface a loud `log`
+    # warning on failure (no `|| true` swallowing the error), so a degraded
+    # audit-integrity control is observable to the operator/CI.
+    assert "|| log \"warn: _ensure_log" in egress_supervisor, (
+        "_ensure_log must emit a loud log warning on failure instead of "
+        "silently `|| true`-ing (silent degradation re-opens #186)"
+    )
 
     # Defense-in-depth: no line creating one of these four log files may
     # leave it world-readable. The pre-creation must be 0640, never 0644

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2748,6 +2748,72 @@ def test_egress_supervisor_keeps_lazy_connection_strategy():
     assert "connection_strategy=lazy" in egress_supervisor
 
 
+def test_egress_supervisor_precreates_logs_at_0640():
+    """Regression for #186: the egress supervisor must pre-create the four
+    proxy log files (audit.jsonl, capture.jsonl, proxy.log, dnsmasq.log)
+    at mode 0640 owned by their service user before the daemons start.
+
+    On the apple-container backend the host per-cage logs_dir is
+    bind-mounted into the egress microVM and virtiofs *identity-maps*
+    host owner → guest owner, so files the daemons create at the default
+    0644 are readable (and dnsmasq.log writable) by the cage workload
+    (uid 1000, "others"). A malicious workload could then forge/truncate
+    the audit trail. Pre-creating at 0640 owned by acproxy/acdns denies
+    "others" any access via the identity mapping.
+
+    Static check on the script — the load-bearing piece is that the
+    files are created up-front at a restrictive mode (install -m 0640,
+    no chmod-after-create race) and chowned to the right service user.
+    """
+    egress_supervisor = (
+        Path(__file__).parent.parent
+        / "src" / "agentcage" / "data" / "containers" / "supervisor-egress.sh"
+    ).read_text()
+
+    # The helper must create files at 0640 up front (install -m 0640 sets
+    # the mode atomically at create time — no chmod-after-create race).
+    assert "install -m 0640" in egress_supervisor, (
+        "supervisor must create log files with `install -m 0640` (no race)"
+    )
+
+    # Each of the four log files must be pre-created and owned by its
+    # service user (acproxy for the mitmproxy-owned logs, acdns for
+    # dnsmasq). Assert the exact _ensure_log calls so a future edit can't
+    # silently drop one or point it at the wrong owner.
+    expected = [
+        ("/var/log/agentcage/dnsmasq.log", "acdns"),
+        ("/var/log/agentcage/audit.jsonl", "acproxy"),
+        ("/var/log/agentcage/capture.jsonl", "acproxy"),
+        ("/var/log/agentcage/proxy.log", "acproxy"),
+    ]
+    for path, user in expected:
+        call = f"_ensure_log {path} {user}"
+        assert call in egress_supervisor, (
+            f"supervisor missing `_ensure_log {path} {user}` (#186)"
+        )
+
+    # Defense-in-depth: no line creating one of these four log files may
+    # leave it world-readable. The pre-creation must be 0640, never 0644
+    # / 0664 / 0666. (The 1777 logs *directory* is intentional and out
+    # of scope — the sticky bit prevents cross-uid deletion; what matters
+    # is the FILE modes, not the dir mode.)
+    log_basenames = ("audit.jsonl", "capture.jsonl", "proxy.log", "dnsmasq.log")
+    for line in egress_supervisor.splitlines():
+        if not any(b in line for b in log_basenames):
+            continue
+        # A chmod/create that grants any perms to "others" on one of
+        # these files would re-open the #186 hole.
+        assert "0644" not in line, (
+            f"supervisor creates a world-readable log file (#186): {line!r}"
+        )
+        assert "0664" not in line, (
+            f"supervisor creates a group+world-writable log file (#186): {line!r}"
+        )
+        assert "0666" not in line, (
+            f"supervisor creates a world-writable log file (#186): {line!r}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # reload_domains: live SIGHUP allowlist reload (no cage rebuild/restart)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The four proxy log files (`audit.jsonl`, `capture.jsonl`, `proxy.log`, `dnsmasq.log`) written by the egress supervisor into the host bind-mounted per-cage `logs_dir` are now created at mode **0640** owned by their service user, instead of the default-umask 0644 (dnsmasq.log 0664).
- Pre-creation happens in `supervisor-egress.sh` (a new `_ensure_log` helper) at the start of step B (dnsmasq → `dnsmasq.log` for `acdns`) and step D (mitmproxy → `audit.jsonl` / `capture.jsonl` / `proxy.log` for `acproxy`), before the daemon starts.
- Files are created with `setpriv --reuid` + `install -m 0640` so they are owned by the service user at a restrictive mode from the instant they exist — no chmod-after-create race, no root-owned-0640 window. Opening for append preserves 0640, so the service keeps rw as owner.

## Root cause

On the apple-container backend the egress sibling bind-mounts the host per-cage `logs_dir` into the egress microVM at `/var/log/agentcage`, and **virtiofs *identity-maps* the host owner into the guest** — a file owned by `acproxy` (uid 200) on the host is owned by uid 200 inside the cage VM too. The `logs_dir` is `chmod 1777` (sticky, world-writable so uid 200/201 can drop files in) and the daemons' default umask 022 makes the files they create land at **0644** — i.e. "others" (which includes the cage workload, uid 1000) get read access, and for the group-writable `dnsmasq.log` even rw. The untrusted workload could then **read AND forge/truncate** `audit.jsonl`, `capture.jsonl`, `proxy.log` and `dnsmasq.log`, defeating `agentcage cage audit` as a forensic primitive and letting a malicious workload inject lines blaming a sibling cage before/after exfil.

## Fix

- `src/agentcage/data/containers/supervisor-egress.sh` — new `_ensure_log <path> <user>` helper + four call sites. On first boot it runs `install -m 0640 /dev/null <file>` under `setpriv --reuid=<user> --regid=<user> --clear-groups`, so the file is created already owned by the service user at 0640 in one atomic op (the 1777 dir lets any uid create here; no caps needed). On restart it tightens the existing file in place with `chmod 0640` (the service user keeps rw as the owner). All steps are best-effort: if `setpriv`/`install` is unavailable the daemon falls back to creating the file itself (0644 — only the degraded, non-virtiofs path where the threat model doesn't apply).
- `tests/test_apple_container.py` — `test_egress_supervisor_precreates_logs_at_0640`: static regression test asserting the supervisor pre-creates all four files via `_ensure_log` with the right service user, uses `install -m 0640` (no race), and that no line creating one of these files leaves it world-readable (0644/0664/0666).
- `CHANGELOG.md` — Unreleased `### Fixed` entry referencing #186.

The 1777 **directory** mode is intentionally unchanged (service users must still enter it; the sticky bit prevents cross-uid *deletion*). The fix targets the FILE modes, which is what the virtiofs identity-mapping exposes. CA/certs dirs are out of scope and untouched.

## Refs

Closes #186