### PR TITLE
[#319] fix(vm): restart the guest user manager so rootless podman gets its D-Bus

### DIFF
--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -90,6 +90,12 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
 
 VM_SERVICE_STARTUP_DELAY_S = 5
 VM_SERVICE_STARTUP_POLL_INTERVAL_S = 0.1
+# Issue #319: how long to wait for the guest's systemd *user* session before
+# dispatching the first in-VM podman build. Observed window on a fresh Lima
+# VM is a few seconds; 90s is a generous ceiling that still fails fast enough
+# to hand over to the build (and #322's output surfacing) rather than hang.
+VM_USER_SESSION_TIMEOUT_S = 90
+VM_USER_SESSION_POLL_INTERVAL_S = 1.0
 PROXY_READINESS_TIMEOUT_S = 30
 PROXY_READINESS_POLL_INTERVAL_S = 0.25
 
@@ -227,6 +233,106 @@ def _wait_infra_active(
     return pending
 
 
+# One round-trip probe for "can rootless podman run a container yet?".
+#
+# ``limactl shell`` opens a NON-login session. Immediately after Lima reports
+# READY, the guest user's systemd user manager (``user@<uid>.service``) and
+# its D-Bus (``/run/user/<uid>/bus``) may not be up yet — the provisioning
+# script enables lingering by touching ``/var/lib/systemd/linger/<user>``,
+# but logind only acts on that sentinel on its next GC/session event, so the
+# user manager is started lazily by the first SSH login and takes a moment.
+#
+# Rootless podman defaults to ``cgroup_manager = "systemd"``, which needs
+# that bus. Dispatching ``podman build`` into the gap fails at the first
+# ``RUN`` step with podman's own diagnosis:
+#
+#     warning: The cgroupv2 manager is set to systemd but there is no
+#              systemd user session available
+#     error running container: from /usr/bin/crun creating container for
+#              [...]: sd-bus call: Interactive authentication required.
+#
+# Deliberately NOT probed: ``loginctl show-user <uid> --property=Linger``.
+# It is a logind D-Bus round-trip, and the provisioning script already
+# documents that logind can wedge during guest bring-up (its dbus calls then
+# block for 25s) — putting that call in a poll loop would turn a transient
+# hiccup into a multi-minute stall. Lingering is set by provisioning anyway;
+# and ``loginctl enable-linger`` over a *remote* SSH session is not an
+# ``allow_active`` polkit subject, so it would hit the very "Interactive
+# authentication required" wall we are working around. Waiting is correct.
+_USER_SESSION_PROBE = (
+    'uid=$(id -u); '
+    'if [ ! -S "/run/user/$uid/bus" ]; then echo no-user-bus; exit 0; fi; '
+    'systemctl --user is-system-running 2>/dev/null || true'
+)
+
+# ``systemctl --user is-system-running`` states that mean the user manager is
+# up and can service podman's sd-bus call. ``degraded`` counts: it only says
+# some user unit failed, the bus and the cgroup delegation are live (and it
+# exits non-zero, which is why this matches on stdout, not the exit code).
+# Everything else — ``initializing``/``starting``/``offline``/``unknown``, or
+# the socket not existing yet — keeps us waiting.
+_USER_SESSION_READY_STATES = frozenset({"running", "degraded"})
+
+
+def _probe_user_session(inst: LimaInstance) -> str:
+    """Return the guest's user-session state as a short token.
+
+    Never raises: this runs on the happy path in front of a build, so a
+    flaky ``limactl shell`` must degrade to "not ready yet", not to an
+    exception that pre-empts the build we are trying to protect.
+    """
+    try:
+        r = inst.exec(["bash", "-c", _USER_SESSION_PROBE], check=False)
+    except Exception as e:  # pragma: no cover - defensive
+        return f"probe failed: {e}"
+    return _decode_stream(r.stdout).strip() or "unknown"
+
+
+def _wait_user_session_ready(
+    inst: LimaInstance,
+    *,
+    timeout_s: float = VM_USER_SESSION_TIMEOUT_S,
+    interval_s: float = VM_USER_SESSION_POLL_INTERVAL_S,
+) -> bool:
+    """Block until the guest's rootless-podman preconditions hold.
+
+    Returns True if the session became ready, False if *timeout_s* elapsed
+    first. The caller must proceed with the build either way: a timeout is
+    a *hint*, not a verdict. Failing early here would trade one opaque
+    error for another and would throw away the real podman diagnostic that
+    ``_exec_build`` now surfaces (#322).
+
+    This is a readiness gate, not a retry: the build is still dispatched
+    exactly once, so a genuine build failure fails immediately and loudly.
+    """
+    deadline = time.monotonic() + timeout_s
+    announced = False
+    while True:
+        state = _probe_user_session(inst)
+        if state in _USER_SESSION_READY_STATES:
+            if announced:
+                click.echo(f"Guest systemd user session ready ({state}).")
+            return True
+        if time.monotonic() >= deadline:
+            with output.pause_active_spinner():
+                click.echo(
+                    f"warning: gave up after {timeout_s:.0f}s waiting for the "
+                    "guest systemd user session (rootless podman needs "
+                    "/run/user/<uid>/bus for its systemd cgroup manager); "
+                    f"last probe reported {state!r}. Building anyway — if the "
+                    "build fails, podman's own error is printed below.",
+                    err=True,
+                )
+            return False
+        if not announced:
+            announced = True
+            click.echo(
+                "Waiting for the guest systemd user session "
+                f"(rootless podman needs its user D-Bus; state: {state})..."
+            )
+        time.sleep(interval_s)
+
+
 class VmBackend:
     """Backend using Lima VMs with Podman + quadlets inside.
 
@@ -295,6 +401,19 @@ class VmBackend:
             build_flags.append("--no-cache")
         if pull:
             build_flags.append("--pull=always")
+
+        # Gate the FIRST in-VM podman invocation on the guest's systemd user
+        # session being up (#319). Placed after the build-context copy on
+        # purpose: the copy and the `rm -rf`/`mkdir` round-trips above give
+        # the guest a few free seconds (and each `limactl shell` login is
+        # itself what makes logind start `user@<uid>.service`), so on a warm
+        # VM this is a single probe that returns immediately.
+        with Phase("wait.user_session", cage=deploy_name):
+            _wait_user_session_ready(
+                inst,
+                timeout_s=VM_USER_SESSION_TIMEOUT_S,
+                interval_s=VM_USER_SESSION_POLL_INTERVAL_S,
+            )
 
         version = _pkg_version("agentcage")
         click.echo(f"Building egress image inside VM (agentcage-egress:{version})...")

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -90,11 +90,14 @@ def push_config_files(name: str, inst: LimaInstance) -> None:
 
 VM_SERVICE_STARTUP_DELAY_S = 5
 VM_SERVICE_STARTUP_POLL_INTERVAL_S = 0.1
-# Issue #319: how long to wait for the guest's systemd *user* session before
-# dispatching the first in-VM podman build. Observed window on a fresh Lima
-# VM is a few seconds; 90s is a generous ceiling that still fails fast enough
-# to hand over to the build (and #322's output surfacing) rather than hang.
-VM_USER_SESSION_TIMEOUT_S = 90
+# Issue #319 safety net: how long to wait for the guest's systemd *user*
+# session before dispatching the first in-VM podman build. The real fix is
+# in provisioning (provision.sh.j2 restarts user@<uid>.service so it picks
+# up dbus.socket), so the bus should already be present and this gate should
+# resolve on its first probe. The ceiling is deliberately short: if the bus
+# is missing here it is a provisioning fault that waiting cannot repair, and
+# a long stall would only delay the real error.
+VM_USER_SESSION_TIMEOUT_S = 20
 VM_USER_SESSION_POLL_INTERVAL_S = 1.0
 PROXY_READINESS_TIMEOUT_S = 30
 PROXY_READINESS_POLL_INTERVAL_S = 0.25
@@ -235,30 +238,34 @@ def _wait_infra_active(
 
 # One round-trip probe for "can rootless podman run a container yet?".
 #
-# ``limactl shell`` opens a NON-login session. Immediately after Lima reports
-# READY, the guest user's systemd user manager (``user@<uid>.service``) and
-# its D-Bus (``/run/user/<uid>/bus``) may not be up yet — the provisioning
-# script enables lingering by touching ``/var/lib/systemd/linger/<user>``,
-# but logind only acts on that sentinel on its next GC/session event, so the
-# user manager is started lazily by the first SSH login and takes a moment.
-#
-# Rootless podman defaults to ``cgroup_manager = "systemd"``, which needs
-# that bus. Dispatching ``podman build`` into the gap fails at the first
-# ``RUN`` step with podman's own diagnosis:
+# Rootless podman defaults to ``cgroup_manager = "systemd"``, which needs the
+# guest user's D-Bus at ``/run/user/<uid>/bus``. Without it every container
+# creation fails at the first ``RUN`` step:
 #
 #     warning: The cgroupv2 manager is set to systemd but there is no
 #              systemd user session available
 #     error running container: from /usr/bin/crun creating container for
 #              [...]: sd-bus call: Interactive authentication required.
 #
+# That is issue #319, and the *cause* is fixed in provisioning, not here:
+# apt installs ``dbus-user-session`` underneath a ``user@<uid>.service``
+# that Lima's own SSH bring-up already started, and a running user manager
+# never loads the socket unit that appeared beneath it — so the bus stays
+# absent for the whole boot. ``provision.sh.j2`` now restarts that manager.
+#
+# This gate is therefore defense-in-depth, not the remedy. It should be a
+# single probe that returns immediately. If it ever has to wait, the guest
+# is in a state waiting cannot repair, which is why the ceiling is short and
+# why a timeout hands straight over to the build (and to #322's diagnostics)
+# instead of stalling.
+#
 # Deliberately NOT probed: ``loginctl show-user <uid> --property=Linger``.
-# It is a logind D-Bus round-trip, and the provisioning script already
-# documents that logind can wedge during guest bring-up (its dbus calls then
-# block for 25s) — putting that call in a poll loop would turn a transient
-# hiccup into a multi-minute stall. Lingering is set by provisioning anyway;
-# and ``loginctl enable-linger`` over a *remote* SSH session is not an
-# ``allow_active`` polkit subject, so it would hit the very "Interactive
-# authentication required" wall we are working around. Waiting is correct.
+# It is a logind D-Bus round-trip, and the provisioning script documents that
+# logind can wedge during guest bring-up (its dbus calls then block for 25s)
+# — putting that in a poll loop would turn a hiccup into a multi-minute
+# stall. Lingering is set by provisioning's sentinel file anyway, and it was
+# not the problem: logind was verified healthy and the sentinel present while
+# the bus was still missing.
 _USER_SESSION_PROBE = (
     'uid=$(id -u); '
     'if [ ! -S "/run/user/$uid/bus" ]; then echo no-user-bus; exit 0; fi; '
@@ -294,13 +301,17 @@ def _wait_user_session_ready(
     timeout_s: float = VM_USER_SESSION_TIMEOUT_S,
     interval_s: float = VM_USER_SESSION_POLL_INTERVAL_S,
 ) -> bool:
-    """Block until the guest's rootless-podman preconditions hold.
+    """Check the guest's rootless-podman preconditions before building.
 
-    Returns True if the session became ready, False if *timeout_s* elapsed
-    first. The caller must proceed with the build either way: a timeout is
-    a *hint*, not a verdict. Failing early here would trade one opaque
-    error for another and would throw away the real podman diagnostic that
-    ``_exec_build`` now surfaces (#322).
+    Expected to succeed on the first probe: provisioning now guarantees the
+    user D-Bus exists (see ``_USER_SESSION_PROBE``). The bounded wait covers
+    a slow manager restart on an underpowered host.
+
+    Returns True if the session is ready, False if *timeout_s* elapsed. The
+    caller must proceed with the build either way: a timeout is a *hint*,
+    not a verdict. Failing early here would trade one opaque error for
+    another and would throw away the real podman diagnostic that
+    ``_exec_build`` surfaces (#322).
 
     This is a readiness gate, not a retry: the build is still dispatched
     exactly once, so a genuine build failure fails immediately and loudly.
@@ -316,11 +327,15 @@ def _wait_user_session_ready(
         if time.monotonic() >= deadline:
             with output.pause_active_spinner():
                 click.echo(
-                    f"warning: gave up after {timeout_s:.0f}s waiting for the "
-                    "guest systemd user session (rootless podman needs "
-                    "/run/user/<uid>/bus for its systemd cgroup manager); "
-                    f"last probe reported {state!r}. Building anyway — if the "
-                    "build fails, podman's own error is printed below.",
+                    "warning: the guest's systemd user D-Bus "
+                    "(/run/user/<uid>/bus) is still absent after "
+                    f"{timeout_s:.0f}s; last probe reported {state!r}. "
+                    "Rootless podman needs it for its systemd cgroup manager. "
+                    "This usually means the guest's user dbus.socket never "
+                    "came up (a provisioning fault, not a slow start — see "
+                    "#319), so recreating the VM is more likely to help than "
+                    "retrying. Building anyway — if the build fails, podman's "
+                    "own error is printed below.",
                     err=True,
                 )
             return False
@@ -402,12 +417,12 @@ class VmBackend:
         if pull:
             build_flags.append("--pull=always")
 
-        # Gate the FIRST in-VM podman invocation on the guest's systemd user
-        # session being up (#319). Placed after the build-context copy on
-        # purpose: the copy and the `rm -rf`/`mkdir` round-trips above give
-        # the guest a few free seconds (and each `limactl shell` login is
-        # itself what makes logind start `user@<uid>.service`), so on a warm
-        # VM this is a single probe that returns immediately.
+        # Safety net for #319: confirm the guest's systemd user D-Bus exists
+        # before the FIRST in-VM podman invocation. Provisioning is what
+        # guarantees it (provision.sh.j2 restarts user@<uid>.service so it
+        # loads dbus.socket); this only catches a guest that slipped through,
+        # and turns "podman build failed" into a message that names the
+        # actual precondition. Normally a single probe, no sleep.
         with Phase("wait.user_session", cage=deploy_name):
             _wait_user_session_ready(
                 inst,

--- a/src/agentcage/templates/lima/provision.sh.j2
+++ b/src/agentcage/templates/lima/provision.sh.j2
@@ -89,4 +89,49 @@ chmod -R g+rX /var/log/journal
 mkdir -p /var/lib/systemd/linger
 touch "/var/lib/systemd/linger/$lima_user"
 
+# Restart the cage user's systemd manager so it picks up dbus.socket.
+#
+# MUST come after BOTH the apt install above and the linger sentinel touch.
+#
+# Lima SSHes into the guest before running this provisioning script, and
+# that login has already started `user@<uid>.service`. A *running* user
+# manager does not notice a socket unit that apt drops underneath it, so
+# even though `dbus-user-session` is installed above, the user manager
+# keeps running without dbus.socket loaded and `/run/user/<uid>/bus` never
+# appears for the life of that boot. Observed live on a fresh host:
+#
+#   user@503.service:  active            <- manager running
+#   systemd-logind:    active, rc=0      <- NOT wedged
+#   linger sentinel:   present
+#   dbus-user-session: ii 1.16.2-2       <- installed
+#   user dbus.socket:  inactive          <- the cause
+#   /run/user/503/bus: ABSENT
+#
+# Rootless podman defaults to the systemd cgroup manager, which needs that
+# bus, so the first in-VM `podman build` dies at its first RUN step with
+# "sd-bus call: Interactive authentication required." — issue #319. Only a
+# reboot or manager restart fixed it, because a *fresh* manager starts with
+# the package already present. That is why retrying `cage create` worked
+# and why waiting never could: the socket was never going to appear.
+#
+# `systemctl restart user@<uid>.service` (verified in-guest: dbus.socket
+# inactive -> active, bus socket ABSENT -> PRESENT) is preferred over
+# `systemctl --user daemon-reload && systemctl --user start dbus.socket`:
+# this script runs as root, so `systemctl --user` would target root's own
+# manager, and reaching the cage user's manager instead needs XDG_RUNTIME_DIR
+# plumbing that is exactly what is half-initialised here. Running as root
+# during provisioning also means no polkit prompt — unlike `loginctl
+# enable-linger`, which is avoided for the reason documented above.
+#
+# Only the manager unit is restarted; the live SSH session lives in its own
+# session scope under user-<uid>.slice and is not torn down. Non-fatal: a
+# warning is better than aborting the whole provisioning run.
+lima_uid="$(id -u "$lima_user" 2>/dev/null || true)"
+if [ -n "$lima_uid" ]; then
+    systemctl restart "user@${lima_uid}.service" \
+        || echo "warning: failed to restart user@${lima_uid}.service; rootless podman may lack its user D-Bus" >&2
+else
+    echo "warning: could not resolve uid for $lima_user; skipping user manager restart" >&2
+fi
+
 echo "agentcage provisioning complete"

--- a/tests/test_lima_provisioning.py
+++ b/tests/test_lima_provisioning.py
@@ -229,6 +229,74 @@ class TestGenerateLimaConfig:
         assert not any("loginctl" in ln for ln in code_lines)
         assert "/var/lib/systemd/linger" in output
 
+    def test_provision_restarts_user_manager_for_dbus_socket(self):
+        """Issue #319: apt installs `dbus-user-session` underneath a
+        `user@<uid>.service` that Lima's own SSH bring-up already started,
+        and a running user manager never loads a socket unit that appeared
+        beneath it. `/run/user/<uid>/bus` therefore stays absent for the
+        whole boot, and rootless podman's systemd cgroup manager fails every
+        container it creates with "sd-bus call: Interactive authentication
+        required." Provisioning must restart the manager so it picks up
+        dbus.socket."""
+        cfg = MockConfig(name="test-cage")
+        output = generate_lima_config(cfg)
+        code_lines = [
+            ln for ln in output.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        joined = "\n".join(code_lines)
+        # The uid is resolved from the templated guest username, not guessed.
+        assert 'id -u "$lima_user"' in joined
+        assert 'systemctl restart "user@${lima_uid}.service"' in joined
+
+    def test_user_manager_restart_runs_after_install_and_linger(self):
+        """Ordering is load-bearing: restarting before the apt install would
+        bring the manager back up without dbus.socket, and restarting before
+        the linger sentinel exists would let logind reap the fresh manager."""
+        cfg = MockConfig(name="test-cage")
+        output = generate_lima_config(cfg)
+        code_lines = [
+            ln for ln in output.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+
+        def _index(needle):
+            hits = [i for i, ln in enumerate(code_lines) if needle in ln]
+            assert hits, f"{needle!r} not found in provisioning code"
+            return hits[0]
+
+        install = _index("dbus-user-session")
+        linger = _index('touch "/var/lib/systemd/linger/$lima_user"')
+        restart = _index('systemctl restart "user@${lima_uid}.service"')
+        assert install < restart
+        assert linger < restart
+
+    def test_user_manager_restart_is_non_fatal(self):
+        """`set -euo pipefail` is in force, so an unguarded failing restart
+        would abort provisioning and leave a half-built VM. Consistent with
+        the script's `usermod ... || true` style, it must only warn."""
+        cfg = MockConfig(name="test-cage")
+        output = generate_lima_config(cfg)
+        restart_block = output.split('systemctl restart "user@${lima_uid}.service"')[1]
+        # The very next thing after the restart is its `|| echo warning:` guard.
+        assert restart_block.lstrip().startswith("\\")
+        assert "|| echo" in restart_block.split("\n")[1]
+        assert "warning:" in restart_block
+
+    def test_user_manager_restart_does_not_use_loginctl(self):
+        """The restart must not reintroduce the logind D-Bus path that
+        `test_provision_does_not_call_loginctl_enable_linger` rules out, and
+        must not use `systemctl --user`, which as root targets root's own
+        manager rather than the cage user's."""
+        cfg = MockConfig(name="test-cage")
+        output = generate_lima_config(cfg)
+        code_lines = [
+            ln for ln in output.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        assert not any("loginctl" in ln for ln in code_lines)
+        assert not any("systemctl --user" in ln for ln in code_lines)
+
     def test_name_in_comment(self):
         cfg = MockConfig(name="my-agent")
         output = generate_lima_config(cfg)

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -908,18 +908,20 @@ class TestInVmBuildFailureDiagnostics:
 
 
 class TestUserSessionReadinessGate:
-    """Issue #319: on a fresh Lima VM the first in-VM ``podman build`` failed
-    because ``limactl shell`` opens a non-login session and the guest's
-    systemd user manager / user D-Bus was not up yet, so rootless podman's
-    systemd cgroup manager could not make its sd-bus call::
+    """Issue #319 safety net. Rootless podman's systemd cgroup manager needs
+    the guest user's D-Bus, and without it every container creation fails::
 
         warning: The cgroupv2 manager is set to systemd but there is no
                  systemd user session available
         error running container: from /usr/bin/crun ...: sd-bus call:
                  Interactive authentication required.: Permission denied
 
-    A retry always succeeded, which is why this is a readiness gate (probe
-    the precondition once, wait for it) and NOT a retry around the build."""
+    The cause is fixed in provisioning (see
+    ``TestUserManagerRestartForDbusSocket``), so this gate is defense in
+    depth: it should resolve on its first probe, and on timeout it names the
+    precondition and still hands over to the build rather than stalling or
+    failing early. It is a gate, never a retry — the build runs exactly
+    once, so genuine build failures still fail immediately."""
 
     @staticmethod
     def _is_probe(cmd) -> bool:
@@ -1022,10 +1024,13 @@ class TestUserSessionReadinessGate:
         ]
         assert len(builds) == 1, "the build must still be attempted on timeout"
         err = capsys.readouterr().err
-        # The timeout message names the precondition, not just "timed out".
-        assert "systemd user session" in err
+        # The timeout message names the precondition, not just "timed out",
+        # and points at the provisioning fault rather than implying that
+        # waiting or retrying is the remedy.
         assert "/run/user/<uid>/bus" in err
         assert "no-user-bus" in err
+        assert "dbus.socket" in err
+        assert "#319" in err
 
     def test_wait_is_bounded(self):
         """Never an unbounded loop: the wait returns False at the deadline."""

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -24,6 +24,18 @@ def _make_config(name: str = "testcage") -> Config:
     return cfg
 
 
+def _ready_probe_exec(cmd, **kwargs):
+    """Mock ``LimaInstance.exec`` for a guest whose user session is already up.
+
+    ``build_artifacts`` gates the first in-VM podman call on the guest's
+    systemd user session (#319), so any mock guest must answer that probe —
+    otherwise every build test would sit out the full readiness timeout.
+    """
+    if any("is-system-running" in str(a) for a in cmd):
+        return MagicMock(returncode=0, stdout="running\n", stderr="")
+    return MagicMock(returncode=0, stdout="", stderr="")
+
+
 class TestCheckPrerequisites:
     def test_delegates_to_lima_prerequisites(self):
         backend = VmBackend()
@@ -51,6 +63,7 @@ class TestBuildArtifacts:
         mock_inst = MagicMock()
         mock_inst.is_running.return_value = True
         mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = _ready_probe_exec
         config = _make_config()
 
         with patch.object(backend, "_instance", return_value=mock_inst), \
@@ -94,6 +107,7 @@ class TestBuildArtifacts:
         mock_inst = MagicMock()
         mock_inst.is_running.return_value = True
         mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = _ready_probe_exec
         with patch.object(backend, "_instance", return_value=mock_inst), \
              patch("subprocess.run", return_value=MagicMock(returncode=0)):
             backend.build_artifacts(
@@ -125,6 +139,7 @@ class TestBuildArtifacts:
         mock_inst = MagicMock()
         mock_inst.is_running.return_value = True
         mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = _ready_probe_exec
         config = _make_config()
         config.container.build.containerfile = "Containerfile"
 
@@ -782,7 +797,7 @@ class TestInVmBuildFailureDiagnostics:
                                  "--", *cmd],
                     output=stdout, stderr=stderr,
                 )
-            return MagicMock(returncode=0, stdout="", stderr="")
+            return _ready_probe_exec(cmd, **kwargs)
 
         return _exec
 
@@ -890,6 +905,171 @@ class TestInVmBuildFailureDiagnostics:
         err = capsys.readouterr().err
         assert "stdout bytes" in err
         assert "stderr bytes" in err
+
+
+class TestUserSessionReadinessGate:
+    """Issue #319: on a fresh Lima VM the first in-VM ``podman build`` failed
+    because ``limactl shell`` opens a non-login session and the guest's
+    systemd user manager / user D-Bus was not up yet, so rootless podman's
+    systemd cgroup manager could not make its sd-bus call::
+
+        warning: The cgroupv2 manager is set to systemd but there is no
+                 systemd user session available
+        error running container: from /usr/bin/crun ...: sd-bus call:
+                 Interactive authentication required.: Permission denied
+
+    A retry always succeeded, which is why this is a readiness gate (probe
+    the precondition once, wait for it) and NOT a retry around the build."""
+
+    @staticmethod
+    def _is_probe(cmd) -> bool:
+        return any("is-system-running" in str(a) for a in cmd)
+
+    @staticmethod
+    def _backend_with(exec_side_effect):
+        backend = VmBackend()
+        mock_inst = MagicMock()
+        mock_inst.is_running.return_value = True
+        mock_inst.name = "agentcage-testcage"
+        mock_inst.exec.side_effect = exec_side_effect
+        return backend, mock_inst
+
+    def test_ready_session_passes_straight_through(self):
+        """A warm VM costs exactly one probe and no sleep."""
+        import time as _time
+
+        backend, mock_inst = self._backend_with(_ready_probe_exec)
+
+        with patch.object(backend, "_instance", return_value=mock_inst), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)):
+            t0 = _time.monotonic()
+            backend.build_artifacts(_make_config(), "testcage")
+            elapsed = _time.monotonic() - t0
+
+        probes = [c for c in mock_inst.exec.call_args_list if self._is_probe(c[0][0])]
+        assert len(probes) == 1
+        assert elapsed < 0.5
+        builds = [
+            c for c in mock_inst.exec.call_args_list
+            if "podman" in str(c) and "build" in str(c)
+        ]
+        assert len(builds) == 1
+
+    def test_degraded_counts_as_ready(self):
+        """``is-system-running`` exits non-zero for ``degraded``, but the bus
+        and the cgroup delegation are live — that must not block the build."""
+        from agentcage.backends.vm import _wait_user_session_ready
+
+        mock_inst = MagicMock()
+        mock_inst.exec.return_value = MagicMock(returncode=1, stdout="degraded\n")
+
+        assert _wait_user_session_ready(
+            mock_inst, timeout_s=5.0, interval_s=0.01,
+        ) is True
+        assert mock_inst.exec.call_count == 1
+
+    def test_waits_then_proceeds_when_session_appears(self, capsys):
+        """The gate polls while the precondition is missing and continues as
+        soon as it appears — the build is still dispatched exactly once."""
+        states = ["no-user-bus", "starting", "running"]
+
+        def _exec(cmd, **kwargs):
+            if TestUserSessionReadinessGate._is_probe(cmd):
+                return MagicMock(returncode=0, stdout=states.pop(0) + "\n")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        backend, mock_inst = self._backend_with(_exec)
+
+        with patch.object(backend, "_instance", return_value=mock_inst), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("agentcage.backends.vm.VM_USER_SESSION_POLL_INTERVAL_S", 0.01):
+            backend.build_artifacts(_make_config(), "testcage")
+
+        assert states == []
+        calls = mock_inst.exec.call_args_list
+        probe_idx = [i for i, c in enumerate(calls) if self._is_probe(c[0][0])]
+        build_idx = [
+            i for i, c in enumerate(calls)
+            if "podman" in str(c) and "build" in str(c)
+        ]
+        assert len(probe_idx) == 3
+        assert len(build_idx) == 1
+        # The gate must close BEFORE the first in-VM podman invocation.
+        assert max(probe_idx) < build_idx[0]
+        out = capsys.readouterr().out
+        assert "Waiting for the guest systemd user session" in out
+
+    def test_timeout_still_attempts_the_build(self, capsys):
+        """A gate timeout is a hint, not a verdict: failing early would swap
+        one opaque error for another and discard podman's real diagnostic,
+        which #322 exists to surface."""
+        def _exec(cmd, **kwargs):
+            if TestUserSessionReadinessGate._is_probe(cmd):
+                return MagicMock(returncode=0, stdout="no-user-bus\n")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        backend, mock_inst = self._backend_with(_exec)
+
+        with patch.object(backend, "_instance", return_value=mock_inst), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("agentcage.backends.vm.VM_USER_SESSION_TIMEOUT_S", 0.02), \
+             patch("agentcage.backends.vm.VM_USER_SESSION_POLL_INTERVAL_S", 0.01):
+            backend.build_artifacts(_make_config(), "testcage")
+
+        builds = [
+            c for c in mock_inst.exec.call_args_list
+            if "podman" in str(c) and "build" in str(c)
+        ]
+        assert len(builds) == 1, "the build must still be attempted on timeout"
+        err = capsys.readouterr().err
+        # The timeout message names the precondition, not just "timed out".
+        assert "systemd user session" in err
+        assert "/run/user/<uid>/bus" in err
+        assert "no-user-bus" in err
+
+    def test_wait_is_bounded(self):
+        """Never an unbounded loop: the wait returns False at the deadline."""
+        from agentcage.backends.vm import _wait_user_session_ready
+
+        mock_inst = MagicMock()
+        mock_inst.exec.return_value = MagicMock(returncode=0, stdout="starting\n")
+
+        assert _wait_user_session_ready(
+            mock_inst, timeout_s=0.02, interval_s=0.01,
+        ) is False
+
+    def test_probe_never_raises(self):
+        """A flaky ``limactl shell`` degrades to 'not ready', it must not
+        pre-empt the build with an exception from the gate itself."""
+        from agentcage.backends.vm import _probe_user_session
+
+        mock_inst = MagicMock()
+        mock_inst.exec.side_effect = RuntimeError("ssh: connection reset")
+
+        assert "probe failed" in _probe_user_session(mock_inst)
+
+    def test_probe_not_run_when_vm_not_running(self):
+        """No guest, no probe — the existing is_running() early return still
+        short-circuits before any limactl round-trip."""
+        backend = VmBackend()
+        mock_inst = MagicMock()
+        mock_inst.is_running.return_value = False
+
+        with patch.object(backend, "_instance", return_value=mock_inst):
+            backend.build_artifacts(_make_config(), "testcage")
+
+        mock_inst.exec.assert_not_called()
+
+    def test_probe_does_not_call_loginctl(self):
+        """``loginctl`` round-trips logind over D-Bus, and provisioning already
+        documents that logind can wedge for 25s during guest bring-up — that
+        must never sit inside a poll loop. Lingering is set by the provisioning
+        script's sentinel file instead."""
+        from agentcage.backends.vm import _USER_SESSION_PROBE
+
+        assert "loginctl" not in _USER_SESSION_PROBE
+        assert "/run/user/$uid/bus" in _USER_SESSION_PROBE
+        assert "systemctl --user is-system-running" in _USER_SESSION_PROBE
 
 
 class TestDeployCageStartOrder:


