### PR TITLE
[#311] fix(apple-container): hand np mount seeds to the cage user

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -98,6 +98,12 @@ semantics:
 - **Apple container, file source:** the file is copied to its exact target in
   the fresh cage filesystem.
 
+On Apple container the seeded copy is handed to the cage workload user (uid
+1000) so the mount is writable regardless of who owns the host source; file
+modes are otherwise preserved from the host. The copy runs during cage
+startup, so a `cage exec` issued in the first seconds after `cage start` can
+observe the target still empty.
+
 Use an ordinary `ro` bind instead if the cage does not need to edit the data.
 Use `container.tmpfs` for empty scratch space that does not need initial
 contents from the host.

--- a/src/agentcage/data/apple-container/cage-init.sh
+++ b/src/agentcage/data/apple-container/cage-init.sh
@@ -288,12 +288,40 @@ if [ -n "${AGENTCAGE_NONPERSISTENT_COPIES:-}" ]; then
       mkdir -p "${target}"
       (cd "${lower}" && tar cf - .) | (cd "${target}" && tar xpf -) 2>/dev/null \
         || log "warn: failed to seed non-persistent mount ${target} from ${lower}"
+      # `tar xp` replays the HOST source's ownership and modes into the
+      # fresh tmpfs, and this stage runs as root. An ordinary host source
+      # (0755, not owned by uid 1000) therefore lands root-owned and the
+      # uid-1000 workload of stage D cannot write a single byte into it —
+      # the exact opposite of what `np` promises ("writable in the cage;
+      # changes discarded"). Hand the ephemeral copy to the cage user.
+      #
+      # Only the tmpfs ${target} is chowned; ${lower} is the read-only
+      # host bind and is never touched. `-h` chowns symlinks themselves
+      # rather than their referents, so a symlink inside the seeded tree
+      # (e.g. ./evil -> /etc/shadow, replayed verbatim from the host
+      # source) cannot redirect the chown at a path outside ${target}.
+      chown -Rh 1000:1000 "${target}" 2>/dev/null \
+        || log "warn: failed to chown non-persistent mount ${target} to uid 1000 — the cage workload may not be able to write to it"
     elif [ -f "${lower}" ]; then
       # A file target must remain a file: creating ${target} itself as a
       # directory would make cp place the source at ${target}/lower.
-      mkdir -p "$(dirname "${target}")"
+      np_parent=$(dirname "${target}")
+      # Only a parent this stage invents may be handed to the cage user;
+      # an image-provided parent (e.g. /home/node/.config) keeps its own
+      # ownership. A parent we create would otherwise be root-owned 0755,
+      # which blocks the write-to-temp-then-rename save path most config
+      # writers use even though the seeded file itself is writable.
+      np_new_parent=0
+      [ -d "${np_parent}" ] || np_new_parent=1
+      mkdir -p "${np_parent}"
       cp -f "${lower}" "${target}" 2>/dev/null \
         || log "warn: failed to seed non-persistent file mount ${target} from ${lower}"
+      if [ "${np_new_parent}" -eq 1 ]; then
+        chown 1000:1000 "${np_parent}" 2>/dev/null \
+          || log "warn: failed to chown non-persistent mount parent ${np_parent} to uid 1000"
+      fi
+      chown -h 1000:1000 "${target}" 2>/dev/null \
+        || log "warn: failed to chown non-persistent file mount ${target} to uid 1000 — the cage workload may not be able to write to it"
     fi
   done
 fi

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import platform
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2138,8 +2140,117 @@ def test_start_routes_np_file_to_exact_target_without_tmpfs(tmp_path, monkeypatc
         Path(__file__).parents[1]
         / "src/agentcage/data/apple-container/cage-init.sh"
     ).read_text()
-    assert 'mkdir -p "$(dirname "${target}")"' in init_script
+    assert 'np_parent=$(dirname "${target}")' in init_script
+    assert 'mkdir -p "${np_parent}"' in init_script
     assert 'cp -f "${lower}" "${target}"' in init_script
+
+
+# ---------------------------------------------------------------------------
+# cage-init.sh stage C' — non-persistent seed ownership
+# ---------------------------------------------------------------------------
+
+def _stage_c_prime_script():
+    """Return cage-init.sh's stage C' block as a standalone POSIX-sh script.
+
+    Stage C' is the only part of cage-init that can be exercised off-VM: it
+    is pure filesystem work driven by AGENTCAGE_NONPERSISTENT_COPIES. Slicing
+    it out (rather than asserting on source text) lets the tests below run the
+    real control flow — which branch chowns what — against a temp dir.
+    """
+    text = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "agentcage" / "data" / "apple-container" / "cage-init.sh"
+    ).read_text()
+    start = text.index("#-- Stage C'. Per-bind non-persistent mounts")
+    end = text.index("#-- Stage D.", start)
+    return "set -eu\nlog() { printf '%s\\n' \"$*\" >&2; }\n" + text[start:end]
+
+
+def _run_stage_c_prime(tmp_path, copies):
+    """Run stage C' with a recording `chown` stub; return its arg lines.
+
+    chown(1) to uid 1000 needs root, which the test suite is not. The stub
+    keeps the assertions about *which paths are handed to the cage user*
+    honest without needing privileges, and keeps the on-disk seeding real.
+    """
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    log = tmp_path / "chown.log"
+    stub = bindir / "chown"
+    stub.write_text(f'#!/bin/sh\nprintf \'%s\\n\' "$*" >> {log}\n')
+    stub.chmod(0o755)
+
+    script = tmp_path / "stage_c_prime.sh"
+    script.write_text(_stage_c_prime_script())
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["AGENTCAGE_NONPERSISTENT_COPIES"] = "\n".join(
+        f"{lower}\t{target}" for lower, target in copies
+    )
+    proc = subprocess.run(
+        ["sh", str(script)], env=env, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def test_cage_init_hands_np_directory_seed_to_the_cage_user(tmp_path):
+    """REGRESSION (#311): `tar xp` replays the host source's root-owned 0755
+    modes into the tmpfs, so the uid-1000 workload could not write to an `np`
+    mount at all — `echo x > /mnt/xfer/test2` returned EACCES, defeating the
+    documented "writable in the cage; changes discarded" contract. The seeded
+    tree must be chowned to uid 1000."""
+    lower = tmp_path / "lower"
+    (lower / "sub").mkdir(parents=True)
+    (lower / "sub" / "f.txt").write_text("hi")
+    target = tmp_path / "target"
+
+    chowns = _run_stage_c_prime(tmp_path, [(lower, target)])
+
+    assert (target / "sub" / "f.txt").read_text() == "hi"
+    assert chowns == [f"-Rh 1000:1000 {target}"]
+    # The read-only host bind is the operator's real data — never chowned
+    # through, not even via -R on a path that contains it.
+    assert not any(str(lower) in line for line in chowns)
+
+
+def test_cage_init_np_directory_chown_does_not_follow_symlinks(tmp_path):
+    """The seeded tree is a verbatim copy of a host directory, so it can
+    contain a symlink to an absolute path outside the mount (/etc/shadow).
+    chown must carry -h so it retargets the link, not the referent."""
+    assert "chown -Rh 1000:1000" in _stage_c_prime_script()
+
+
+def test_cage_init_hands_np_file_seed_and_invented_parent_to_the_cage_user(tmp_path):
+    """A single-file np source is copied to its exact target. The copy must be
+    owned by uid 1000, and so must a parent directory this stage invents —
+    otherwise the root-owned 0755 parent blocks the write-temp-then-rename
+    save path that config writers use."""
+    lower = tmp_path / "settings.json"
+    lower.write_text("{}")
+    target = tmp_path / "cage" / "config" / "settings.json"
+
+    chowns = _run_stage_c_prime(tmp_path, [(lower, target)])
+
+    assert target.read_text() == "{}"
+    assert chowns == [
+        f"1000:1000 {target.parent}",
+        f"-h 1000:1000 {target}",
+    ]
+
+
+def test_cage_init_np_file_seed_leaves_a_preexisting_parent_alone(tmp_path):
+    """A parent that already exists belongs to the image (e.g.
+    /home/node/.config or /etc) — seeding one file into it must not rewrite
+    that directory's ownership."""
+    lower = tmp_path / "settings.json"
+    lower.write_text("{}")
+    target = tmp_path / "existing" / "settings.json"
+    target.parent.mkdir()
+
+    chowns = _run_stage_c_prime(tmp_path, [(lower, target)])
+
+    assert chowns == [f"-h 1000:1000 {target}"]
 
 
 def test_unit_json_bakes_env_var_so_mount_survives_restart(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #311.

## The bug

`np` binds are documented as "writable in the cage; changes discarded". On apple-container the cage workload could not write to one at all:

```
$ agentcage cage exec e2e-ac278 -- sh -c 'id; ls -ld /mnt/xfer; echo x > /mnt/xfer/test2'
uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu)
drwxr-xr-x 2 root root 60 /mnt/xfer
sh: 1: cannot create /mnt/xfer/test2: Permission denied
```

(host source: an ordinary `drwxr-xr-x` dir owned by the host user, mounted `"$HOME/ac-tp-xfer:/mnt/xfer:rw,np"`)

Stage C' of `cage-init.sh` seeds the tmpfs target from the read-only host lowerdir with `tar xp`, as root. `-p` replays the host source's ownership and modes into the fresh tmpfs, so a stock 0755 source lands root-owned and the uid-1000 workload that stage D drops to has no write access. Nothing chowned the seeded tree to the cage user, so the option was inert for its entire stated purpose on this backend.

## The fix

Chown the seeded result to uid 1000 in both branches of stage C':

- **Directory source:** `chown -Rh 1000:1000 "${target}"`. Only the tmpfs target is touched — `lower` is the operator's real host data (bind-mounted `ro`) and is never chowned through. `-h` chowns symlinks themselves rather than their referents, so a link replayed verbatim from the host source (`./x -> /etc/shadow`) cannot redirect the chown at a path outside the mount.
- **File source:** chown the copied file, and the parent directory *only when this stage invented it*. An image-provided parent (`/home/node/.config`, `/etc`) keeps its own ownership; a parent created here would otherwise be root-owned 0755 and block the write-temp-then-rename save path most config writers use, even though the seeded file itself is writable.

Chown failures `log "warn: ..."` like the neighbouring seed failures rather than killing the cage. Ephemeral semantics are unchanged: everything happens in the tmpfs / fresh cage filesystem, nothing is written back to the host.

## Podman: not affected

The container/VM path routes an `np` directory through podman's `:O` overlay over the host source with `upperdir`/`workdir` under `%t` (`quadlets.py::_non_persistent_overlay_mount`), and an `np` file through a systemd `ExecStartPre` copy into `%t` that is then bind-mounted `rw`. In both cases the ownership the workload observes is exactly what it would observe for an ordinary `rw` bind of the same host source under the cage's `userns` mapping (scaffolds set `userns: keep-id`, which maps the host user's uid identically inside). There is no root-owned re-materialization step to correct, so `np` on podman is no less writable than a plain bind of the same path. Apple-container was the outlier because it is the only backend that re-creates the tree as root. Fixed here only.

## Secondary observation (documented, not changed)

Seeding is asynchronous relative to `cage start`: the tmpfs is mounted 1777 and empty when `container run` returns, and stages A–C (egress ARP wait, route handoff, CA-cert wait, up to ~10s) run before stage C' seeds it. A `cage exec` issued in the first seconds after `cage start` can therefore observe the mount still empty. The cage's own workload is never affected — it is exec'd in stage D, strictly after seeding. Fixing this properly means gating `cage start`'s return on a readiness signal from cage-init, which is out of scope here; `docs/reference/configuration.md` now states the window instead.

## Tests

Four new regression tests in `tests/test_apple_container.py` (alongside the existing `cage-init` / `AGENTCAGE_NONPERSISTENT_COPIES` tests). Rather than asserting on source text, they slice stage C' out of `cage-init.sh` between its stage markers and **run it for real** under `sh` against a temp dir, with a recording `chown` stub on `PATH` (chowning to uid 1000 needs root, which the suite is not). That exercises the actual control flow — which paths get handed to the cage user — while keeping the on-disk seeding real:

- directory seed is chowned `-Rh 1000:1000`, and no chown line ever mentions the `lower` source;
- the `-h` symlink guard is present;
- file seed chowns both the invented parent and the file;
- a pre-existing parent is left alone.

All four fail against the pre-fix script. One neighbouring assertion in `test_start_routes_np_file_to_exact_target_without_tmpfs` was updated for the `np_parent` refactor (same invariant, new shape).

## Test run

`uv run pytest` (full suite): **13 failed, 1962 passed, 39 skipped, 6 errors**.

Baseline on `origin/master` @ c9bf107 on the same machine: **13 failed, 1958 passed, 39 skipped, 6 errors** — the identical failure/error set. The delta is exactly the 4 new tests passing. The pre-existing failures are environmental on this host (podman-backed `test_egress_image.py`, plus container-backend tests that resolve to apple-container on macOS) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
