### PR TITLE
[#319] fix(vm): surface captured podman build output on in-VM build failure

### DIFF
--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import click
 
+from agentcage import output
 from agentcage._timing import Phase
 from agentcage.config import Config
 from agentcage.lima import prerequisites as lima_prerequisites
@@ -121,6 +122,56 @@ def _dump_service_failure(inst: LimaInstance, svc: str) -> None:
             click.echo(journal.stdout.rstrip(), err=True)
     except Exception:
         pass
+
+
+def _decode_stream(stream: str | bytes | None) -> str:
+    """Return *stream* as text, tolerating the bytes form of ``exec(text=False)``."""
+    if stream is None:
+        return ""
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", errors="replace")
+    return stream
+
+
+def _exec_build(inst: LimaInstance, cmd: list[str], *, what: str) -> None:
+    """Run an image build inside the guest, surfacing its output on failure.
+
+    ``LimaInstance.exec`` runs with ``capture_output=True``, so a failed
+    in-guest ``podman build`` used to reach the operator as a bare
+    ``CalledProcessError`` traceback whose only content was the (very
+    long) ``limactl shell ...`` command line and an exit status —
+    podman's actual error was stranded on the exception and never
+    printed. Issue #319: a first ``cage create`` on a fresh host failed
+    here and the reason could not be determined from agentcage's output
+    at all; it had to be reproduced by hand inside the VM.
+
+    Dump the captured streams at the point of failure — same shape as
+    ``_systemctl_start`` surfacing a failed unit — then raise a
+    ``click.ClickException`` so the CLI reports a one-line error instead
+    of a Python traceback (``cage create``/``cage update`` re-raise, and
+    click renders ``Error: ...``). The original ``CalledProcessError`` is
+    kept as ``__cause__``.
+    """
+    try:
+        inst.exec(cmd)
+    except subprocess.CalledProcessError as e:
+        stdout = _decode_stream(e.stdout).rstrip()
+        stderr = _decode_stream(e.stderr).rstrip()
+        # A build log is many lines and fights the "Starting cage..."
+        # spinner for the same terminal line; pause it while we dump.
+        with output.pause_active_spinner():
+            click.echo(
+                f"error: {what} failed inside the VM "
+                f"(exit status {e.returncode})",
+                err=True,
+            )
+            if stdout:
+                click.echo(stdout, err=True)
+            if stderr:
+                click.echo(stderr, err=True)
+            if not stdout and not stderr:
+                click.echo("(the build produced no output)", err=True)
+        raise click.ClickException(f"{what} failed inside the VM") from e
 
 
 def _systemctl_start(
@@ -248,7 +299,7 @@ class VmBackend:
         version = _pkg_version("agentcage")
         click.echo(f"Building egress image inside VM (agentcage-egress:{version})...")
         with Phase("build.egress", cage=deploy_name):
-            inst.exec([
+            _exec_build(inst, [
                 "podman", "build", *build_flags,
                 "--cap-add=CAP_CHOWN", "--cap-add=CAP_FOWNER",
                 "--cap-add=CAP_SETUID", "--cap-add=CAP_SETGID",
@@ -256,7 +307,7 @@ class VmBackend:
                 "-t", f"agentcage-egress:{version}",
                 "-f", f"{vm_build_dir}/containers/Containerfile.egress",
                 vm_build_dir,
-            ])
+            ], what=f"build of agentcage-egress:{version}")
 
         # Build or pull the cage image inside the VM
         if config and config.container.image:
@@ -425,7 +476,7 @@ class VmBackend:
             "-f", f"{vm_scaffold_dir}/{containerfile.name}",
             vm_scaffold_dir,
         ]
-        inst.exec(build_cmd)
+        _exec_build(inst, build_cmd, what=f"build of {config.container.image}")
 
     def _deploy_cage(self, name: str, inst: LimaInstance, config: Config | None = None) -> None:
         """Deploy quadlet files and start services inside the Lima VM."""

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -763,6 +763,135 @@ class TestSystemctlStart:
         )
 
 