### PR DESCRIPTION
Closes #319. PR #322 landed the diagnostic half (surfacing the captured in-VM build output); this fixes the underlying failure it exposed.

**The fix is one line of provisioning.** The readiness gate in `backends/vm.py` is a safety net, not the remedy.

## The bug

First `agentcage cage create` with `isolation: vm` on a fresh macOS host fails building the egress image. With #322's output surfacing in place, the real error is:

```
Building egress image inside VM (agentcage-egress:0.32.0)...
error: build of agentcage-egress:0.32.0 failed inside the VM (exit status 1)

time="..." level=warning msg="The cgroupv2 manager is set to systemd but there is no systemd user session available"
time="..." level=warning msg="For using systemd, you may need to log in using a user session"
time="..." level=warning msg="Alternatively, you can enable lingering with: `loginctl enable-linger 503` (possibly as root)"
time="..." level=warning msg="Falling back to --cgroup-manager=cgroupfs"
error running container: from /usr/bin/crun creating container for [/bin/sh -c pip install --no-cache-dir pyyaml==6.0.3 'cryptography>=41']: sd-bus call: Interactive authentication required.: Permission denied
Error: building at STEP "RUN pip install --no-cache-dir pyyaml==6.0.3 'cryptography>=41'": while running runtime: exit status 1
```

