### PR TITLE
[#318] feat(apple-container): honor container.tmpfs so the #170/#173 workspace masks apply

### DIFF
--- a/docs/explain/isolation-modes.md
+++ b/docs/explain/isolation-modes.md
@@ -47,6 +47,8 @@ For the threat-by-threat matrix, see [Security model](security-model.md).
 
 **apple-container — most edits need `cage update`.** Allowlist, command, env, secret-injection rules, capture, and autostart are baked into the wrapper image at build time. `domain add / rm` auto-rebuilds; other edits need an explicit `cage update`.
 
+**apple-container — tmpfs options are not applied.** `container.tmpfs` mounts are created, including the scaffold masks over `/workspace/.git/hooks/` and `/workspace/.claude/`, but Apple's runtime takes a bare path so `noexec`, `nosuid`, `nodev` and `size=` are dropped. Set `container.memory` to bound an unlimited tmpfs. See [tmpfs mounts](../reference/configuration.md#tmpfs-mounts).
+
 **apple-container — `cage backup --include-secrets` is unsupported.** Secrets are provided once at `cage create` and never reconciled into a portable backup. The backup manifest records the env-var names; re-set them on the restore host with `--set-secret`.
 
 ## Related

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -130,6 +130,13 @@ agent cannot plant a git hook that a later host-side `git commit` executes,
 nor a project `.claude/settings.json` `hooks` block that another cage honors
 on launch.
 
+A mask over a path that does not exist on the host creates it there — a bind
+shares inodes with its source, so the runtime's mount-point `mkdir` writes
+through. agentcage records which of those directories were absent when the
+cage started and removes them again, while still empty, on `cage stop` and
+`cage destroy`. Directories you already had, and any that gained content, are
+left alone.
+
 **Apple container applies the mounts but not their options.** Apple's
 `container run --tmpfs` takes a bare path, so `noexec`, `nosuid`, `nodev` and
 `size=` are dropped and each mount lands with kernel-default tmpfs semantics.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -48,7 +48,7 @@ Settings under `container:`.
 | `volumes` | `list[string]` | `[]` | Host bind specs in `host:container[:options]` form. Host paths are resolved to absolute paths at generation time; regenerate the deployment if a source moves. Add the agentcage-only `np` option to make one bind non-persistent; see [Non-persistent bind mounts](#non-persistent-bind-mounts). |
 | `env` | `map[string, string]` | `{}` | Environment variables. `${VAR}` references are expanded from your current shell environment at generation time — the values are baked into the generated quadlet files, not resolved at container start. |
 | `named_volumes` | `map[string, string]` | `{}` | Podman named volume to mount spec (e.g. `mydata: "/data:rw"`). Not resolved with realpath. |
-| `tmpfs` | `list[string]` | `[]` | tmpfs mount specs (useful for writable areas on read-only containers). |
+| `tmpfs` | `list[string]` | `[]` | tmpfs mount specs in `path[:options]` form — useful for writable areas on read-only containers, and for masking a path inside a bind mount. See [tmpfs mounts](#tmpfs-mounts). |
 | `ports` | `list[string]` | `[]` | Published port specs — see [Ports](#ports). |
 | `podman_secrets` | `list[string]` | `[]` | [Podman secret](https://docs.podman.io/en/latest/markdown/podman-secret.1.html) names (injected as env vars). |
 | `user` | `string` | `"1000:1000"` | UID:GID for the cage workload (Quadlet `User=`). Set to `""` to use the image default. Interactive `agentcage run` / `cage exec` / `cage shell` sessions are pinned to uid 1000 (or `0` with `--as-root`) regardless of this field — matching the apple-container backend's behavior. See [Podman `--user`](https://docs.podman.io/en/latest/markdown/podman-run.1.html). |
@@ -107,6 +107,36 @@ observe the target still empty.
 Use an ordinary `ro` bind instead if the cage does not need to edit the data.
 Use `container.tmpfs` for empty scratch space that does not need initial
 contents from the host.
+
+### tmpfs mounts
+
+Each `container.tmpfs` entry is `path[:options]`. The cage sees an empty,
+writable directory at `path`; everything written there is discarded when the
+cage stops.
+
+A tmpfs entry can also target a path *inside* a bind mount, which masks the
+host content underneath it. The built-in scaffolds use this to close two
+cage-to-host paths:
+
+```yaml
+container:
+  tmpfs:
+    - "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M"
+    - "/workspace/.claude/:rw,noexec,nosuid,nodev,size=64M"
+```
+
+The cage can write to both paths, but nothing reaches the host, so a caged
+agent cannot plant a git hook that a later host-side `git commit` executes,
+nor a project `.claude/settings.json` `hooks` block that another cage honors
+on launch.
+
+**Apple container applies the mounts but not their options.** Apple's
+`container run --tmpfs` takes a bare path, so `noexec`, `nosuid`, `nodev` and
+`size=` are dropped and each mount lands with kernel-default tmpfs semantics.
+The masks above still work — the protection comes from the overlay hiding the
+bind, not from `noexec`. What is lost is the size cap: a tmpfs the cage fills
+is bounded only by the cage VM's memory, so set `container.memory` on this
+backend. `agentcage cage create` warns and names the affected paths.
 
 ### Ports
 

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -61,6 +61,7 @@ from agentcage.config import Config
 from agentcage.quadlets import _effective_port_policy
 from agentcage.volume_mounts import (
     is_non_persistent_volume,
+    mask_mountpoint_dirs,
     split_volume_spec,
     validate_non_persistent_volume,
 )
@@ -297,6 +298,113 @@ class AppleContainerBackend:
 
     def _state_dir(self, name: str) -> Path:
         return Path(os.path.expanduser("~/.config/agentcage/apple-container")) / name
+
+    def _mask_state_path(self, name: str) -> Path:
+        """Bookkeeping file for tmpfs-mask mount points created on the host.
+
+        Written by ``_record_mask_mountpoints`` immediately before
+        ``container run`` and consumed by ``_cleanup_mask_mountpoints`` on
+        stop / destroy. Lives inside the per-cage state dir so
+        ``destroy_resources``'s ``rmtree`` disposes of any leftover.
+        """
+        return self._state_dir(name) / "mask-mountpoints.json"
+
+    def _record_mask_mountpoints(
+        self, name: str, tmpfs_specs: list[str], volume_entries: list[str],
+    ) -> None:
+        """Record which tmpfs-mask mount points are ABSENT on the host now.
+
+        A ``container.tmpfs`` target nested under a host bind makes the
+        in-guest OCI runtime create the mount point, and a bind shares inodes
+        with its source, so that ``mkdir -p`` lands in the operator's project
+        directory on the host: masking ``/workspace/.git/hooks/`` on a
+        non-git project leaves a stray host ``.git/hooks/`` that the
+        ubiquitous ``test -d .git`` idiom misreads as a repository (#320).
+
+        Pre-#318 apple-container never wired ``container.tmpfs`` into
+        ``container run``, which is why #320's quadlet-side fix concluded
+        this backend was unaffected. Wiring tmpfs through made it affected,
+        so this is the same bookkeeping the quadlet backend does with an
+        ``ExecStartPre``/``ExecStopPost`` pair — there is no such hook here,
+        so it is Python-side. The mask itself stays unconditional: dropping
+        it when ``.git`` is absent would reopen the #170 pivot for a ``.git``
+        created later.
+
+        Only paths that do not exist right now are recorded, so a
+        pre-existing directory is never a removal candidate. A symlink
+        counts as existing (``lexists``) — mirrors the quadlet hook's
+        ``[ -e ] || [ -L ]`` skip.
+        """
+        mount_targets: list[tuple[str, str]] = []
+        for entry in volume_entries:
+            host_src, target, _opts = split_volume_spec(entry)
+            if not target:
+                continue
+            # An ``np`` bind's target is a tmpfs seeded from a read-only
+            # lowerdir; writes there never reach the host, so it must not
+            # attribute a nested mask to its host source.
+            mount_targets.append(
+                (target, "" if is_non_persistent_volume(entry) else host_src)
+            )
+        absent: dict[str, list[str]] = {}
+        for root, dirs in mask_mountpoint_dirs(tmpfs_specs, mount_targets).items():
+            # `dirs` is deepest-first; keep that order for teardown.
+            missing = [d for d in dirs if not os.path.lexists(d)]
+            if missing:
+                absent[root] = missing
+        state = self._mask_state_path(name)
+        if not absent:
+            # Nothing to clean up — drop any stale record from an earlier
+            # start so teardown can't act on outdated bookkeeping.
+            state.unlink(missing_ok=True)
+            return
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text(json.dumps(absent, indent=2))
+
+    def _cleanup_mask_mountpoints(self, name: str) -> None:
+        """Remove the still-empty mask mount points ``start()`` created.
+
+        ``rmdir`` is the whole "only if empty" safety story: a mount point
+        the operator (or the workload, through a persistent bind) put content
+        into is kept, with a warning. Removal is additionally contained to
+        the bind source recorded at start and re-checked against
+        ``realpath`` here, so a symlink swapped in after start cannot
+        redirect a removal out of the project directory.
+
+        Best-effort and idempotent throughout — a missing/unreadable state
+        file (start hook never ran, older cage, hand-deleted state) is a
+        silent no-op, and nothing here may fail a stop or destroy.
+        """
+        state = self._mask_state_path(name)
+        try:
+            recorded = json.loads(state.read_text())
+        except (OSError, ValueError):
+            return
+        if not isinstance(recorded, dict):
+            state.unlink(missing_ok=True)
+            return
+        for root, dirs in sorted(recorded.items()):
+            if not isinstance(root, str) or not isinstance(dirs, list):
+                continue
+            # `realpath` on a non-existent path resolves lexically, matching
+            # the quadlet hook's `realpath -m`.
+            real_root = os.path.realpath(root)
+            for d in dirs:
+                if not isinstance(d, str):
+                    continue
+                if not os.path.realpath(d).startswith(real_root + os.sep):
+                    continue
+                if os.path.islink(d) or not os.path.isdir(d):
+                    continue
+                try:
+                    os.rmdir(d)
+                except OSError:
+                    click.echo(
+                        f"warning: keeping {d} (created as a tmpfs mask "
+                        f"mount point, but not empty)",
+                        err=True,
+                    )
+        state.unlink(missing_ok=True)
 
     def logs_dir(self, name: str) -> Path:
         """Per-cage logs dir on the host, bind-mounted into the egress microVM.
@@ -1640,6 +1748,13 @@ class AppleContainerBackend:
             if tmpfs_target in np_tmpfs_targets:
                 continue
             cage_argv += ["--tmpfs", tmpfs_target]
+        # A mask nested under a host bind makes the in-guest OCI runtime
+        # mkdir the mount point THROUGH the bind, onto the host (#320).
+        # Record which of those dirs are absent right now so stop/destroy
+        # can retire exactly those, and only while still empty.
+        self._record_mask_mountpoints(
+            name, meta.get("tmpfs") or [], volume_entries,
+        )
         # Apple's --cpus / --memory normalization (uppercase suffix, ceil
         # fractions). Backward-compat fallback to pre-0.20.6 `mem_mb` int.
         cpus_raw = meta.get("cpus")
@@ -1859,6 +1974,10 @@ class AppleContainerBackend:
         """Stop both microVMs (cage + egress)."""
         ac_cli.run(["stop", name], check=False)
         ac_cli.run(["stop", f"{name}-egress"], check=False)
+        # Retire the host dirs the tmpfs masks materialized through the
+        # workspace bind (#320). After the cage VM is down, so a still-live
+        # mount can't make an empty dir look occupied.
+        self._cleanup_mask_mountpoints(name)
 
     def restart(self, name: str) -> None:
         self.stop(name)
@@ -1887,6 +2006,10 @@ class AppleContainerBackend:
                 r = ac_cli.run(["delete", "-f", cname], check=False)
                 if r.returncode == 0:
                     removed.append(f"container:{cname}")
+        # Mask mount points created through the workspace bind (#320).
+        # Runs before the state rmtree below, which would otherwise take the
+        # bookkeeping file with it. No-op when stop() already handled it.
+        self._cleanup_mask_mountpoints(name)
         # Per-cage network. `network delete` is idempotent in Apple's CLI
         # but we only care to report when it actually existed; rely on the
         # rc to decide whether to add it to `removed`.

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -428,6 +428,55 @@ class AppleContainerBackend:
             out.append(f"{real}:{parts[1]}")
         return out
 
+    @staticmethod
+    def _tmpfs_targets(raw_entries: list[str]) -> list[str]:
+        """Normalize ``container.tmpfs`` specs into bare cage paths.
+
+        Apple's ``container run --tmpfs`` takes a BARE PATH — at container
+        1.0.0 the whole argument is the destination, so Docker's
+        ``path:opts`` form would mount a tmpfs at a directory literally
+        named ``path:opts``. (1.3.0 learned to split ``path:opts``, but we
+        target the older contract too, so the option list is dropped on
+        every version.) That means the scaffolds'
+        ``rw,noexec,nosuid,nodev,size=64M`` is NOT forwarded: the mount
+        lands with kernel-default tmpfs options — writable, exec/suid/dev
+        permitted, and bounded only by the cage VM's memory. This is not
+        silent: ``validate_config`` warns per cage about exactly which
+        options were dropped (see config.py's apple-container block).
+
+        Returns absolute, de-duplicated, trailing-slash-stripped targets.
+        Entries that are not absolute paths, or that ask for ``/``
+        (a tmpfs over the rootfs would hide the whole image), are skipped
+        with a warning rather than handed to the runtime.
+        """
+        out: list[str] = []
+        seen: set[str] = set()
+        for entry in raw_entries:
+            target = entry.split(":", 1)[0].strip()
+            # `/workspace/.git/hooks/` -> `/workspace/.git/hooks`; Apple
+            # lexically normalizes destinations too, so strip here to keep
+            # our own dedupe honest.
+            normalized = target.rstrip("/")
+            if not target.startswith("/"):
+                click.echo(
+                    f"warning: skipping tmpfs {entry!r} on apple-container "
+                    "(target must be an absolute path)",
+                    err=True,
+                )
+                continue
+            if not normalized:
+                click.echo(
+                    f"warning: skipping tmpfs {entry!r} on apple-container "
+                    "(a tmpfs over `/` would hide the cage image's rootfs)",
+                    err=True,
+                )
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            out.append(normalized)
+        return out
+
     def _launchd_plist_path(self, name: str) -> Path:
         """Host path of the per-cage launchd plist.
 
@@ -1087,6 +1136,14 @@ class AppleContainerBackend:
                 # already-absolute paths, so start() re-running it is a safe
                 # revalidation, not a re-expansion.
                 "volumes": self._user_volume_argv(config.container.volumes),
+                # User-declared ``container.tmpfs:`` targets. Persisted raw
+                # (spec string, options included) so a future agentcage that
+                # can forward options doesn't need a metadata migration;
+                # start() normalizes to the bare paths Apple's --tmpfs
+                # accepts. Pre-#318 this field was dropped entirely, which
+                # silently disabled the #170 /workspace/.git/hooks/ and #173
+                # /workspace/.claude/ masks on this backend.
+                "tmpfs": list(config.container.tmpfs or []),
                 # User-defined ``container.env:`` entries. Apple's
                 # `container run` accepts `-e KEY=VAL` like podman. The
                 # container backend wires these via quadlets.py:338;
@@ -1537,6 +1594,7 @@ class AppleContainerBackend:
         # and copied to a tmpfs at its requested target. Other binds are
         # passed directly through unchanged.
         copies: list[str] = []
+        np_tmpfs_targets: set[str] = set()
         for idx, vol_entry in enumerate(volume_entries):
             host_src, target, _opts = split_volume_spec(vol_entry)
             if not target:
@@ -1550,11 +1608,38 @@ class AppleContainerBackend:
                 # Apple `container run --tmpfs` takes a bare path only;
                 # Docker's `path:opts` syntax is interpreted literally.
                 cage_argv += ["--tmpfs", target]
+                np_tmpfs_targets.add(target.rstrip("/") or "/")
             copies.append(f"{lower}\t{target}")
         if copies:
             cage_argv += [
                 "-e", "AGENTCAGE_NONPERSISTENT_COPIES=" + "\n".join(copies),
             ]
+        # User-declared `container.tmpfs:` entries (#318 / the tmpfs half of
+        # the #120 parity gap). Pre-0.32 these were dropped on this backend,
+        # which silently disabled the claude-code scaffold's #170
+        # `/workspace/.git/hooks/` and #173 `/workspace/.claude/` masks — the
+        # one backend macOS picks by default was the one without them.
+        #
+        # Ordering: these masks overlay a path INSIDE the `/workspace` bind,
+        # so the bind must be mounted first or the tmpfs is shadowed. argv
+        # order does not decide that — Apple hands `--volume` and `--tmpfs`
+        # to the guest in ONE `spec.mounts` array that containerization
+        # sorts by destination depth before the in-guest OCI runtime applies
+        # it (`cleanAndSortMounts` / `sortMountsByDestinationDepth` in
+        # apple/containerization's LinuxContainer.swift, present since the
+        # 0.33.x pinned by container 1.0.0). `/workspace` (depth 1) is
+        # therefore always mounted before `/workspace/.git/hooks` (depth 3),
+        # and the runtime creates the missing mountpoint. We still emit
+        # after the volumes so the argv reads in mount order.
+        for tmpfs_target in self._tmpfs_targets(meta.get("tmpfs") or []):
+            # An `np` bind already owns this target with a tmpfs of its own
+            # (seeded from the host lowerdir by cage-init stage C'); a second
+            # --tmpfs would be a redundant destination that Apple dedupes
+            # anyway. Skip it so the seeded copy is not masked by an empty
+            # mount on a runtime that keeps both.
+            if tmpfs_target in np_tmpfs_targets:
+                continue
+            cage_argv += ["--tmpfs", tmpfs_target]
         # Apple's --cpus / --memory normalization (uppercase suffix, ceil
         # fractions). Backward-compat fallback to pre-0.20.6 `mem_mb` int.
         cpus_raw = meta.get("cpus")

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -1170,19 +1170,6 @@ def validate_config(config: Config) -> list[str]:
             "proxy (default-deny)."
         )
 
-    def _is_scaffold_default_tmpfs(entries: list[str]) -> bool:
-        """A single entry whose target is /tmp matches the stock scaffold
-        default (``tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]``). On
-        apple-container the cage's /tmp lives in the RW rootfs, so the
-        functional outcome (writable /tmp for the workload) is the same;
-        the noexec/nosuid hardening flags aren't enforced but no scaffold
-        relies on them. Multiple entries OR a non-``/tmp`` target IS
-        operator intent that this backend can't honor — keep warning."""
-        if len(entries) != 1:
-            return False
-        target = entries[0].split(":", 1)[0]
-        return target == "/tmp"
-
     # Apple-container backend: surface config knobs that the backend doesn't
     # respect today (silently dropped pre-this-warning). Tracked as the full
     # parity work in #120. Plain `validate_config` warnings so the user sees
@@ -1191,8 +1178,9 @@ def validate_config(config: Config) -> list[str]:
     # unconditionally for the container backend. The right long-term fix is
     # either to make the supervisor honor them or to make the scaffold
     # cage.yaml.j2 templates omit them on apple-container; until then, this
-    # tells the operator their `tmpfs:` / `volumes:` / `add_capabilities:`
-    # entries are decorative on this backend.
+    # tells the operator which of their entries are decorative on this
+    # backend. `volumes:` and (since #318) `tmpfs:` are NOT in that set —
+    # both are wired through `container run` argv now.
     if config.isolation == "apple-container":
         # Each entry: (field-path, predicate-on-config-that-says-"non-default",
         # human-readable summary of what the field's effect would be elsewhere).
@@ -1205,22 +1193,11 @@ def validate_config(config: Config) -> list[str]:
             # `_user_volume_argv`.
             ("container.named_volumes", bool(config.container.named_volumes),
              "podman named volumes (no equivalent on apple-container)"),
-            # Stock scaffold ships `tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]`
-            # as defense-in-depth for the container backend. On apple-
-            # container the cage's /tmp lives in the RW rootfs — the
-            # workload functionally gets a writable /tmp, and the noexec
-            # /nosuid hardening flags aren't enforced. A single /tmp
-            # entry is the documented scaffold default; treating it as
-            # "compatible enough" silences the noisiest warning on every
-            # default cage. Anything else (multiple entries, non-/tmp
-            # targets like /run, /var/cache) still warns because those
-            # do represent operator intent that this backend can't honor.
-            ("container.tmpfs",
-             bool(config.container.tmpfs) and not _is_scaffold_default_tmpfs(
-                 config.container.tmpfs
-             ),
-             "tmpfs mounts (apple-container's rootfs is RW; explicit tmpfs entries "
-             "are not wired)"),
+            # container.tmpfs is no longer silently dropped — #318 wired it
+            # to per-entry `container run --tmpfs <path>` argv on the cage
+            # microVM (backends/apple_container.py `_tmpfs_targets`). Only
+            # the OPTION list is lost, and that gets its own precise warning
+            # below rather than a blanket "has no effect".
             ("container.podman_secrets", bool(config.container.podman_secrets),
              "Podman secret refs (no host Podman secret store on apple-container; "
              "use cage.yaml `secret_injection:` or env: instead)"),
@@ -1293,44 +1270,51 @@ def validate_config(config: Config) -> list[str]:
                     f"{field_path}: silently has no effect on apple-container "
                     f"({summary}). See issue #120 for the parity plan."
                 )
-        # The generic ``container.tmpfs`` warning above is harmless-
-        # parity noise for most tmpfs targets (an extra /run, /var/cache
-        # overlay that the RW rootfs already covers functionally). But the
-        # #170 / #173 workspace executable-config masks are SECURITY
-        # controls, not /tmp-parity convenience: without them a caged agent
-        # can plant a host git hook (#170 cage→host pivot) or a project
-        # .claude/settings.json hooks block (#173 cage→cage injection).
-        # An operator who has learned to ignore the generic tmpfs warning
-        # as "harmless /tmp parity" would silently be running an OPEN
-        # cage→host pivot on apple-container. Call out those specific
-        # dropped entries by name so the residual exposure is unmissable,
-        # instead of folding them into the generic ``container.tmpfs``
-        # warning an operator may already tune out.
-        if config.container.tmpfs:
-            for entry in config.container.tmpfs:
-                target = entry.split(":", 1)[0]
-                if target == "/workspace/.git/hooks/":
-                    warnings.append(
-                        f"container.tmpfs: SECURITY-RELEVANT drop on "
-                        f"apple-container — the #170 cage→host git-hook "
-                        f"pivot mask (/workspace/.git/hooks/) is NOT "
-                        f"applied on apple-container — a caged agent can "
-                        f"still plant a host git hook that the next "
-                        f"host-side `git commit` runs as the host user. "
-                        f"The pivot remains exploitable. "
-                        f"See #120 for tmpfs parity."
-                    )
-                elif target == "/workspace/.claude/":
-                    warnings.append(
-                        f"container.tmpfs: SECURITY-RELEVANT drop on "
-                        f"apple-container — the #173 cage→cage "
-                        f"hooks-injection mask (/workspace/.claude/) is "
-                        f"NOT applied on apple-container — a caged agent "
-                        f"can still plant a project .claude/settings.json "
-                        f"`hooks` block that Claude Code in another cage "
-                        f"honors on launch. The injection chain remains "
-                        f"exploitable. See #120 for tmpfs parity."
-                    )
+        # `container.tmpfs` IS applied on apple-container since #318:
+        # `start()` emits one `container run --tmpfs <path>` per entry, and
+        # Apple sorts the container's mounts by destination depth before the
+        # in-guest OCI runtime applies them, so `/workspace/.git/hooks`
+        # (depth 3) lands ON TOP of the `/workspace` bind (depth 1). The
+        # #170 cage->host git-hook pivot mask and the #173 cage->cage
+        # `.claude/settings.json` injection mask therefore take effect here.
+        #
+        # What is still NOT honored is the OPTION list. Apple's `--tmpfs`
+        # takes a bare path (container 1.0.0 treats the whole argument as
+        # the destination), so `rw,noexec,nosuid,nodev,size=64M` is dropped
+        # and the mount lands with kernel-default tmpfs semantics: writable,
+        # exec/suid/dev permitted, and sized only by the cage VM's memory.
+        # Be precise about that split. The masks' pivot defense comes from
+        # the overlay itself, not from `noexec` (the planted hook would
+        # execute on the HOST, outside the cage's mount namespace, where an
+        # in-cage `noexec` is irrelevant) — but an operator who wrote
+        # `size=64M` deserves to know it is not enforced, and an unbounded
+        # tmpfs is a memory-exhaustion vector against the cage VM.
+        _tmpfs_dropped_opts = [
+            target for target, _, options in (
+                entry.partition(":") for entry in config.container.tmpfs
+            )
+            if options
+        ]
+        if _tmpfs_dropped_opts:
+            _masks = [
+                t for t in _tmpfs_dropped_opts
+                if t.rstrip("/") in ("/workspace/.git/hooks", "/workspace/.claude")
+            ]
+            _mask_note = (
+                " The mask entries (%s) do still block their cage→host / "
+                "cage→cage pivot: that protection comes from the tmpfs "
+                "overlaying the bind, not from `noexec`."
+                % ", ".join(_masks)
+            ) if _masks else ""
+            warnings.append(
+                "container.tmpfs: the mounts ARE applied on apple-container, "
+                "but their OPTIONS are not — Apple's `container run --tmpfs` "
+                "takes a bare path, so %s get kernel-default tmpfs semantics: "
+                "noexec/nosuid/nodev are NOT enforced and any `size=` cap is "
+                "ignored (an unbounded tmpfs can exhaust the cage VM's "
+                "memory; bound it with container.memory).%s See #120."
+                % (", ".join(_tmpfs_dropped_opts), _mask_note)
+            )
         # secret_injection.transform now runs end-to-end on apple-container
         # — the in-cage mitmproxy addon loads the same data/proxy/transforms
         # registry the container backend uses. KNOWN_TRANSFORMS is the

--- a/src/agentcage/volume_mounts.py
+++ b/src/agentcage/volume_mounts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 
 # Keep np deliberately portable across Podman and apple-container. In
 # particular, Podman's overlay ``O`` cannot compose with z/Z, U mutates the
@@ -52,3 +54,73 @@ def validate_non_persistent_volume(spec: str) -> None:
             f"volume {spec!r}: the np option cannot be combined with "
             f"{joined}; only rw,np is supported"
         )
+
+
+def mask_mountpoint_dirs(
+    tmpfs: list[str],
+    mount_targets: list[tuple[str, str]],
+) -> dict[str, list[str]]:
+    """Map bind-mount host source -> host dirs a ``tmpfs:`` mask materializes.
+
+    A ``tmpfs:`` entry whose target sits *under* a host bind-mount forces the
+    OCI runtime to create the mount point, and because a bind shares inodes
+    with its source, that ``mkdir -p`` lands in the operator's project
+    directory on the host. The scaffold masks are the common case: masking
+    ``/workspace/.git/hooks/`` on a project that is not a git repo leaves a
+    stray host ``.git/hooks/``, which makes the ubiquitous ``test -d .git``
+    idiom misreport the directory as a repository (issue #320).
+
+    The mask itself stays unconditional — dropping it when ``.git`` is absent
+    would reopen the #170 cage->host git-hook pivot for any ``.git`` created
+    later. Instead the caller records which of these paths were absent
+    immediately before container start and removes exactly those, and only
+    while still empty, on teardown.
+
+    Args:
+        tmpfs: Raw ``container.tmpfs`` specs (``target[:options]``).
+        mount_targets: ``(container_target, host_source)`` for every mount the
+            backend emits, where *host_source* is empty for mounts that do not
+            write through to the host (named volumes, ``np`` mounts whose
+            writes land in an overlay upperdir or a tmpfs). Longest-prefix
+            matching runs over the whole list so that a mask under, say, a
+            named volume nested inside a bind is correctly attributed to the
+            named volume and therefore skipped.
+
+    Returns:
+        ``{host_source: [host_path, ...]}`` with each list ordered deepest
+        first, so removing ``<project>/.git/hooks`` is attempted before the
+        ``<project>/.git`` parent that the same mask also created.
+    """
+    normalized = [
+        (target.rstrip("/") or "/", source)
+        for target, source in mount_targets
+        if target.startswith("/")
+    ]
+    result: dict[str, list[str]] = {}
+    for spec in tmpfs:
+        target = spec.split(":", 1)[0].rstrip("/")
+        if not target.startswith("/"):
+            continue
+        best_target = ""
+        best_source = ""
+        for mount_target, source in normalized:
+            if target != mount_target and not target.startswith(mount_target + "/"):
+                continue
+            if len(mount_target) >= len(best_target):
+                best_target, best_source = mount_target, source
+        # No enclosing mount (the mount point is created in the container's
+        # own writable layer), the mask covers the whole mount (nothing to
+        # create), or the enclosing mount does not reach the host.
+        if not best_source or target == best_target:
+            continue
+        parts = [p for p in target[len(best_target):].split("/") if p]
+        if not parts or any(p in (".", "..") for p in parts):
+            continue
+        dirs = result.setdefault(best_source, [])
+        for depth in range(len(parts), 0, -1):
+            path = os.path.join(best_source, *parts[:depth])
+            if path not in dirs:
+                dirs.append(path)
+    for dirs in result.values():
+        dirs.sort(key=lambda path: path.count("/"), reverse=True)
+    return result

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2146,6 +2146,139 @@ def test_start_routes_np_file_to_exact_target_without_tmpfs(tmp_path, monkeypatc
 
 
 # ---------------------------------------------------------------------------
+# container.tmpfs (#318 — the tmpfs half of the #120 parity gap)
+# ---------------------------------------------------------------------------
+
+def test_unit_json_persists_container_tmpfs(tmp_path, monkeypatch):
+    """`generate_units` must persist `container.tmpfs` into the unit JSON —
+    start() is meta-driven (no Config), so an unpersisted field is a silently
+    dropped mount. Persisted RAW (options included) so a future agentcage
+    that can forward options needs no metadata migration."""
+    from agentcage.config import Config, ContainerConfig
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = Config(
+        name="demo",
+        isolation="apple-container",
+        container=ContainerConfig(
+            image="localhost/test:latest",
+            tmpfs=[
+                "/tmp:rw,noexec,nosuid,size=256M",
+                "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M",
+            ],
+        ),
+    )
+    out = AppleContainerBackend().generate_units(
+        cfg, "/tmp/proxy-config.yaml", "/tmp/patches", "demo"
+    )
+    assert json.loads(out["demo.json"])["tmpfs"] == [
+        "/tmp:rw,noexec,nosuid,size=256M",
+        "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M",
+    ]
+
+
+def test_start_emits_container_tmpfs_as_bare_paths(tmp_path, monkeypatch):
+    """#318: `container.tmpfs` entries reach the cage VM's `container run`
+    argv as `--tmpfs <bare path>`.
+
+    Bare path, not `path:opts`: Apple `container` 1.0.0 treats the WHOLE
+    --tmpfs argument as the destination, so passing the scaffold's
+    `rw,noexec,nosuid,nodev,size=64M` suffix would mount a tmpfs at a
+    directory literally named `/workspace/.git/hooks/:rw,noexec,...`. The
+    trailing slash is stripped for the same reason.
+
+    This is what makes the #170 (cage->host git-hook pivot) and #173
+    (project .claude/settings.json injection) masks real on the backend
+    macOS picks by default."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+            "volumes": [f"{workspace}:/workspace:rw"],
+            "tmpfs": [
+                "/tmp:rw,noexec,nosuid,size=256M",
+                "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M",
+                "/workspace/.claude/:rw,noexec,nosuid,nodev,size=64M",
+            ],
+        },
+    )
+    backend.start("demo", quiet=True)
+    cage_argv = _cage_run_argv(captured)
+    tmpfs_args = [
+        cage_argv[i + 1] for i, arg in enumerate(cage_argv[:-1])
+        if arg == "--tmpfs"
+    ]
+    assert tmpfs_args == [
+        "/tmp", "/workspace/.git/hooks", "/workspace/.claude",
+    ]
+    # The bind the masks overlay is still mounted; Apple depth-sorts the
+    # merged mount list, so the bind lands before its nested tmpfs.
+    assert f"{workspace}:/workspace:rw" in cage_argv
+    # Option strings must never leak into the argv.
+    assert not any("noexec" in arg for arg in cage_argv)
+    assert not any("size=" in arg for arg in cage_argv)
+    # The egress sibling gets no user tmpfs — its mount set is fixed.
+    assert "--tmpfs" not in _egress_run_argv(captured)
+
+
+def test_start_without_container_tmpfs_emits_no_tmpfs(tmp_path, monkeypatch):
+    """No `tmpfs:` in the cage.yaml → no --tmpfs argv. Guards against a
+    stray empty-string mount from a missing/None metadata field."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+        },
+    )
+    backend.start("demo", quiet=True)
+    assert "--tmpfs" not in _cage_run_argv(captured)
+
+
+def test_start_does_not_double_tmpfs_an_np_volume_target(tmp_path, monkeypatch):
+    """An `np` bind already provides a tmpfs at its target, seeded from the
+    host lowerdir by cage-init stage C'. A `container.tmpfs` entry naming the
+    same target must not add a second, EMPTY mount over the seeded copy."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    np_host = tmp_path / "np-src"
+    np_host.mkdir()
+    backend, captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+            "volumes": [f"{np_host}:/workspace:rw,np"],
+            "tmpfs": ["/workspace/:rw,size=64M"],
+        },
+    )
+    backend.start("demo", quiet=True)
+    cage_argv = _cage_run_argv(captured)
+    assert [
+        cage_argv[i + 1] for i, arg in enumerate(cage_argv[:-1])
+        if arg == "--tmpfs"
+    ] == ["/workspace"]
+
+
+def test_tmpfs_targets_normalizes_dedupes_and_rejects_unsafe():
+    """`_tmpfs_targets` is the single normalizer for this backend: strip the
+    option suffix and trailing slashes, drop duplicates, and refuse targets
+    the runtime must never be handed — a relative path, or `/` (a tmpfs over
+    the rootfs would hide the cage image)."""
+    assert AppleContainerBackend._tmpfs_targets([
+        "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M",
+        "/workspace/.git/hooks",          # duplicate after normalization
+        "/tmp",
+        "relative/path:rw",               # not absolute
+        "/:rw",                           # rootfs
+        "/",
+    ]) == ["/workspace/.git/hooks", "/tmp"]
+
+
+# ---------------------------------------------------------------------------
 # cage-init.sh stage C' — non-persistent seed ownership
 # ---------------------------------------------------------------------------
 

--- a/tests/test_apple_container.py
+++ b/tests/test_apple_container.py
@@ -2279,6 +2279,199 @@ def test_tmpfs_targets_normalizes_dedupes_and_rejects_unsafe():
 
 
 # ---------------------------------------------------------------------------
+# tmpfs mask mount points created through the workspace bind (#320)
+# ---------------------------------------------------------------------------
+
+def _start_with_masks(tmp_path, monkeypatch, project):
+    """start() a cage whose scaffold masks sit under a `/workspace` bind."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+            "volumes": [f"{project}:/workspace:rw"],
+            "tmpfs": [
+                "/tmp:rw,noexec,nosuid,size=256M",
+                "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M",
+                "/workspace/.claude/:rw,noexec,nosuid,nodev,size=64M",
+            ],
+        },
+    )
+
+
+def test_stop_removes_mask_mountpoints_created_on_a_non_git_project(
+    tmp_path, monkeypatch,
+):
+    """#320, apple-container half: wiring container.tmpfs (#318) means the
+    in-guest OCI runtime mkdir's each mask mount point, and a bind shares
+    inodes with its source — so on a project that is not a git repo the
+    host gains a stray `.git/hooks/` that `test -d .git` misreads as a
+    repository. stop() must retire exactly the dirs that were absent at
+    start, deepest-first including the implied `.git` parent."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "file.txt").write_text("x")
+    backend, _captured = _start_with_masks(tmp_path, monkeypatch, project)
+
+    backend.start("demo", quiet=True)
+    # Simulate the runtime's mkdir -p landing on the host through the bind.
+    (project / ".git" / "hooks").mkdir(parents=True)
+    (project / ".claude").mkdir()
+
+    backend.stop("demo")
+    assert not (project / ".git").exists()
+    assert not (project / ".claude").exists()
+    # Untouched project content survives.
+    assert (project / "file.txt").exists()
+    # Bookkeeping is consumed, so a second stop is a no-op.
+    assert not backend._mask_state_path("demo").exists()
+    backend.stop("demo")
+
+
+def test_stop_keeps_preexisting_and_non_empty_mask_mountpoints(
+    tmp_path, monkeypatch,
+):
+    """Never remove a dir the operator already had, and never remove one
+    that has content. A real repo's `.git/hooks` (pre-existing) and a
+    `.claude/` that gained a file while the cage ran must both survive."""
+    project = tmp_path / "project"
+    (project / ".git" / "hooks").mkdir(parents=True)
+    (project / ".git" / "hooks" / "pre-commit.sample").write_text("#!/bin/sh\n")
+    backend, _captured = _start_with_masks(tmp_path, monkeypatch, project)
+
+    backend.start("demo", quiet=True)
+    # `.claude/` was absent at start, so it IS a candidate — but the
+    # operator dropped a file in it before stop.
+    (project / ".claude").mkdir()
+    (project / ".claude" / "settings.json").write_text("{}")
+
+    backend.stop("demo")
+    # Pre-existing: never recorded, so never a candidate.
+    assert (project / ".git" / "hooks" / "pre-commit.sample").exists()
+    # Recorded but non-empty: rmdir refuses, we warn and keep.
+    assert (project / ".claude" / "settings.json").exists()
+
+
+def test_mask_cleanup_is_contained_to_the_bind_source(tmp_path, monkeypatch):
+    """A symlink swapped in after start must not redirect a removal out of
+    the project. Both the islink guard and the realpath containment check
+    have to hold, because either alone would let `<project>/.git ->
+    <elsewhere>` retire a directory the cage never created."""
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    backend, _captured = _start_with_masks(tmp_path, monkeypatch, project)
+
+    backend.start("demo", quiet=True)
+    (project / ".claude").symlink_to(outside)
+
+    backend.stop("demo")
+    assert outside.is_dir()
+    assert (project / ".claude").is_symlink()
+
+
+def test_mask_cleanup_refuses_a_recorded_path_outside_its_root(
+    tmp_path, monkeypatch,
+):
+    """Containment is re-checked at teardown against the root recorded at
+    start, not trusted from the bookkeeping file: tampered or stale state
+    must not turn stop() into an arbitrary rmdir. Exercises the realpath
+    guard directly, with a real empty directory that rmdir would otherwise
+    happily remove."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "elsewhere" / "empty"
+    outside.mkdir(parents=True)
+    backend = AppleContainerBackend()
+    state = backend._mask_state_path("demo")
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(json.dumps({str(project): [str(outside)]}))
+
+    backend._cleanup_mask_mountpoints("demo")
+    assert outside.is_dir()
+    assert not state.exists()
+
+
+def test_destroy_removes_mask_mountpoints_when_stop_did_not(
+    tmp_path, monkeypatch,
+):
+    """destroy_resources must clean up too — it runs before the per-cage
+    state rmtree that would otherwise take the bookkeeping file with it,
+    and a cage can be destroyed without a preceding stop()."""
+    project = tmp_path / "project"
+    project.mkdir()
+    backend, _captured = _start_with_masks(tmp_path, monkeypatch, project)
+
+    backend.start("demo", quiet=True)
+    (project / ".git" / "hooks").mkdir(parents=True)
+    monkeypatch.setattr(backend, "_launchd_plist_path", lambda _n: tmp_path / "nope")
+    backend.destroy_resources("demo")
+    assert not (project / ".git").exists()
+
+
+def test_start_does_not_record_mask_mountpoints_for_np_binds(
+    tmp_path, monkeypatch,
+):
+    """An `np` bind's target is a tmpfs seeded from a read-only lowerdir —
+    the runtime's mkdir lands in guest memory, never on the host. Recording
+    a candidate there would make stop() rmdir a host path the cage never
+    created."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    project = tmp_path / "project"
+    project.mkdir()
+    backend, _captured = _setup_start_test(
+        tmp_path, monkeypatch,
+        unit_meta={
+            "name": "demo", "user_image": "x", "cpus": 1,
+            "memory": "1G", "lifecycle": "interactive",
+            "volumes": [f"{project}:/workspace:rw,np"],
+            "tmpfs": ["/workspace/.git/hooks/:rw,size=64M"],
+        },
+    )
+    backend.start("demo", quiet=True)
+    assert not backend._mask_state_path("demo").exists()
+
+
+def test_cleanup_mask_mountpoints_is_a_noop_without_bookkeeping(
+    tmp_path, monkeypatch,
+):
+    """Safe when the start hook never ran (older cage, hand-deleted state):
+    no crash, no removal, and stop/destroy must not fail."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    backend = AppleContainerBackend()
+    backend._cleanup_mask_mountpoints("never-started")
+    backend._mask_state_path("demo").parent.mkdir(parents=True, exist_ok=True)
+    backend._mask_state_path("demo").write_text("not json{")
+    backend._cleanup_mask_mountpoints("demo")
+
+
+def test_mask_mountpoint_dirs_maps_masks_to_host_paths(tmp_path):
+    """The shared path computation (volume_mounts.mask_mountpoint_dirs, the
+    same helper the quadlet backend's #320 fix uses): only masks nested
+    under a host-backed bind produce candidates, the implied parent chain is
+    included, and the list is deepest-first."""
+    from agentcage.volume_mounts import mask_mountpoint_dirs
+    project = str(tmp_path / "project")
+    assert mask_mountpoint_dirs(
+        [
+            "/tmp:rw,size=256M",                     # no enclosing bind
+            "/workspace:rw",                         # covers the whole mount
+            "/workspace/.git/hooks/:rw,size=64M",
+            "/cache/x:rw",                           # enclosing mount is not host-backed
+        ],
+        [("/workspace", project), ("/cache", "")],
+    ) == {
+        project: [
+            os.path.join(project, ".git", "hooks"),
+            os.path.join(project, ".git"),
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # cage-init.sh stage C' — non-persistent seed ownership
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2128,9 +2128,14 @@ class TestAppleContainerSilentDrops:
         _, warnings = self._validate_under_apple(str(p))
         assert not any("container.ports" in w for w in warnings), warnings
 
-    def test_tmpfs_non_default_warns(self, tmp_path):
-        """Multi-entry tmpfs or non-/tmp target → operator intent that
-        apple-container can't honor → warn."""
+    def test_tmpfs_with_options_warns_about_options_not_the_mount(
+        self, tmp_path,
+    ):
+        """#318 wired `container.tmpfs` to `container run --tmpfs <path>`, so
+        the mounts DO happen here. Apple's flag takes a bare path though, so
+        the option list is still lost — the warning must say exactly that,
+        and must not regress into "silently has no effect" (which would be
+        false, and would train operators to ignore the field's warnings)."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -2142,15 +2147,18 @@ class TestAppleContainerSilentDrops:
                 - "/run:rw,size=16M"
         """))
         _, warnings = self._validate_under_apple(str(p))
-        assert any("container.tmpfs" in w for w in warnings), warnings
+        tmpfs_warns = [w for w in warnings if "container.tmpfs" in w]
+        assert tmpfs_warns, warnings
+        joined = " | ".join(tmpfs_warns)
+        assert "ARE applied" in joined, joined
+        assert "/tmp" in joined and "/run" in joined, joined
+        assert not any(
+            "container.tmpfs: silently has no effect" in w for w in warnings
+        ), joined
 
-    def test_tmpfs_single_tmp_entry_does_not_warn(self, tmp_path):
-        """Scaffold default ``tmpfs: ["/tmp:rw,noexec,nosuid,size=256M"]``
-        is the single-most-common cage.yaml shape across built-in scaffolds.
-        On apple-container the cage's /tmp lives in the RW rootfs — the
-        workload still gets a writable /tmp — so the noisiest warning on
-        every default cage was pure cosmetic friction. 0.22.7+ suppresses
-        it when the only tmpfs entry targets /tmp."""
+    def test_tmpfs_without_options_does_not_warn(self, tmp_path):
+        """Nothing is lost for a bare-path entry — it maps 1:1 onto Apple's
+        `--tmpfs`. No warning, so the option-drop warning stays meaningful."""
         p = tmp_path / "config.yaml"
         p.write_text(textwrap.dedent("""\
             name: ac-demo
@@ -2158,7 +2166,7 @@ class TestAppleContainerSilentDrops:
             container:
               image: localhost/test:latest
               tmpfs:
-                - "/tmp:rw,noexec,nosuid,size=256M"
+                - "/tmp"
         """))
         _, warnings = self._validate_under_apple(str(p))
         assert not any(

--- a/tests/test_scaffolds.py
+++ b/tests/test_scaffolds.py
@@ -355,77 +355,82 @@ class TestWorkspaceExecutableConfigMasks:
             "/workspace/.claude/. Masking HOME breaks claude login/creds."
         )
 
-    def test_apple_container_git_hooks_drop_warns_security_relevant(
-        self, tmp_path
-    ):
-        """On apple-container the #170 /workspace/.git/hooks/ mask is silently
-        dropped (tmpfs parity tracked in #120). The generic tmpfs warning is
-        harmless-parity noise an operator may tune out, so a security control
-        being dropped must call out the residual exposure by name: a caged
-        agent can still plant a host git hook. The warning must NOT read as
-        generic /tmp-parity gap."""
+    def _apple_warnings(self, tmp_path, scaffold="claude-code"):
+        """validate_config() for a scaffold-rendered cage.yaml, forced onto
+        the apple-container backend on a simulated macOS 26 ASi host."""
         import platform as _platform
         from unittest import mock
         from agentcage.config import load_config, validate_config
-        cfg_text = render_config("demo", scaffold="claude-code")
         p = tmp_path / "cage.yaml"
-        p.write_text(cfg_text)
+        p.write_text(render_config("demo", scaffold=scaffold))
         cfg = load_config(str(p))
         cfg.isolation = "apple-container"
         with mock.patch.object(_platform, "system", return_value="Darwin"), \
              mock.patch.object(_platform, "machine", return_value="arm64"):
-            warnings = validate_config(cfg)
-        git_hook_warns = [w for w in warnings if "/workspace/.git/hooks/" in w]
-        assert git_hook_warns, (
-            "apple-container validation must warn about the dropped "
-            "/workspace/.git/hooks/ mask (#170)"
-        )
-        assert any("SECURITY-RELEVANT" in w for w in git_hook_warns), (
-            "the .git/hooks tmpfs drop warning must be flagged "
-            "SECURITY-RELEVANT, not generic /tmp parity noise"
-        )
-        assert any("pivot" in w and "exploitable" in w for w in git_hook_warns), (
-            "the .git/hooks drop warning must name the cage→host pivot "
-            "and that it remains exploitable"
+            return validate_config(cfg)
+
+    def test_apple_container_git_hooks_mask_no_longer_reported_dropped(
+        self, tmp_path
+    ):
+        """#318: the #170 /workspace/.git/hooks/ mask is WIRED on
+        apple-container now (start() emits `--tmpfs /workspace/.git/hooks`).
+        validate_config must therefore stop telling operators the cage->host
+        pivot "remains exploitable" — a stale scare warning trains people to
+        ignore the SECURITY-RELEVANT prefix, and this one would now be
+        factually wrong."""
+        warnings = self._apple_warnings(tmp_path)
+        stale = [
+            w for w in warnings
+            if "/workspace/.git/hooks/" in w and "exploitable" in w
+        ]
+        assert not stale, (
+            "the .git/hooks mask is applied on apple-container since #318 — "
+            "validate_config must not report it as a dropped, still-"
+            "exploitable pivot: " + " | ".join(stale)
         )
 
-    def test_apple_container_dotclaude_drop_warns_security_relevant(
+    def test_apple_container_dotclaude_mask_no_longer_reported_dropped(
         self, tmp_path
     ):
-        """Symmetric to the git-hooks case: on apple-container the #173
-        /workspace/.claude/ mask is dropped, leaving the cage→cage
-        hooks-injection chain open. The warning must call out the
-        hooks-injection exposure by name, not fold it into generic tmpfs
-        parity noise."""
-        import platform as _platform
-        from unittest import mock
-        from agentcage.config import load_config, validate_config
-        cfg_text = render_config("demo", scaffold="claude-code")
-        p = tmp_path / "cage.yaml"
-        p.write_text(cfg_text)
-        cfg = load_config(str(p))
-        cfg.isolation = "apple-container"
-        with mock.patch.object(_platform, "system", return_value="Darwin"), \
-             mock.patch.object(_platform, "machine", return_value="arm64"):
-            warnings = validate_config(cfg)
-        claude_warns = [w for w in warnings if "/workspace/.claude/" in w]
-        assert claude_warns, (
-            "apple-container validation must warn about the dropped "
-            "/workspace/.claude/ mask (#173)"
+        """Symmetric to the git-hooks case: the #173 /workspace/.claude/
+        mask is applied on apple-container since #318, so the "injection
+        chain remains exploitable" warning must be gone."""
+        warnings = self._apple_warnings(tmp_path)
+        stale = [
+            w for w in warnings
+            if "/workspace/.claude/" in w and "exploitable" in w
+        ]
+        assert not stale, (
+            "the .claude/ mask is applied on apple-container since #318 — "
+            "validate_config must not report it as a dropped, still-"
+            "exploitable injection chain: " + " | ".join(stale)
         )
-        assert any("SECURITY-RELEVANT" in w for w in claude_warns), (
-            "the .claude/ tmpfs drop warning must be flagged "
-            "SECURITY-RELEVANT, not generic /tmp parity noise"
+
+    def test_apple_container_tmpfs_warning_names_dropped_options_only(
+        self, tmp_path
+    ):
+        """What apple-container really loses is the tmpfs OPTION list
+        (Apple's `--tmpfs` takes a bare path). The warning must say the
+        mounts ARE applied, and name noexec/nosuid/nodev and `size=` as the
+        part that is not — overstating enforcement is worse than the old
+        loud warning."""
+        warnings = self._apple_warnings(tmp_path)
+        tmpfs_warns = [w for w in warnings if "container.tmpfs" in w]
+        assert tmpfs_warns, (
+            "the stock scaffold ships tmpfs entries WITH options, so "
+            "apple-container must warn that the options are dropped"
         )
-        assert any("hooks-injection" in w and "exploitable" in w
-                   for w in claude_warns), (
-            "the .claude/ drop warning must name the cage→cage "
-            "hooks-injection chain and that it remains exploitable"
-        )
+        joined = " | ".join(tmpfs_warns)
+        assert "ARE applied" in joined, joined
+        assert "noexec" in joined and "size=" in joined, joined
+        # Never claim the whole field is inert.
+        assert not any(
+            "container.tmpfs: silently has no effect" in w for w in warnings
+        ), joined
 
     def test_apple_container_plain_tmp_warning_not_security_flagged(self):
-        """A plain /tmp tmpfs entry (the stock scaffold default) dropped on
-        apple-container must stay a generic parity warning — it must NOT be
+        """A plain /tmp tmpfs entry (the stock scaffold default) must stay a
+        generic parity warning about its dropped OPTIONS — it must NOT be
         mis-flagged SECURITY-RELEVANT, otherwise operators learn to treat
         the security flag as noise too. Pins the specificity of Major 1."""
         import platform as _platform


### PR DESCRIPTION
Closes #318. Closes the tmpfs half of the #120 parity gap. Also carries the apple-container half of #320 — see [Mount-point cleanup](#mount-point-cleanup-320) below.

## Status: runtime-verified on bare-metal Apple Silicon ✅

The original 7-step checklist was verified on hardware by the reviewer. Observed in-cage:

```
virtiofs on /workspace              type virtiofs
tmpfs on /workspace/.claude         type tmpfs
tmpfs on /workspace/.git/hooks      type tmpfs
```

The depth-sort reasoning below held: the host's 14 `.sample` hooks are invisible in-cage (a real overlay, no copy-up), uid 1000 can write, and a planted `pre-commit` + `.claude/settings.json` reached the host **neither** while running nor after stop. Host `.sample` hooks survived; a real host `git commit` executed nothing. **#170 and #173 are genuinely closed on apple-container.**

⚠️ **The second commit (mount-point cleanup) still needs a hardware pass** — see [What to verify](#what-to-verify).

## The problem

`default_isolation()` picks `apple-container` on any macOS 26+ Apple Silicon host with the `container` CLI installed. That was the one backend that dropped `container.tmpfs` entirely — and the claude-code scaffold's two workspace masks are tmpfs entries:

```yaml
- "/workspace/.git/hooks/:rw,noexec,nosuid,nodev,size=64M"   # #170 cage→host git-hook pivot
- "/workspace/.claude/:rw,noexec,nosuid,nodev,size=64M"      # #173 cage→cage hooks injection
```

So the default backend on a modern Mac was the one without those protections. `config.py` already said so loudly, but a create-time warning is not a control.

## Approach: option 4 from the issue

Rather than change `default_isolation()` or gate `cage create`, make the masks actually work here. If tmpfs is honored, the default becomes safe and no default change is needed.

- `generate_units` persists `container.tmpfs` into the unit JSON (`start()` is meta-driven, so an unpersisted field is a silently dropped mount).
- `start()` emits one `container run --tmpfs <path>` per entry on the cage microVM's argv, next to the existing `--tmpfs` the `np` bind path already uses (`backends/apple_container.py:1552`).

## Constraint 1 — Apple's `--tmpfs` takes a bare path

Confirmed against Apple's source rather than assumed:

- **container 1.0.0** (`Sources/Services/ContainerAPIService/Client/Parser.swift`, `tmpfsMounts`): `Filesystem.tmpfs(destination: tmpfs, options: [])` — the *whole* argument is the destination. Passing `path:opts` would mount a tmpfs at a directory literally named `path:opts`.
- **container 1.3.0**: same function now splits on the first `:` and parses options.

We target the older contract too, so we pass a **bare path** and the option list is dropped on every version. `Filesystem.tmpfs` with empty options means kernel-default tmpfs semantics: rw, exec/suid/dev permitted, mode 1777, size bounded only by the cage VM's memory.

**This is not papered over.** The two `SECURITY-RELEVANT drop … remains exploitable` warnings are removed (they are now factually wrong, and a stale scare warning trains operators to ignore the prefix), the blanket `container.tmpfs: silently has no effect` entry is removed, and a single precise warning replaces them:

> `container.tmpfs: the mounts ARE applied on apple-container, but their OPTIONS are not — Apple's `container run --tmpfs` takes a bare path, so /tmp, /workspace/.git/hooks/, /workspace/.claude/ get kernel-default tmpfs semantics: noexec/nosuid/nodev are NOT enforced and any `size=` cap is ignored (an unbounded tmpfs can exhaust the cage VM's memory; bound it with container.memory). The mask entries (/workspace/.git/hooks/, /workspace/.claude/) do still block their cage→host / cage→cage pivot: that protection comes from the tmpfs overlaying the bind, not from `noexec`. See #120.`

### Does losing `noexec,nosuid,nodev` weaken the #170 defense?

No. The #170 threat is a *cage→host pivot*: the agent plants `/workspace/.git/hooks/pre-commit`, and the next **host-side** `git commit` executes it as the host user. The execution happens on the host, in the host's mount namespace, where an in-cage `noexec` has no bearing. The defense is entirely "the write never reaches the host disk" — i.e. the tmpfs overlaying the bind-mounted path. That property is preserved exactly.

`nosuid`/`nodev` are generic in-cage hardening, not part of this threat model. Their loss is a real (small) parity gap for the `/tmp` entry, which is why the warning still fires.

### The missing `size=` limit

Worth calling out: an unbounded tmpfs is a memory-exhaustion consideration. Blast radius is the cage's own microVM, not the host — the tmpfs lives in guest memory and the kernel default caps it at half of VM RAM, which is itself bounded by `--memory` (the scaffold sets `memory: "8g"`). So a cage filling its tmpfs OOMs itself. Still, an operator who wrote `size=64M` deserves to know it is not enforced, hence the warning and the `container.memory` pointer.

## Constraint 2 + 3 — tmpfs over a bind subpath, and ordering

**This is the main technical risk.** The masks overlay a path *inside* a bind (`/workspace/.git/hooks/` under the `/workspace` virtiofs bind). The existing `np` usage does not do this — it tmpfs's a standalone target. If the tmpfs is mounted *before* the bind, the bind shadows it and the mask silently does nothing.

argv order does not decide this. Reasoning from Apple's source:

1. `Sources/Services/ContainerAPIService/Client/Utility.swift` builds `config.mounts` as `tmpfs + volumes + mounts` — tmpfs entries are appended **first**, so raw array order is actively *wrong* for our case.
2. But `apple/containerization` `Sources/Containerization/LinuxContainer.swift` does `spec.mounts = cleanAndSortMounts(mounts)`, which lexically normalizes each destination (stripping our trailing slash) and then `sortMountsByDestinationDepth` — sorted by `destination.split("/").count`.
3. Both `--volume` and `--tmpfs` land in that same array, and virtiofs shares are transformed into ordinary bind mounts before the sort.

So `/workspace` (depth 1) is ordered before `/workspace/.git/hooks` (depth 3), and the in-guest OCI runtime applies `spec.mounts` in order, creating the missing mountpoint. `cleanAndSortMounts` is present in containerization **0.33.3**, which is what `container` 1.0.0 pins (`Package.resolved`), so this is not a main-branch-only property.

Consequences of this being source-derived rather than observed are why runtime verification is required.

We still emit `--tmpfs` after the volumes so the argv reads in mount order, and the code comment records the mechanism so a future reader does not "fix" the ordering.

`cage-init.sh` does not need a change: its stage C' only touches `AGENTCAGE_NONPERSISTENT_COPIES` targets, and a kernel-default tmpfs is mode 1777, so the uid-1000 workload can write into the mask without a chown.

## Mount-point cleanup (#320)

Wiring `container.tmpfs` through made this backend subject to #320, which it previously was not. A mask target nested under a host bind makes the in-guest OCI runtime `mkdir -p` the mount point, and a bind shares inodes with its source, so the mkdir lands in the operator's project directory **on the host**. On a non-git project, observed on hardware with the first commit:

```
$ ls -a ~/ac-t320      # before
.  ..  f
$ agentcage cage create ... && agentcage cage destroy ...
$ ls -a ~/ac-t320      # after — and these persisted past destroy
.  ..  .claude  .git  f
```

PR #326 fixed this for container/vm and explicitly concluded apple-container was unaffected, quoting *"`container.tmpfs` is never wired into `container run`; only `np` volumes emit `--tmpfs` (#120)"*. That was true on master; this PR makes it false. #326's fix is an `ExecStartPre`/`ExecStopPost` pair in the podman quadlet, which apple-container does not use — so the second commit here adds the Python-side equivalent, and #325 is self-consistent regardless of merge order with #326.

Same semantics as #326:

- `start()` records, immediately before `container run`, which mask mount points were **absent** on the host — including the implied parent chain (`<project>/.git` as well as `<project>/.git/hooks`), deepest-first. A symlink counts as existing (`os.path.lexists`, matching the hook's `[ -e ] || [ -L ]` skip).
- `stop()` and `destroy_resources()` `rmdir` exactly those. `rmdir` is the entire "only if empty" guarantee: a directory that gained content is **kept**, with a warning. A pre-existing directory was never recorded, so it is never a candidate. `destroy_resources` runs the cleanup *before* the per-cage state `rmtree` that would otherwise take the bookkeeping file with it.
- **Containment:** removal is restricted to the bind source recorded at start and re-checked against `realpath` at teardown (plus an `islink` guard), so a symlink swapped in *after* start cannot redirect a removal out of the project. Path components of `.`/`..` are rejected in the path computation.
- Best-effort and idempotent: a missing or unreadable bookkeeping file (start hook never ran, older cage, hand-deleted state) is a silent no-op and can never fail a stop or destroy.
- `np` binds are excluded — their target is a tmpfs seeded from a read-only lowerdir, so the mkdir lands in guest memory and there is no host path to retire.

The mask itself stays unconditional. Dropping it when `.git` is absent would reopen the #170 pivot for any `.git` created later.

**Shared, not duplicated.** #326's `_mask_mountpoint_dirs()` is lifted verbatim into `volume_mounts.mask_mountpoint_dirs()` — a module #326 does not touch, so there is no merge conflict in either direction and no import from an unmerged branch. Once both land, `quadlets.py` can drop its private copy for the import; that is a one-line follow-up, not a blocker.

## Other behavior

- `_tmpfs_targets` normalizes (`/workspace/.git/hooks/` → `/workspace/.git/hooks`), de-duplicates, and **skips with a warning** a relative target or `/` (a tmpfs over the rootfs would hide the cage image).
- An `np` bind's target is not double-`--tmpfs`'d — that would put an empty mount over the copy stage C' seeds from the host lowerdir.

## What to verify

**Still outstanding — the mount-point cleanup commit.** On a bare-metal Apple Silicon Mac:

1. **Non-git project dir** → `cage create` → `cage stop` / `cage destroy`: no stray `.git/` or `.claude/` left behind, and unrelated project files untouched.
2. **Git project dir** → the mask still blocks the pivot (steps 4–6 below), and the real `.git/` — including the `.sample` hooks — is untouched after stop and destroy.
3. A `.claude/` that gained a file on the host while the cage ran must be **kept**, with the "not empty" warning.

<details>
<summary>Original checklist (already verified ✅)</summary>

On a bare-metal Apple Silicon Mac, with a `claude-code` scaffold cage on `isolation: apple-container`, in a project directory that is a git repo:

1. `agentcage cage create` — confirm the new warning text appears and the old "remains exploitable" warnings do not.
2. `agentcage cage start`, then `agentcage cage exec <name> -- mount | grep workspace` — **the load-bearing check**: `tmpfs on /workspace/.git/hooks` and `tmpfs on /workspace/.claude` must be present, *after* the `/workspace` bind.
3. In-cage: `ls /workspace/.git/hooks` must be **empty** (the host's `*.sample` hooks masked, no copy-up).
4. In-cage: plant the pivot —
   ```
   printf '#!/bin/sh\ntouch /tmp/PWNED\n' > /workspace/.git/hooks/pre-commit
   chmod +x /workspace/.git/hooks/pre-commit
   echo '{"hooks":{}}' > /workspace/.claude/settings.json
   ```
   Both writes must succeed in-cage (uid 1000 must be able to write the tmpfs).
5. On the **host**, while the cage is still running: `ls -la <project>/.git/hooks/` and `<project>/.claude/` — neither planted file may be visible.
6. `agentcage cage stop`, then re-check on the host — still absent. Run `git commit` on the host and confirm nothing executes.
7. Regression on the existing `np` path: a cage with `~/src:/workspace:rw,np` must still get its seeded copy (not an empty mount).

Failure mode to watch for: if step 2 shows no tmpfs at the nested paths, the depth-sort reasoning is wrong for the installed `container` version and this PR must **not** merge — a mask that appears configured but does not block the pivot is worse than the current loud warning.

</details>

## Tests

`uv run pytest` on macOS: **12 failed, 1997 passed, 39 skipped, 6 errors** — identical failure/error set to the `origin/master` baseline (**12 failed, 1983 passed, 39 skipped, 6 errors**); all pre-existing and unrelated (podman/lima-dependent). Net +14 passing.

New/rewritten:
- `test_unit_json_persists_container_tmpfs` — the field reaches the unit JSON.
- `test_start_emits_container_tmpfs_as_bare_paths` — argv is `--tmpfs /workspace/.git/hooks` with no `noexec`/`size=` string anywhere; egress sibling gets none.
- `test_start_without_container_tmpfs_emits_no_tmpfs` — no stray empty mount from a missing field.
- `test_start_does_not_double_tmpfs_an_np_volume_target`.
- `test_tmpfs_targets_normalizes_dedupes_and_rejects_unsafe`.
- Mount-point cleanup: `test_stop_removes_mask_mountpoints_created_on_a_non_git_project`, `test_stop_keeps_preexisting_and_non_empty_mask_mountpoints`, `test_mask_cleanup_is_contained_to_the_bind_source`, `test_mask_cleanup_refuses_a_recorded_path_outside_its_root`, `test_destroy_removes_mask_mountpoints_when_stop_did_not`, `test_start_does_not_record_mask_mountpoints_for_np_binds`, `test_cleanup_mask_mountpoints_is_a_noop_without_bookkeeping`, `test_mask_mountpoint_dirs_maps_masks_to_host_paths`.
- `test_config.py` / `test_scaffolds.py`: the drop-warning tests are inverted — they now assert the "remains exploitable" claims are **gone** and that the replacement warning says the mounts ARE applied while naming `noexec` and `size=` as what is not.

## Scope

`quadlets.py` is untouched — #321 is in flight there, and #326's copy of the path helper is deliberately left alone so this PR conflicts with neither. `default_isolation()` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