+class TestInVmBuildFailureDiagnostics:
+    """Issue #319: a failed ``podman build`` inside the VM used to reach the
+    operator as a bare CalledProcessError traceback. ``LimaInstance.exec``
+    runs with ``capture_output=True``, so podman's real error was stranded
+    on the exception and thrown away — the reported first-``cage create``
+    failure was undiagnosable without reproducing it by hand in the guest."""
+
+    @staticmethod
+    def _exec_failing_on_build(*, stdout="", stderr="", returncode=1):
+        """Mock ``inst.exec`` that fails only on the ``podman build`` call."""
+        import subprocess
+
+        def _exec(cmd, **kwargs):
+            if "build" in cmd:
+                raise subprocess.CalledProcessError(
+                    returncode, ["limactl", "shell", "agentcage-testcage",
+                                 "--", *cmd],
+                    output=stdout, stderr=stderr,
+                )
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        return _exec
+
+    def test_egress_build_failure_surfaces_captured_output(self, capsys):
+        import subprocess
+
+        import click
+
+        backend = VmBackend()
+        mock_inst = MagicMock()
+        mock_inst.is_running.return_value = True
+        mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = self._exec_failing_on_build(
+            stdout="STEP 5/12: RUN apt-get update\n",
+            stderr="error: mount /proc: operation not permitted\n",
+        )
+
+        with patch.object(backend, "_instance", return_value=mock_inst), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             pytest.raises(click.ClickException) as excinfo:
+            backend.build_artifacts(_make_config(), "testcage")
+
+        err = capsys.readouterr().err
+        # Both captured streams reach the operator, not just the exit status.
+        assert "STEP 5/12" in err
+        assert "operation not permitted" in err
+        assert "exit status 1" in err
+        # ClickException => click prints "Error: ..." and exits 1 instead of
+        # dumping a Python traceback; the original failure stays as __cause__.
+        assert "agentcage-egress" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+
+    def test_build_failure_without_output_says_so(self, capsys):
+        import click
+
+        backend = VmBackend()
+        mock_inst = MagicMock()
+        mock_inst.is_running.return_value = True
+        mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = self._exec_failing_on_build(returncode=125)
+
+        with patch.object(backend, "_instance", return_value=mock_inst), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             pytest.raises(click.ClickException):
+            backend.build_artifacts(_make_config(), "testcage")
+
+        err = capsys.readouterr().err
+        assert "exit status 125" in err
+        assert "produced no output" in err
+
+    def test_scaffold_cage_build_failure_surfaces_output(self, capsys, tmp_path):
+        """The scaffold cage image build inside the VM is routed through the
+        same reporting helper as the egress build."""
+        import click
+
+        backend = VmBackend()
+        mock_inst = MagicMock()
+        mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = self._exec_failing_on_build(
+            stderr="Error: no such file or directory\n",
+        )
+        config = _make_config()
+        config.container.build.containerfile = "Containerfile"
+        (tmp_path / "Containerfile").write_text("FROM scratch\n")
+
+        with patch("agentcage.state.deployment_dir", return_value=tmp_path), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             pytest.raises(click.ClickException) as excinfo:
+            backend._build_cage_image_in_vm(
+                config, "testcage", mock_inst, "/tmp/agentcage-build",
+            )
+
+        err = capsys.readouterr().err
+        assert "no such file or directory" in err
+        assert config.container.image in str(excinfo.value)
+
+    def test_successful_build_stays_quiet(self, capsys):
+        from agentcage.backends.vm import _exec_build
+
+        mock_inst = MagicMock()
+        mock_inst.exec.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        _exec_build(mock_inst, ["podman", "build", "-t", "x", "."], what="build of x")
+
+        assert capsys.readouterr().err == ""
+        mock_inst.exec.assert_called_once_with(
+            ["podman", "build", "-t", "x", "."]
+        )
+
+    def test_bytes_streams_are_decoded(self, capsys):
+        """``exec(text=False)`` yields bytes; the dump must not crash on it."""
+        import subprocess
+
+        import click
+
+        from agentcage.backends.vm import _exec_build
+
+        mock_inst = MagicMock()
+        mock_inst.exec.side_effect = subprocess.CalledProcessError(
+            1, ["podman", "build"], output=b"stdout bytes\n", stderr=b"stderr bytes\n",
+        )
+
+        with pytest.raises(click.ClickException):
+            _exec_build(mock_inst, ["podman", "build"], what="build of x")
+
+        err = capsys.readouterr().err
+        assert "stdout bytes" in err
+        assert "stderr bytes" in err
+
+
 class TestDeployCageStartOrder:
     """The cage's ExecStartPre is a 30s poll for mitmproxy's CA cert.
     Starting cage in the same loop as the egress container races that


### PR DESCRIPTION
Addresses the **diagnostic half** of #319. Does **not** close it — the startup race stays tracked there (rationale below).

## The problem

`LimaInstance.exec` runs every guest command with `capture_output=True`. The two in-VM `podman build` calls in the VM backend (the egress image in `build_artifacts`, the scaffold cage image in `_build_cage_image_in_vm`) used that default and then discarded the captured streams.

A failed build therefore propagated as a bare `subprocess.CalledProcessError` whose only user-visible content was the very long `limactl shell ... podman build ...` command line and an exit status. `cage create` re-raises after printing its debugging hints, and `cage update` has no handler at all, so the operator got a raw Python traceback with no cause:

```
subprocess.CalledProcessError: Command '['limactl', 'shell', '--workdir', '/', '--tty=false',
  'agentcage-e2e-vmnogit', '--', 'podman', 'build', ...]' returned non-zero exit status 1.
```

Podman's actual error was sitting on `e.stdout`/`e.stderr` the whole time and was never printed. In the reported first-create failure the underlying reason could not be determined from agentcage's output at all — it had to be reproduced by hand inside the guest.

## The change

Both in-VM builds now go through a `_exec_build` helper in `backends/vm.py` that, on `CalledProcessError`:

- echoes a one-line header (`error: build of agentcage-egress:0.32.0 failed inside the VM (exit status 1)`) plus the captured stdout and stderr to stderr, at the point of failure — the same shape `_systemctl_start` already uses to surface a failed unit and its journal;
- says so explicitly when the build produced no output at all;
- raises `click.ClickException` so the CLI renders `Error: ...` and exits 1 instead of dumping a traceback (the repo already uses `ClickException` in `init.py`). The original `CalledProcessError` is preserved as `__cause__`.

Two details worth noting:

- The dump is wrapped in `output.pause_active_spinner()` — a multi-line build log would otherwise fight the `Starting cage...` spinner for the same terminal line, which is exactly what that existing helper is for.
- Bytes streams are decoded defensively, since `LimaInstance.exec` accepts `text=False`.

Swapping the exception type does not change any cleanup path: `run.py`'s `except CalledProcessError` and `except Exception` branches perform identical state cleanup and both `return 1`, and the previous behaviour there was to dump the same streams a second time — that duplicate dump is now gone.

## The race — deliberately not attempted

The issue also suggests a readiness gate or bounded retry before dispatching the build into a freshly started Lima instance. I did not implement one, on purpose:

- The cause of the failure is still unknown. That is the point of this PR — the build output was discarded, so there is no evidence about *what* was not ready in the fresh guest (podman storage? network? cgroups? something else entirely). Any gate I added would be a guess at a mechanism nobody has observed.
- A retry around the build specifically risks masking genuine build failures, which is worse than the current bug.
- It could not be validated here: Lima is not available in CI and the constraints for this task forbid running `limactl`/`podman`/`cage create` on this host.

With this change the next occurrence reports the real error, and the gate can then be aimed at the actual precondition. #319 stays open for that.

## Tests

`TestInVmBuildFailureDiagnostics` in `tests/test_vm_backend.py`, following the neighbouring `TestSystemctlStart` style (mocked `LimaInstance`, no Lima required): egress build failure surfaces both captured streams and the exit status and raises `ClickException` with the `CalledProcessError` as `__cause__`; the no-output case says so; the scaffold cage build path is routed through the same helper; a successful build stays silent; bytes streams are decoded rather than crashing the reporter.

`uv run pytest`: baseline on `origin/master` @ `3e883e0` was `12 failed, 1983 passed, 39 skipped, 6 errors`; with this branch `12 failed, 1988 passed, 39 skipped, 6 errors`. The failing/erroring sets are byte-identical (verified by diff) — they are the known unrelated macOS-host backend failures. Delta: **+5 passed, 0 new failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
