### PR TITLE
[#317] fix(e2e): surface swallowed phase failures and refuse container phases on macOS

### DIFF
--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -234,7 +234,9 @@ dump_cage_diagnostics() {
     nsenter -t "$_cage_pid" -U -n -- ip route 2>&1 | sed 's/^/          /' >&2 || echo "          (nsenter failed)" >&2
     # Pick the egress IP that lives on the same /24 as the cage (the cage-net interface).
     local _egress_cage_ip
-    _egress_cage_ip=$(podman inspect --format '{{(index .NetworkSettings.Networks "'"${cage}"'-net").IPAddress}}' "${cage}-egress" 2>/dev/null)
+    # `|| true`: a failing inspect must not abort the diagnostic dump
+    # half-way through under `set -e` (#317).
+    _egress_cage_ip=$(podman inspect --format '{{(index .NetworkSettings.Networks "'"${cage}"'-net").IPAddress}}' "${cage}-egress" 2>/dev/null || true)
     echo "        [cage → egress IP ping (target=$_egress_cage_ip, 3 probes)]" >&2
     if [ -n "$_egress_cage_ip" ]; then
       nsenter -t "$_cage_pid" -U -n -- ping -c 3 -W 2 -q "$_egress_cage_ip" 2>&1 | sed 's/^/          /' >&2 || true
@@ -307,7 +309,13 @@ register_cage() {
   E2E_CAGES_TO_CLEANUP+=("$1")
 }
 
-# Destroy a cage silently
+# Destroy a cage silently.
+#
+# Unlike create_cage (#317) this one stays silent on failure ON PURPOSE:
+# every phase calls it up-front to clear a *possibly non-existent* stale
+# cage, so a non-zero exit is the normal case and carries no signal. The
+# `|| true` is likewise deliberate — a failed destroy must never abort a
+# phase under `set -e`.
 destroy_cage() {
   stop_mock "$1"
   agentcage cage destroy "$1" -y >/dev/null 2>&1 || true
@@ -327,17 +335,45 @@ destroy_cage_with_volumes() {
   done
 }
 
-# Create a cage from a config template (expands env vars) and register for cleanup.
-# Streams output to stderr so callers can redirect with >/dev/null.
+# _dump_captured LABEL OUTPUT
+#   Print a captured command's combined output to stderr, indented and
+#   framed like dump_cage_diagnostics. Used by the helpers below so a
+#   failing command explains itself even when the caller redirects the
+#   helper's stdout to /dev/null.
+_dump_captured() {
+  local label="$1" output="$2"
+  {
+    echo "        ── $label ──"
+    if [ -n "$output" ]; then
+      printf '%s\n' "$output" | sed 's/^/          /'
+    else
+      echo "          (no output)"
+    fi
+    echo "        ── end $label ──"
+  } >&2
+}
+
+# Create a cage from a config template (expands env vars).
+#
+# Output handling (issue #317): `agentcage cage create` output is CAPTURED,
+# not streamed. On success nothing is printed, so phases keep their clean
+# output with the customary `create_cage ... >/dev/null`. On failure the
+# captured output is dumped to stderr before returning the non-zero rc, so
+# a broken create explains itself instead of producing a bare
+# `Phase N: FAIL (0/0)`. Capturing here (rather than asking callers to stop
+# redirecting) is what makes the diagnostic survive `>/dev/null` callers.
 create_cage() {
   local config="$1"
   shift
   local tmpconfig
   tmpconfig=$(mktemp /tmp/e2e-config-XXXXXX.yaml)
   envsubst < "$config" > "$tmpconfig"
-  local rc=0
-  AGENT_DIR="$AGENT_DIR" agentcage cage create -c "$tmpconfig" "$@" 2>&1 || rc=$?
+  local rc=0 output
+  output=$(AGENT_DIR="$AGENT_DIR" agentcage cage create -c "$tmpconfig" "$@" 2>&1) || rc=$?
   rm -f "$tmpconfig"
+  if [ "$rc" -ne 0 ]; then
+    _dump_captured "cage create FAILED (exit $rc): $(basename "$config")" "$output"
+  fi
   return $rc
 }
 
@@ -450,13 +486,28 @@ start_mock() {
   # — build_artifacts() tags as ``agentcage-egress:<pkg-version>``. The
   # mock just needs an image with python3 inside; egress has it (debian
   # bookworm-slim + the mitmproxy bundle which ships its own python).
+  #
+  # The `|| true` is load-bearing (#317): lib.sh runs under `set -euo
+  # pipefail`, so when the store holds no agentcage-egress image grep exits
+  # 1, pipefail propagates it, and the bare assignment killed the ENTIRE
+  # phase right here — no message, no test results, just `FAIL (0/0)`. That
+  # is precisely what a macOS run hit, because the image had been built into
+  # the apple-container store where podman cannot see it. Tolerate the empty
+  # result so the diagnostic below actually gets a chance to run.
   local mock_image
   mock_image=$(podman images --format '{{.Repository}}:{{.Tag}}' \
-    | grep -E '^localhost/agentcage-egress:' | head -n 1)
+    | grep -E '^localhost/agentcage-egress:' | head -n 1 || true)
   if [ -z "$mock_image" ]; then
     # Fall back to the unversioned name in case the test runner pre-built
     # one without a version tag.
     mock_image=localhost/agentcage-egress
+    # A missing egress image after a successful `cage create` almost always
+    # means the cage was built by a NON-podman backend (vm / apple-container),
+    # whose image store podman cannot see — the exact #317 failure mode.
+    echo "WARNING: no localhost/agentcage-egress:* image in the podman store;" >&2
+    echo "         falling back to '$mock_image'. If the cage was created with a" >&2
+    echo "         vm or apple-container backend its egress image lives in a" >&2
+    echo "         different image store — see issue #317." >&2
   fi
 
   # Start mock container (reuses the already-built agentcage-egress image
@@ -470,21 +521,28 @@ start_mock() {
   #   [tini, --, /opt/agentcage/supervisor]. We override here so
   #   `python3 /mock.py` runs directly instead of being parsed as the
   #   supervisor's args.
-  if ! podman run -d --name "${cage}-mock" \
+  # Capture podman's own error (#317): a bare "failed to start mock
+  # container" hides the actual cause (missing image, missing network, …).
+  local run_out run_rc=0
+  run_out=$(podman run -d --name "${cage}-mock" \
     --user root \
     --network "${cage}-net" \
     --sysctl net.ipv4.ip_unprivileged_port_start=80 \
     --entrypoint=python3 \
     -v "${MOCK_SCRIPT}:/mock.py:ro" \
-    "$mock_image" /mock.py >/dev/null 2>&1; then
-    echo "WARNING: failed to start mock container for $cage" >&2
+    "$mock_image" /mock.py 2>&1) || run_rc=$?
+  if [ "$run_rc" -ne 0 ]; then
+    echo "WARNING: failed to start mock container for $cage (image: $mock_image)" >&2
+    _dump_captured "podman run FAILED (exit $run_rc)" "$run_out"
     return 1
   fi
 
-  # Get mock IP
+  # Get mock IP. `|| true` for the same reason as the image lookup above:
+  # a failing inspect must reach the explicit check below, not abort the
+  # phase with no output via `set -e`.
   local mock_ip
   mock_ip=$(podman inspect "${cage}-mock" \
-    --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null)
+    --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 2>/dev/null || true)
   if [ -z "$mock_ip" ]; then
     echo "WARNING: mock container has no IP for $cage" >&2
     stop_mock "$cage"

--- a/tests/e2e/phase3_secrets.sh
+++ b/tests/e2e/phase3_secrets.sh
@@ -317,7 +317,8 @@ register_cage "$CAGE_SRC"
 e2e_timer_start
 export E2E_SRC_ENV_SECRET="env-secret-value-99"
 export E2E_PORT_SECRETS_SRC="$SECRET_PORT_SRC"
-if create_cage "$CONFIGS/secrets-source.yaml" >/dev/null 2>&1; then
+# stderr is kept so a failing create explains itself (#317).
+if create_cage "$CONFIGS/secrets-source.yaml" >/dev/null; then
   e2e_pass "3.7" "env: source cage created"
 else
   e2e_fail "3.7" "env: source cage created" "cage create failed"

--- a/tests/e2e/phase6_hardening.sh
+++ b/tests/e2e/phase6_hardening.sh
@@ -132,7 +132,9 @@ export E2E_MASK_PROJECT_DIR="$MASK_PROJECT"
 destroy_cage "$MASK_CAGE"
 register_cage "$MASK_CAGE"
 MASK_CREATE_RC=0
-create_cage "$CONFIGS/workspace-mask.yaml" >/dev/null 2>&1 || MASK_CREATE_RC=$?
+# Only stdout is dropped: create_cage dumps a failing create to stderr
+# (#317), and the skip below needs that reason to be visible.
+create_cage "$CONFIGS/workspace-mask.yaml" >/dev/null || MASK_CREATE_RC=$?
 if [ "$MASK_CREATE_RC" -ne 0 ]; then
   e2e_skip "6.11" "Workspace .git/hooks tmpfs mask" \
     "cage create failed (no podman / buildkit available)"

--- a/tests/e2e/phase7_vm.sh
+++ b/tests/e2e/phase7_vm.sh
@@ -23,6 +23,10 @@ podman build -t basic-agent "$REPO_ROOT/examples/basic/agent" >/dev/null 2>&1
 
 echo "Creating VM cage (this takes a few minutes)..."
 export E2E_PORT_VM="$PORT"
+# stderr is suppressed here on purpose: this create is EXPECTED to fail
+# routinely (the agent image isn't inside the VM yet — it's transferred
+# and the services started by hand just below), so the #317 failure dump
+# would be pure noise on every run.
 create_cage "$CONFIGS/vm.yaml" >/dev/null 2>&1 || true
 
 # The cage service may fail because the image isn't in the VM yet

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   bash tests/e2e/run.sh                    # run all phases
 #   bash tests/e2e/run.sh 1 2 3 4            # run specific phases
-#   bash tests/e2e/run.sh container          # phases 1-6
+#   bash tests/e2e/run.sh container          # phases 1-6 (Linux only, see #317)
 #   bash tests/e2e/run.sh vm                 # phase 7 only
 #   E2E_PORT_BASE=19100 bash tests/e2e/run.sh  # custom port base
 
@@ -39,10 +39,13 @@ else
         echo "  8  OpenClaw scaffold regression canary (pulls openclaw:latest)"
         echo ""
         echo "Shortcuts:"
-        echo "  container   Phases 1-6"
+        echo "  container   Phases 1-6 (Linux host only)"
         echo "  vm          Phase 7 only"
         echo "  openclaw    Phase 8 only"
         echo "  all         Phases 1-8 (default)"
+        echo ""
+        echo "Note: phases 1-6 and 8 require rootless podman and therefore a"
+        echo "      Linux host. On macOS use 'vm' or tests/e2e/phase_apple.sh."
         echo ""
         echo "Environment:"
         echo "  E2E_PORT_BASE    Port base for test cages (default: 19080)"
@@ -54,6 +57,47 @@ else
         ;;
     esac
   done
+fi
+
+# ── host guard: container phases are Linux-only (issue #317) ─────────
+# Phases 1-6 and 8 are "container phases": they drive rootless podman
+# directly (start_mock, the mock container, `podman images`) and their
+# configs pin no `isolation:` key.
+#
+# On macOS that combination silently runs the WRONG backend:
+#   * `container` isolation is rejected outright by config validation
+#     ("container isolation is not available on macOS"), and
+#   * `default_isolation()` resolves an unpinned config to
+#     apple-container (macOS 26+ Apple Silicon) or vm (anything else).
+# `cage create` then builds the egress image into the apple-container
+# image store while start_mock looks for it via `podman images` — a
+# different, empty store — and the phase dies somewhere unrelated.
+#
+# Refuse up front with the real constraint instead. Deliberately scoped:
+# `run.sh vm` (phase 7, Lima) and tests/e2e/phase_apple.sh are supported
+# on macOS and are not blocked; on Linux this guard never fires.
+if [ "$(uname -s)" = "Darwin" ]; then
+  BLOCKED=()
+  for p in "${PHASES[@]}"; do
+    case "$p" in
+      1|2|3|4|5|6|8) BLOCKED+=("$p") ;;
+    esac
+  done
+  if [ ${#BLOCKED[@]} -gt 0 ]; then
+    {
+      echo "ERROR: phase(s) ${BLOCKED[*]} need 'container' isolation (rootless podman),"
+      echo "       which agentcage does not support on macOS — config validation"
+      echo "       rejects it, and these phases would otherwise run against a"
+      echo "       different backend whose images podman cannot see (issue #317)."
+      echo ""
+      echo "Supported on macOS:"
+      echo "  bash tests/e2e/run.sh vm       # phase 7 — Lima VM mode"
+      echo "  bash tests/e2e/phase_apple.sh  # apple-container (macOS 26+ Apple Silicon)"
+      echo ""
+      echo "For the container phases, use a Linux host (or CI)."
+    } >&2
+    exit 1
+  fi
 fi
 
 # ── preflight ────────────────────────────────────────────────────────

--- a/tests/test_e2e_harness_diagnostics.py
+++ b/tests/test_e2e_harness_diagnostics.py
@@ -1,0 +1,315 @@
+"""Tests for the e2e harness's failure diagnostics and macOS host guard.
+
+Issue #317 reported two halves of the same problem: running
+``bash tests/e2e/run.sh container`` on macOS produced
+
+    Phase 1: FAIL (0/0, 46s)
+    Total: 0 passed
+
+with no explanation whatsoever.
+
+1. ``tests/e2e/lib.sh`` swallowed the reason. ``create_cage`` folded
+   stderr into stdout and every caller redirected stdout to
+   ``/dev/null``; ``start_mock``'s image lookup died on a bare
+   ``set -e``/``pipefail`` assignment before it could say anything.
+2. ``tests/e2e/run.sh container`` ran the wrong backend in the first
+   place: the e2e configs pin no ``isolation:`` key, ``container``
+   isolation is rejected on macOS, so the phases silently resolved to
+   apple-container whose image store podman cannot see.
+
+These tests follow ``test_phase_apple_skip.py``: drive the real shell
+scripts under a temp ``PATH`` of fake shims so the host-specific paths
+can be exercised from any CI, plus a couple of static assertions for
+the branches that cannot be executed without launching a real phase.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+E2E_DIR = Path(__file__).resolve().parent / "e2e"
+RUN_SH = E2E_DIR / "run.sh"
+LIB_SH = E2E_DIR / "lib.sh"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_shim(bindir: Path, name: str, body: str) -> Path:
+    p = bindir / name
+    p.write_text(f"#!/bin/sh\n{body}\n")
+    p.chmod(p.stat().st_mode | stat.S_IEXEC | stat.S_IREAD)
+    return p
+
+
+def _run_bash(script: str, bindir: Path, timeout: int = 30):
+    """Run *script* with *bindir* prepended to PATH."""
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ.get('PATH', '')}",
+        "REPO_ROOT": str(REPO_ROOT),
+    }
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True, text=True, env=env, timeout=timeout,
+    )
+
+
+class TestRunShMacOSContainerGuard:
+    """``run.sh`` must refuse the podman-backed phases on a macOS host."""
+
+    @pytest.fixture
+    def bindir(self, tmp_path):
+        b = tmp_path / "fakebin"
+        b.mkdir()
+        # `uname -s` reports Darwin so the guard fires from any CI host.
+        _write_shim(b, "uname", "echo Darwin")
+        # Tripwires: the guard must fire BEFORE any backend command runs.
+        # If run.sh reaches its stale-cage sweep or a phase, these record it.
+        touched = tmp_path / "touched"
+        for cmd in ("agentcage", "podman", "limactl", "container"):
+            _write_shim(b, cmd, f'echo "$0 $*" >> "{touched}"\nexit 0')
+        return b
+
+    @pytest.fixture
+    def touched(self, tmp_path):
+        return tmp_path / "touched"
+
+    def _run(self, bindir, args: str):
+        return _run_bash(f'bash "{RUN_SH}" {args}', bindir)
+
+    @pytest.mark.parametrize(
+        "args, expected_phases",
+        [
+            ("container", "1 2 3 4 5 6"),
+            ("openclaw", "8"),
+            ("all", "1 2 3 4 5 6 8"),
+            ("", "1 2 3 4 5 6 8"),   # no args ⇒ all phases
+            ("1", "1"),
+            ("3 7", "3"),            # 7 alone is fine, 3 is not
+        ],
+    )
+    def test_refuses_container_phases_on_darwin(
+        self, bindir, touched, args, expected_phases
+    ):
+        result = self._run(bindir, args)
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert f"phase(s) {expected_phases} need" in result.stderr
+        assert not touched.exists(), (
+            f"guard ran backend commands before refusing: {touched.read_text()}"
+        )
+
+    def test_message_names_the_real_constraint(self, bindir):
+        """The message must explain *why*, not just say no."""
+        err = self._run(bindir, "container").stderr
+        assert "'container' isolation (rootless podman)" in err
+        assert "does not support on macOS" in err
+        assert "podman cannot see" in err
+        assert "#317" in err
+
+    def test_message_is_actionable(self, bindir):
+        """It must point at the paths that DO work on macOS."""
+        err = self._run(bindir, "container").stderr
+        assert "run.sh vm" in err
+        assert "phase_apple.sh" in err
+        assert "Linux host" in err
+
+    def test_refusal_goes_to_stderr(self, bindir):
+        """stdout stays clean so it can't be mistaken for a phase result."""
+        result = self._run(bindir, "container")
+        assert "ERROR" not in result.stdout
+        assert result.stderr.startswith("ERROR:")
+
+    def test_help_still_works_on_darwin(self, bindir, touched):
+        """``-h`` is handled during arg parsing and must not be blocked."""
+        result = self._run(bindir, "-h")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Usage:" in result.stdout
+        assert "ERROR" not in result.stderr
+        assert not touched.exists()
+
+    def test_unknown_arg_still_rejected_on_darwin(self, bindir):
+        result = self._run(bindir, "bogus")
+        assert result.returncode == 1
+        assert "Unknown argument: bogus" in result.stdout
+
+    def test_guard_is_darwin_scoped_and_excludes_the_vm_phase(self):
+        """Static: phase 7 (Lima VM) is supported on macOS, so it must not
+        appear in the blocked set, and the whole guard must sit behind a
+        Darwin test so Linux behaviour is unchanged.
+
+        Asserted statically rather than by running ``run.sh vm``: that
+        would launch the real phase 7 against the host's Lima/podman.
+        """
+        text = RUN_SH.read_text()
+        assert '[ "$(uname -s)" = "Darwin" ]' in text
+        assert "1|2|3|4|5|6|8) BLOCKED+=" in text
+        assert "|7|" not in text
+        # The guard block must precede the stale-cage sweep, which is the
+        # first thing that talks to a backend.
+        assert text.index("BLOCKED+=") < text.index("agentcage cage list")
+
+
+class TestCreateCageFailureDiagnostics:
+    """``create_cage`` must explain a failed create even when the caller
+    redirects its stdout to /dev/null (every phase script does)."""
+
+    @pytest.fixture
+    def bindir(self, tmp_path):
+        b = tmp_path / "fakebin"
+        b.mkdir()
+        # envsubst isn't installed everywhere; `cat` is a faithful stand-in
+        # for a config with no ${VAR} references.
+        _write_shim(b, "envsubst", "exec cat")
+        return b
+
+    @pytest.fixture
+    def config(self, tmp_path):
+        cfg = tmp_path / "cage.yaml"
+        cfg.write_text("name: e2e-fake\n")
+        return cfg
+
+    def _create(self, bindir, config, redirect: str):
+        script = (
+            f'source "{LIB_SH}"\n'
+            "rc=0\n"
+            f'create_cage "{config}" {redirect} || rc=$?\n'
+            'echo "RC=$rc"\n'
+        )
+        return _run_bash(script, bindir)
+
+    def test_failure_output_survives_dev_null_caller(self, bindir, config):
+        """The phase-script idiom ``create_cage ... >/dev/null`` must still
+        show why a create failed — the #317 regression."""
+        _write_shim(
+            bindir, "agentcage",
+            'echo "Building egress image..."\n'
+            'echo "Error: container isolation is not available on macOS" >&2\n'
+            "exit 42",
+        )
+        result = self._create(bindir, config, ">/dev/null")
+        assert "RC=42" in result.stdout
+        assert "cage create FAILED (exit 42)" in result.stderr
+        # Both streams of the failed command are preserved.
+        assert "container isolation is not available on macOS" in result.stderr
+        assert "Building egress image..." in result.stderr
+
+    def test_failure_names_the_config(self, bindir, config):
+        _write_shim(bindir, "agentcage", "exit 1")
+        result = self._create(bindir, config, ">/dev/null")
+        assert config.name in result.stderr
+
+    def test_failure_with_no_output_still_reports(self, bindir, config):
+        """A create that dies mutely still yields an exit code and a frame,
+        never a bare `FAIL (0/0)`."""
+        _write_shim(bindir, "agentcage", "exit 7")
+        result = self._create(bindir, config, ">/dev/null")
+        assert "RC=7" in result.stdout
+        assert "cage create FAILED (exit 7)" in result.stderr
+        assert "(no output)" in result.stderr
+
+    def test_success_stays_quiet(self, bindir, config):
+        """A successful create prints nothing on either stream, so phases
+        keep their current clean output."""
+        _write_shim(bindir, "agentcage", 'echo "Cage created."\nexit 0')
+        # Deliberately NOT redirecting: output is captured, not streamed.
+        result = self._create(bindir, config, "")
+        assert "RC=0" in result.stdout
+        assert "Cage created." not in result.stdout
+        assert result.stderr == "", result.stderr
+
+
+class TestStartMockDiagnostics:
+    """``start_mock`` must not die mutely when podman has no egress image."""
+
+    @pytest.fixture
+    def bindir(self, tmp_path):
+        b = tmp_path / "fakebin"
+        b.mkdir()
+        return b
+
+    def _start_mock(self, bindir):
+        script = (
+            f'source "{LIB_SH}"\n'
+            "rc=0\n"
+            'start_mock e2e-fake httpbin.org || rc=$?\n'
+            'echo "RC=$rc"\n'
+        )
+        return _run_bash(script, bindir)
+
+    def test_empty_image_store_does_not_kill_the_phase_silently(self, bindir):
+        """`podman images | grep` finding nothing used to abort the whole
+        phase through `set -e`/`pipefail` before printing anything — the
+        exact `FAIL (0/0)` with no output from #317."""
+        _write_shim(
+            bindir, "podman",
+            'case "$1" in\n'
+            "  images) exit 0 ;;\n"
+            '  run) echo "Error: no such image" >&2; exit 125 ;;\n'
+            "  *) exit 0 ;;\n"
+            "esac",
+        )
+        result = self._start_mock(bindir)
+        # It returned an error instead of aborting the caller...
+        assert "RC=1" in result.stdout, result.stdout + result.stderr
+        # ...and said why, naming the cross-image-store cause.
+        assert "no localhost/agentcage-egress:* image" in result.stderr
+        assert "different image store" in result.stderr
+        assert "#317" in result.stderr
+
+    def test_podman_run_error_is_surfaced(self, bindir):
+        """A failed `podman run` reports podman's own message, not just a
+        bare 'failed to start mock container'."""
+        _write_shim(
+            bindir, "podman",
+            'case "$1" in\n'
+            '  images) echo "localhost/agentcage-egress:0.32.0" ;;\n'
+            '  run) echo "Error: network e2e-fake-net not found" >&2; exit 125 ;;\n'
+            "  *) exit 0 ;;\n"
+            "esac",
+        )
+        result = self._start_mock(bindir)
+        assert "RC=1" in result.stdout, result.stdout + result.stderr
+        assert "failed to start mock container" in result.stderr
+        assert "localhost/agentcage-egress:0.32.0" in result.stderr
+        assert "podman run FAILED (exit 125)" in result.stderr
+        assert "network e2e-fake-net not found" in result.stderr
+
+
+class TestPhaseCallersKeepStderr:
+    """Static: callers must not re-swallow what create_cage now emits."""
+
+    # Every phase script except phase 7 (see below). ``phase8_openclaw.sh``
+    # builds its cage from a rendered scaffold, not via ``create_cage``.
+    CALLERS = [
+        "phase1_lifecycle.sh",
+        "phase2_audit_logs.sh",
+        "phase3_secrets.sh",
+        "phase4_domains.sh",
+        "phase5_backup.sh",
+        "phase6_hardening.sh",
+    ]
+
+    @pytest.mark.parametrize("script", CALLERS)
+    def test_caller_does_not_redirect_stderr(self, script):
+        calls = [
+            line.strip()
+            for line in (E2E_DIR / script).read_text().splitlines()
+            if "create_cage " in line and not line.lstrip().startswith("#")
+        ]
+        assert calls, f"{script}: no create_cage call found"
+        for line in calls:
+            assert "2>&1" not in line, (
+                f"{script}: create_cage stderr is swallowed, hiding the "
+                f"#317 failure dump: {line}"
+            )
+
+    def test_phase7_suppression_is_documented(self):
+        """Phase 7 is the one deliberate exception (its create is expected
+        to fail every run); the waiver must carry its reason."""
+        text = (E2E_DIR / "phase7_vm.sh").read_text()
+        assert 'create_cage "$CONFIGS/vm.yaml" >/dev/null 2>&1 || true' in text
+        assert "stderr is suppressed here on purpose" in text


### PR DESCRIPTION
Closes #317.

`bash tests/e2e/run.sh container` on macOS produced `Phase 1: FAIL (0/0, 46s)` and not one word about why. Two independent defects.

## 1. The harness hid the reason (matters on Linux too)

**`create_cage`** folded stderr into stdout (`... 2>&1`) and every phase calls it as `create_cage ... >/dev/null`, so a failing `cage create` was completely silent. Output is now **captured** and dumped to stderr on non-zero rc, framed like `dump_cage_diagnostics`:

```
        ── cage create FAILED (exit 42): basic.yaml ──
          Error: container isolation is not available on macOS
        ── end cage create FAILED (exit 42): basic.yaml ──
```

A *successful* create prints nothing, so the phases keep their current clean output. Capturing inside the helper (rather than asking callers to stop redirecting) is what makes the diagnostic survive the existing `>/dev/null` callers.

**`start_mock`** was worse than silent. This line

```sh
mock_image=$(podman images --format '{{.Repository}}:{{.Tag}}' \
  | grep -E '^localhost/agentcage-egress:' | head -n 1)
```

is a bare assignment under `set -euo pipefail`. With an empty image store, grep exits 1, pipefail propagates, and `set -e` killed the **entire phase right there** — before the `[ -z "$mock_image" ]` fallback could say anything. That is the literal `FAIL (0/0)` with zero output. Now tolerated and reported, naming the cross-image-store cause; `podman run` failures surface podman's own message instead of a bare "failed to start mock container". Same `|| true` treatment for the mock-IP inspect and for the egress-IP inspect inside `dump_cage_diagnostics` (which could otherwise abort a diagnostic dump half-way through).

**`destroy_cage`** deliberately stays quiet — every phase calls it to clear a *possibly non-existent* stale cage, so a non-zero exit carries no signal. Now documented rather than looking like the same bug.

**Callers**: phases 3 and 6 dropped stderr as well and now keep it. Phase 7 is the one deliberate exception (its create is expected to fail every run — the agent image isn't in the VM yet) and carries a comment saying so.

## 2. `run.sh container` cannot work on macOS at all

`container` isolation is rejected by config validation on Darwin (`config.py:987`), and the e2e configs pin no `isolation:` key — so `default_isolation()` resolved them to **apple-container** on macOS 26+ Apple Silicon. `cage create` built the egress image into apple-container's image store while `start_mock` looked for it via `podman images` — a different, empty store — and the phase died somewhere unrelated.

`run.sh` now refuses phases 1-6 and 8 up front on Darwin:

```
ERROR: phase(s) 1 2 3 4 5 6 need 'container' isolation (rootless podman),
       which agentcage does not support on macOS — config validation
       rejects it, and these phases would otherwise run against a
       different backend whose images podman cannot see (issue #317).

Supported on macOS:
  bash tests/e2e/run.sh vm       # phase 7 — Lima VM mode
  bash tests/e2e/phase_apple.sh  # apple-container (macOS 26+ Apple Silicon)

For the container phases, use a Linux host (or CI).
```

Scoped deliberately: `run.sh vm` (phase 7) and `phase_apple.sh` are supported on macOS and are **not** blocked, and on Linux the guard never fires — `.github/workflows/e2e.yml` is unaffected. The guard runs before the stale-cage sweep, so it touches no backend at all.

## Tests

25 new tests in `tests/test_e2e_harness_diagnostics.py`, following the established `test_phase_apple_skip.py` pattern: the real shell scripts driven under a temp `PATH` of fake `uname`/`agentcage`/`podman`/`envsubst` shims, plus static assertions for the branches that cannot be exercised without launching a real phase (e.g. "`vm` is not blocked" — asserting that by running `run.sh vm` would launch phase 7 against the host's Lima). The guard tests use tripwire shims to assert **no backend command is invoked** before the refusal.

- `uv run pytest`: **12 failed, 2008 passed, 39 skipped, 6 errors**
- baseline on unmodified `origin/master` @ `3e883e0` (same macOS host): **12 failed, 1983 passed, 39 skipped, 6 errors**
- delta: **+25 passed, zero change to failures/errors**. The 12 failures + 6 errors are pre-existing macOS-host backend noise (`test_egress_image` needs podman, the rest assume a Linux/systemd backend); all pass on Linux CI.

`shellcheck -S style tests/e2e/*.sh` reports no new findings — the remaining SC1091/SC2034/SC2001/SC2086/SC2164 hits are all pre-existing and none fall in the changed blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