Rootless podman defaults to `cgroup_manager = "systemd"`, which needs the guest user's D-Bus at `/run/user/<uid>/bus`. It is absent, so `crun` cannot create any container.

## Root cause

Caught live in the guest during a failing create:

```
bus socket:        ABSENT
user@503.service:  active          <- user manager IS running
systemd-logind:    active, loginctl rc=0, 2 sessions listed   <- NOT wedged
linger sentinel:   /var/lib/systemd/linger/luca present
user dbus.socket:  inactive        <- THE CAUSE
dbus-user-session: ii 1.16.2-2     <- installed
```

`provision.sh.j2` apt-installs `dbus-user-session`, but Lima SSHes into the guest *before* running the provisioning script, and that login has already started `user@<uid>.service`. **A running user manager does not load a socket unit that apt drops underneath it**, so `dbus.socket` stays inactive and `/run/user/<uid>/bus` never materializes for the life of that boot. On the next boot the manager starts fresh with the package present — which is exactly why a retry or `cage update` always worked.

Two earlier hypotheses were tested and **disproved**: it is not a generic startup race (the manager was already up), and logind was not wedged (the `usermod -aG` deadlock described in `provision.sh.j2`'s existing comment was not occurring).

## The fix — `provision.sh.j2`

Restart the cage user's manager at the end of provisioning so it picks up `dbus.socket`. Verified in-guest:

```
before:  dbus.socket inactive       /run/user/503/bus ABSENT
$ sudo systemctl restart "user@503.service"
after:   dbus.socket active         /run/user/503/bus PRESENT
```

```sh
lima_uid="$(id -u "$lima_user" 2>/dev/null || true)"
if [ -n "$lima_uid" ]; then
    systemctl restart "user@${lima_uid}.service" \
        || echo "warning: failed to restart user@${lima_uid}.service; ..." >&2
else
    echo "warning: could not resolve uid for $lima_user; ..." >&2
fi
```

Details that matter:

- **Ordering is load-bearing.** It runs after *both* the apt install (else the manager comes back up still without `dbus.socket`) and the linger sentinel touch (else logind could reap the fresh manager). Covered by a test.
- **Non-fatal.** `set -euo pipefail` is in force, so an unguarded failing restart would abort provisioning and leave a half-built VM. It only warns, matching the script's existing `usermod ... || true` style.
- **No `loginctl`.** The existing comment explaining the logind deadlock still stands; this path does not reintroduce it.
- **`systemctl restart user@<uid>.service`, not `systemctl --user ...`.** Provisioning runs as root, so `systemctl --user` would target *root's* manager; reaching the cage user's would need the XDG_RUNTIME_DIR plumbing that is precisely what is half-initialised here. Running as root also means no polkit — unlike the `loginctl enable-linger` that podman's own warning suggests, which over a remote SSH session is not an `allow_active` subject and would hit the same "Interactive authentication required" wall.
- Only the manager unit restarts; the live SSH session lives in its own session scope under `user-<uid>.slice` and is not torn down.

## The safety net — `backends/vm.py`

`_wait_user_session_ready()` runs immediately before the first in-VM podman invocation in `build_artifacts`, probing in one round-trip:

```sh
uid=$(id -u)
if [ ! -S "/run/user/$uid/bus" ]; then echo no-user-bus; exit 0; fi
systemctl --user is-system-running 2>/dev/null || true
```

Ready = socket exists **and** state is `running` or `degraded` (`degraded` only means some unrelated user unit failed; the bus and cgroup delegation are live — and it exits non-zero, which is why the gate matches on stdout, not the exit code).

With the provisioning fix the bus is already present, so this is a single probe with no sleep. Reframed accordingly since the first revision of this PR:

- **Ceiling cut 90s → 20s.** A missing bus here is a provisioning fault that waiting cannot repair; a long stall would only delay the real error.
- **Warning text rewritten** so it no longer implies waiting or retrying is the remedy — it now names `dbus.socket` and points at recreating the VM.
- **Timeout still hands over to the build** (unchanged), so #322's diagnostics report podman's real error rather than a synthetic early failure.
- **A gate, never a retry.** The build is dispatched exactly once, so genuine build failures still fail immediately and loudly.
- The probe never raises; a flaky `limactl shell` degrades to "not ready yet".

### Why the first revision of this PR was not enough

The gate alone was runtime-verified on a fresh host and **did not fix the create**:

```
warning: gave up after 90s waiting for the guest systemd user session ...
  last probe reported 'no-user-bus'. Building anyway — ...
... sd-bus call: Interactive authentication required.: Permission denied
```

The timeout-then-build-anyway fallback behaved exactly as designed and #322's diagnostics surfaced the real error — but waiting was the wrong remedy, because the socket was never going to appear. Hence the provisioning fix.

`--cgroup-manager=cgroupfs` was rejected throughout: it changes the runtime's cgroup semantics to paper over the problem, and podman's own automatic fallback to cgroupfs is visible in the captured log immediately before the build failed anyway.

## Tests

`tests/test_lima_provisioning.py` (new, in the style of the existing `test_provision_does_not_call_loginctl_enable_linger`):

- the restart is present and resolves the uid from the templated guest username;
- it is ordered after both the apt install and the linger sentinel;
- it is guarded so a failure warns instead of aborting provisioning;
- it uses neither `loginctl` nor `systemctl --user`.

`TestUserSessionReadinessGate` in `tests/test_vm_backend.py` (mocked `LimaInstance`, no Lima required) is retained: ready session passes straight through in one probe; `degraded` counts as ready; the gate polls and proceeds when the precondition appears, strictly before the first podman call; **timeout still attempts the build**, with a message naming the precondition; the wait is bounded; the probe never raises; no probe when the VM isn't running; no `loginctl` in the probe.

`uv run pytest`: baseline on `origin/master` @ `8546697` is `12 failed, 2052 passed, 47 skipped, 6 errors`; with this branch `12 failed, 2064 passed, 47 skipped, 6 errors`. The failing/erroring sets are identical — the known unrelated macOS-host backend failures. Delta: **+12 passed, 0 new failures**.

## Verification

The provisioning change cannot be exercised by unit tests — it only runs inside a booting Lima guest, Lima is not available in CI, and the task constraints forbid running `limactl`/`podman`/`cage create` here. The in-guest remedy was verified manually (`dbus.socket` inactive → active, bus ABSENT → PRESENT). **This needs a runtime re-verification on a fresh macOS host with no Lima instances** — @tl-luca-martinetti will do that run. Note that the first revision of this PR already passed unit tests and still failed on real hardware, so that run is the only test that counts here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
