### PR TITLE
feat(vm): domains.auto support on the vm backend

### DIFF
--- a/docs/reference/policy-api.md
+++ b/docs/reference/policy-api.md
@@ -68,11 +68,16 @@ approved grants into the static baseline and prunes expired entries — runs
 on the **container** backend (systemd user unit; explicitly `systemctl
 --user enable`d so it survives host reboots — the egress quadlet units are
 generator-activated at boot, and without the enable the watcher would stay
-dead after a reboot while the cage came up) and **apple-container**
-(launchd plist). The **vm** backend is not supported in v1: the host CLI
-cannot watch a guest-side overlay, so `domains.auto` grants are decided and
-L7-enforced but never promoted to the baseline/DNS (the CLI warns when this
-matters, e.g. `domain add --expires-in` on a vm cage).
+dead after a reboot while the cage came up), the **apple-container**
+backend (launchd plist), and the **vm** backend (systemd user unit on Linux
+hosts, launchd plist on macOS hosts; 5s poll — each tick is an SSH
+round-trip). On vm cages the grants overlay lives VM-LOCAL
+(`~/.config/agentcage-vm/cages/<name>/grants/` inside the guest, like the
+other hot-reloaded config files): the in-guest egress addon writes it with
+no Lima-mount staleness, and the host watcher pulls/pushes it over
+`limactl shell` (the same reliable base64 channel used for
+`dns-allowlist.conf`). A stopped VM is a quiet no-op tick; grants decided
+while the cage is down are promoted when it next runs.
 | `GET`  | `/v1/health` | Liveness + feature flags (which endpoints are enabled). |
 
 ### `GET /v1/allowlist`

--- a/src/agentcage/backends/apple_container.py
+++ b/src/agentcage/backends/apple_container.py
@@ -860,55 +860,13 @@ class AppleContainerBackend:
     def _install_grants_plist(self, name: str) -> None:
         """Write + load the per-cage grants-watcher launchd plist.
 
-        Keeps the watcher alive across restarts (``KeepAlive=true``, unlike
-        the cage autostart plist which is ``RunAtLoad`` only) so approved
-        grants are promoted promptly and expired ``--expires-in`` entries
-        pruned. Idempotent. Best-effort immediate-load (same SSH reachability
-        caveat as the cage plist); the FILE is the persistence.
+        Delegates to :func:`agentcage.watcher.install_grants_watcher_plist`
+        (shared with the vm backend on macOS hosts).
         """
-        import shutil as _shutil, subprocess as _sp
-        binary = _shutil.which("agentcage") or "agentcage"
-        plist = self._grants_plist_path(name)
-        plist.parent.mkdir(parents=True, exist_ok=True)
-        state_dir = self._state_dir(name)
-        state_dir.mkdir(parents=True, exist_ok=True)
-        label = f"io.agentcage.{name}.grants"
-        plist_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>{label}</string>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>ProgramArguments</key>
-    <array>
-        <string>{binary}</string>
-        <string>cage</string>
-        <string>grants</string>
-        <string>{name}</string>
-        <string>watch</string>
-        <string>--interval</string>
-        <string>1</string>
-    </array>
-    <key>StandardOutPath</key>
-    <string>{state_dir}/grants.out.log</string>
-    <key>StandardErrorPath</key>
-    <string>{state_dir}/grants.err.log</string>
-</dict>
-</plist>
-"""
-        plist.write_text(plist_xml)
-        uid = os.getuid()
-        domain = f"gui/{uid}"
-        if not self._gui_domain_reachable(uid):
-            return  # file is persistence; immediate-load not available over SSH
-        _sp.run(["launchctl", "bootout", f"{domain}/{label}"],
-                check=False, capture_output=True)
-        _sp.run(["launchctl", "bootstrap", domain, str(plist)],
-                check=False, capture_output=True)
+        from agentcage.watcher import install_grants_watcher_plist
+        install_grants_watcher_plist(
+            name, log_dir=self._state_dir(name), plist_path=self._grants_plist_path(name),
+        )
 
     def _uninstall_grants_plist(self, name: str) -> None:
         """Unload + remove the per-cage grants-watcher plist. No-op if absent."""

--- a/src/agentcage/backends/vm.py
+++ b/src/agentcage/backends/vm.py
@@ -103,6 +103,81 @@ PROXY_READINESS_TIMEOUT_S = 30
 PROXY_READINESS_POLL_INTERVAL_S = 0.25
 
 
+def ensure_grants_dir(name: str, inst: LimaInstance) -> None:
+    """Create the VM-local grants overlay dir inside the guest.
+
+    The egress quadlet's ExecStartPre chmods this dir (podman-in-guest
+    ``unshare chgrp`` + 0770) BEFORE podman run processes the Volume bind,
+    so it must already exist at unit start — podman's implicit
+    volume-source mkdir only happens later. Idempotent; one exec
+    round-trip.
+    """
+    from agentcage.quadlets import vm_local_grants_dir
+    home = inst.exec(["bash", "-c", "echo ~"]).stdout.strip()
+    p = vm_local_grants_dir(name)
+    abspath = home + p[2:] if p.startswith("%h") else p
+    inst.exec(["mkdir", "-p", abspath])
+
+
+def pull_grants(name: str, inst: LimaInstance) -> list[dict] | None:
+    """Read the VM-local grants overlay from inside the guest.
+
+    Returns the parsed entries, ``[]`` when the overlay is absent or
+    unreadable (mirroring ``state.load_grants`` semantics), or ``None``
+    when the round-trip itself failed — callers treat ``None`` as
+    "VM not reachable, skip this tick" rather than "empty overlay"
+    (a stopped VM must not look like a mass revoke of every overlay
+    entry... the watcher only READS, but conflating the two would also
+    re-audit and re-prune on every unreachable tick).
+    """
+    import yaml
+    from agentcage.quadlets import vm_local_grants_file
+    try:
+        home = inst.exec(["bash", "-c", "echo ~"]).stdout.strip()
+        p = vm_local_grants_file(name)
+        abspath = home + p[2:] if p.startswith("%h") else p
+        res = inst.exec(["cat", abspath], check=False)
+    except Exception:
+        return None
+    if res.returncode != 0:
+        # Missing file (fresh cage) or transient guest error. A missing
+        # overlay is the normal empty state; anything else still degrades
+        # to empty rather than killing the watcher tick.
+        return []
+    try:
+        data = yaml.safe_load(res.stdout or "")
+    except (yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def push_grants(name: str, entries: list[dict], inst: LimaInstance) -> None:
+    """Write the VM-local grants overlay inside the guest (atomic).
+
+    Base64 over ``limactl shell`` — the same reliable host→guest channel
+    ``push_config_files`` uses (the Lima mounts cannot be trusted for
+    host→guest writes). The write is temp+``mv`` so the in-guest addon's
+    mtime-poll never observes a truncated file mid-write.
+    """
+    import yaml
+    from agentcage.quadlets import vm_local_grants_file
+    home = inst.exec(["bash", "-c", "echo ~"]).stdout.strip()
+    p = vm_local_grants_file(name)
+    abspath = home + p[2:] if p.startswith("%h") else p
+    encoded = base64.b64encode(
+        yaml.safe_dump(entries, default_flow_style=False,
+                       sort_keys=False).encode()
+    ).decode()
+    inst.exec([
+        "bash", "-c",
+        f"echo '{encoded}' | base64 -d > {shlex.quote(abspath)}.tmp "
+        f"&& mv {shlex.quote(abspath)}.tmp {shlex.quote(abspath)}",
+    ])
+
+
+
 def _dump_service_failure(inst: LimaInstance, svc: str) -> None:
     """Print ``systemctl status`` + last ``journalctl`` lines for ``svc``.
 
@@ -528,6 +603,18 @@ class VmBackend:
     def unit_dir(self) -> Path:
         return Path(os.path.expanduser("~/.config/agentcage/lima"))
 
+    def grants_unit_path(self, name: str) -> Path:
+        """Host-side systemd user-unit path for the grants watcher.
+
+        The watcher itself runs on the HOST (it writes the operator's
+        cage.yaml and drives the VM-aware live-reload chain via
+        ``limactl shell``), so its unit is a native systemd USER unit in
+        ``~/.config/systemd/user/`` — the same location the container
+        backend uses — NOT in the guest's quadlet dir that
+        ``install_units`` targets.
+        """
+        return Path(os.path.expanduser("~/.config/systemd/user")) / f"{name}-grants.service"
+
     def install_units(self, units: dict[str, str], *, quiet: bool = False) -> None:
         dest = self.unit_dir()
         dest.mkdir(parents=True, exist_ok=True)
@@ -644,6 +731,11 @@ class VmBackend:
         # ``push_config_files`` and ``cli._update_dns_quadlet``.
         with Phase("deploy.vm_local_config", cage=name):
             push_config_files(name, inst)
+            # The grants overlay dir must exist BEFORE the egress unit's
+            # ExecStartPre chmods it (podman's implicit volume-source mkdir
+            # runs later). Also gives the in-guest addon a fresh empty
+            # overlay on first deploy.
+            ensure_grants_dir(name, inst)
 
         # Bridge secrets from host Podman into VM's Podman
         with Phase("deploy.bridge_secrets", cage=name):

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -4417,25 +4417,36 @@ def _ensure_grants_watcher(name: str, cfg) -> None:
         return
     unit_path_fn = getattr(backend, "grants_unit_path", None)
     if unit_path_fn is None:
-        # VM backend: no host-side watcher in v1. The entry is still
-        # enforced at L7 immediately; but the baseline + dnsmasq are not
-        # pruned and Policy-API grants are not promoted on VM.
-        if isolation == "vm":
-            click.echo(
-                "warning: the grants watcher is not supported on the vm "
-                "backend in v1 — expiry is enforced at the proxy (L7), but "
-                "the baseline/DNS are not pruned and domains.auto grants "
-                "are not promoted on VM", err=True)
         return  # backend without host-side systemd units
+    if isolation == "vm" and sys.platform == "darwin":
+        # VM cage on a macOS host (Lima/vz): the watcher runs on the host
+        # like any other backend, supervised by launchd instead of
+        # systemd. Same plist the apple-container backend installs —
+        # the watcher command is isolation-agnostic (the overlay IO and
+        # the live-reload chain dispatch on isolation internally). A 5s
+        # interval: each tick is a limactl SSH round-trip to pull the
+        # guest-local overlay, so 1 Hz would be chatty for no benefit.
+        try:
+            from agentcage.watcher import install_grants_watcher_plist
+            install_grants_watcher_plist(
+                name, log_dir=state.cage_data_dir(name), interval=5)
+        except Exception as e:
+            click.echo(f"warning: could not install grants watcher: {e}",
+                        err=True)
+        return
     unit_path = unit_path_fn(name)
     if unit_path is None:
         return
     # Render + install the unit if missing (mirrors quadlets._grants_service_unit).
+    # VM cages poll at 5s: each tick is a limactl SSH round-trip to pull
+    # the guest-local overlay (container/apple ticks are a local file
+    # read, so 1s is fine there).
+    _interval = 5 if isolation == "vm" else 1
     if not unit_path.exists():
         try:
             from agentcage.quadlets import _grants_service_unit
             unit_path.parent.mkdir(parents=True, exist_ok=True)
-            unit_path.write_text(_grants_service_unit(name))
+            unit_path.write_text(_grants_service_unit(name, interval=_interval))
             from agentcage import systemd as _systemd
             _systemd.daemon_reload()
         except Exception as e:
@@ -4615,6 +4626,47 @@ def grants(name: str):
     """Manage Policy API runtime domain grants (see docs/explain/policy-api.md)."""
 
 
+def _load_grants_overlay(name: str, cfg) -> list[dict] | None:
+    """Load the grants overlay for a cage, isolation-aware.
+
+    Container/apple cages: the host-side file (``state.load_grants``).
+    VM cages: the overlay lives VM-LOCAL inside the guest (see
+    ``quadlets.vm_local_grants_dir`` — Lima mounts can't be trusted for
+    host→guest rewrites), so it is pulled over ``limactl shell``
+    (``backends.vm.pull_grants``). Returns ``None`` when the VM round-trip
+    failed (VM stopped / unreachable) — callers distinguish that from an
+    empty overlay: for the watcher it means "skip this tick quietly",
+    for manual commands it is an error.
+    """
+    if getattr(cfg, "isolation", "container") == "vm":
+        from agentcage.lima.instance import LimaInstance
+        from agentcage.backends.vm import pull_grants
+        return pull_grants(name, LimaInstance(name))
+    return state.load_grants(name)
+
+
+def _save_grants_overlay(name: str, cfg, entries: list[dict]) -> None:
+    """Write the grants overlay for a cage, isolation-aware.
+
+    VM cages: pushed guest-side via base64 over ``limactl shell`` (atomic
+    temp+``mv`` so the in-guest addon's mtime-poll never sees a truncated
+    file). Other backends: the host-side atomic write.
+    """
+    if getattr(cfg, "isolation", "container") == "vm":
+        from agentcage.lima.instance import LimaInstance
+        from agentcage.backends.vm import push_grants
+        push_grants(name, entries, LimaInstance(name))
+        return
+    state.save_grants(name, entries)
+
+
+def _grants_vm_unreachable(name: str) -> None:
+    """Error out: a manual grants command needs the VM running."""
+    click.echo(
+        f"error: could not reach the VM for cage '{name}' — the grants "
+        f"overlay lives guest-side. Start the cage and retry.", err=True)
+    sys.exit(1)
+
 @grants.command("list")
 def grants_list():
     """List runtime grants (overlay) and the static baseline for a cage."""
@@ -4635,7 +4687,9 @@ def grants_list():
     baseline = list(cfg.domains.allow)
     click.echo("Baseline: " + (" ".join(sorted(baseline)) if baseline else "(empty)"))
 
-    entries = state.load_grants(name)
+    entries = _load_grants_overlay(name, cfg)
+    if entries is None:
+        _grants_vm_unreachable(name)
     if not entries:
         click.echo("(no runtime grants)")
         return
@@ -4662,6 +4716,7 @@ def grants_promote(domain: str):
     except FileNotFoundError:
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+    cfg = state.load_deployment_config(name)
     _ensure_v022_cage(name)
     _ensure_domain_section(raw)
     dom = raw["domains"]
@@ -4682,7 +4737,9 @@ def grants_promote(domain: str):
     # domains.expires — otherwise a ttl_seconds grant promoted by hand
     # silently becomes permanent (the watcher's auto-promote has the same
     # fix; see _tick step 2).
-    overlay_entries = state.load_grants(name)
+    overlay_entries = _load_grants_overlay(name, cfg)
+    if overlay_entries is None:
+        _grants_vm_unreachable(name)
     grant_entry = next(
         (e for e in overlay_entries
          if _grant_domain_match(str(e.get("domain", "")), domain)),
@@ -4755,10 +4812,10 @@ def grants_promote(domain: str):
     # lost-update race the watcher's _tick step 3 guards — see Fix 1).
     revoked_dl = domain.rstrip(".").lower()
     remaining = [
-        e for e in state.load_grants(name)
+        e for e in (_load_grants_overlay(name, cfg) or [])
         if str(e.get("domain", "")).rstrip(".").lower() != revoked_dl
     ]
-    state.save_grants(name, remaining)
+    _save_grants_overlay(name, cfg, remaining)
     click.echo(
         f"Promoted '{domain}' into the baseline and removed it from the "
         f"runtime overlay."
@@ -4779,8 +4836,11 @@ def grants_revoke(domain: str):
     except FileNotFoundError:
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+    cfg = state.load_deployment_config(name)
 
-    entries = state.load_grants(name)
+    entries = _load_grants_overlay(name, cfg)
+    if entries is None:
+        _grants_vm_unreachable(name)
     remaining = [
         e for e in entries
         if not _grant_domain_match(str(e.get("domain", "")), domain)
@@ -4798,10 +4858,10 @@ def grants_revoke(domain: str):
     # this re-filter is the durable write.
     revoked_dl = domain.rstrip(".").lower()
     merged = [
-        e for e in state.load_grants(name)
+        e for e in (_load_grants_overlay(name, cfg) or [])
         if str(e.get("domain", "")).rstrip(".").lower() != revoked_dl
     ]
-    state.save_grants(name, merged)
+    _save_grants_overlay(name, cfg, merged)
     state.append_policy_audit(name, {
         "kind": "policy_grant_revoked",
         "domain": domain,
@@ -4858,6 +4918,12 @@ def grants_watch(interval: float, once: bool):
     except FileNotFoundError:
         click.echo(f"error: cage '{name}' does not exist", err=True)
         sys.exit(1)
+    # Isolation-aware overlay IO (see _load_grants_overlay): VM cages
+    # round-trip the guest-local overlay via limactl, others use the
+    # host-side file. Loaded once here; the config's isolation does not
+    # change while the watcher runs.
+    _watch_cfg = state.load_deployment_config(name)
+    _is_vm = getattr(_watch_cfg, "isolation", "container") == "vm"
 
     def _is_expired(entry: dict) -> bool:
         exp = str(entry.get("expires_at", "") or "")
@@ -4889,7 +4955,19 @@ def grants_watch(interval: float, once: bool):
 
     def _tick() -> bool:
         """Process the overlay once. Returns True if anything changed."""
-        entries = state.load_grants(name)
+        # VM cages: the overlay lives guest-side. Pull it over limactl;
+        # an unreachable VM (stopped cage) is a quiet no-op tick, not an
+        # error — the watcher keeps running so it picks up the overlay
+        # again once the cage starts. (L7 enforcement inside the egress
+        # is unaffected either way.)
+        if _is_vm:
+            from agentcage.lima.instance import LimaInstance
+            inst = LimaInstance(name)
+            if not inst.is_running():
+                return False
+        entries = _load_grants_overlay(name, _watch_cfg)
+        if entries is None:
+            return False
         changed = False
         # Domains this tick intentionally REMOVES from the overlay (expired
         # in step 1, promoted in step 2). Tracked explicitly so the step-3
@@ -5120,13 +5198,19 @@ def grants_watch(interval: float, once: bool):
         #    Only write if something actually changed to avoid churning
         #    the mtime the addon hot-reloads on.
         if changed:
-            current = state.load_grants(name)
+            current = _load_grants_overlay(name, _watch_cfg)
+            if current is None:
+                # VM went away mid-tick (stopped between the pull above
+                # and this write): keep the tick's baseline changes (they
+                # are already durable host-side) and skip the overlay
+                # write — the next reachable tick re-merges.
+                return changed
             merged = [
                 e for e in current
                 if str(e.get("domain", "")).rstrip(".").lower()
                 not in removed_domains
             ]
-            state.save_grants(name, merged)
+            _save_grants_overlay(name, _watch_cfg, merged)
         return changed
 
     if once:

--- a/src/agentcage/quadlets.py
+++ b/src/agentcage/quadlets.py
@@ -300,6 +300,30 @@ def vm_local_placeholders_env_path(name: str) -> str:
     return f"{vm_local_cage_env_dir(name)}/placeholders.env"
 
 
+def vm_local_grants_dir(name: str) -> str:
+    """VM-local dir of the Policy-API grants overlay.
+
+    Like the other ``vm_local_*`` paths, this lives OUTSIDE any Lima mount:
+    the in-guest egress addon writes ``grants.yaml`` here (atomic
+    temp+rename), and the HOST-side grants watcher pulls it back via
+    ``limactl shell cat`` and pushes removals back via base64 (see
+    ``backends.vm.pull_grants`` / ``push_grants``). Keeping the overlay
+    guest-local avoids Lima's reverse-sshfs host→guest write caching
+    (host-side rewrites of a mounted file would be invisible to the
+    addon's mtime-poll) and keeps the host-side
+    ``~/.local/share/agentcage/<name>/grants/`` dir operator-owned
+    (never world-writable) — the guest container writes only inside the
+    VM's own filesystem. Returned with the systemd ``%h`` specifier; see
+    ``vm_local_config_dir`` for why.
+    """
+    return f"{vm_local_config_dir(name)}/grants"
+
+
+def vm_local_grants_file(name: str) -> str:
+    """VM-local path of the grants overlay file. See ``vm_local_grants_dir``."""
+    return f"{vm_local_grants_dir(name)}/grants.yaml"
+
+
 # Note: a render_dns_quadlet() helper used to live here for the 3-service
 # shape so ``domain add`` / ``domain rm`` could regenerate just the dns
 # sidecar's quadlet when its --servers-file shape changed. In the 2-
@@ -961,8 +985,14 @@ def generate_quadlets(
     # mitmproxy's mtime-poll hot-reload.
     if config.isolation == "vm":
         proxy_config_path = vm_local_proxy_config_path(deploy_name or name)
+        # Grants overlay: VM-local too. The addon writes it in-guest (atomic
+        # rename, no sshfs cache) and the host watcher round-trips it via
+        # limactl (backends.vm.pull_grants/push_grants). See
+        # vm_local_grants_dir.
+        grants_dir_str = vm_local_grants_dir(deploy_name or name)
     else:
         proxy_config_path = config_host_path
+        grants_dir_str = str(_state.grants_dir(name))
 
     files[f"{name}-egress.container"] = env.get_template("egress.container.j2").render(
         **common,
@@ -984,7 +1014,7 @@ def generate_quadlets(
         capture_host_dir=capture_host_dir,
         domains_auto_enabled=bool(getattr(config.domains.auto, "enable", False))
             or bool(getattr(config.domains, "expires", None)),
-        grants_host_dir=str(_state.grants_dir(name)),
+        grants_host_dir=grants_dir_str,
         passthrough_regex=pt_regex,
         rootless=rootless,
         inspected_tcp_ports=_inspected_tcp,
@@ -1100,19 +1130,25 @@ def generate_quadlets(
         or bool(getattr(config.domains, "expires", None))
     )
     # VM deploys skip the unit: the file would be copied into the guest's
-    # systemd dir where plain .service files never load (not Quadlets), and
-    # the host CLI can't run the watcher against a guest-side overlay.
-    # domains.auto on the vm backend is not supported in v1 (the CLI warns
-    # in _ensure_grants_watcher); container deploys install it into the
-    # host's systemd user dir via the container backend.
+    # systemd dir where plain .service files never load (not Quadlets) —
+    # and the watcher must run on the HOST anyway (it writes the
+    # operator's cage.yaml baseline and drives the VM-aware live-reload
+    # chain via limactl). VM cages get the unit installed host-side by
+    # ``cli._ensure_grants_watcher`` instead (systemd on Linux hosts,
+    # launchd on macOS hosts).
     if needs_watcher and config.isolation != "vm":
         files[f"{name}-grants.service"] = _grants_service_unit(name)
 
     return files
 
 
-def _grants_service_unit(name: str) -> str:
+def _grants_service_unit(name: str, interval: int = 1) -> str:
     """Render the auto-start grants-watcher systemd user unit.
+
+    ``interval`` is the poll interval in seconds. VM cages use a longer
+    interval (each tick is a ``limactl shell`` SSH round-trip to pull the
+    guest-local overlay, so 1 Hz would be chatty; 5 s keeps grant
+    promotion latency negligible).
 
     Plain ``.service`` (not a quadlet): the watcher must run on the host so
     it can write the operator's ``cage.yaml`` baseline and exec into the
@@ -1152,7 +1188,7 @@ After={name}-egress.service
 [Service]
 Type=simple
 # Reuses the literal ``domain add`` live-reload chain for every grant.
-ExecStart={shlex.quote(_agentcage_cli())} cage grants {shlex.quote(name)} watch --interval 1
+ExecStart={shlex.quote(_agentcage_cli())} cage grants {shlex.quote(name)} watch --interval {interval}
 Restart=on-failure
 RestartSec=2
 # Stop cleanly on shutdown so a restart doesn't leave a stale loop.

--- a/src/agentcage/state.py
+++ b/src/agentcage/state.py
@@ -202,6 +202,17 @@ def capture_file(name: str) -> Path:
 # the per-cage request rate limit; last-writer-wins on the rare overlap.
 
 
+def cage_data_dir(name: str) -> Path:
+    """Return (and create) ~/.local/share/agentcage/<name>/.
+
+    The per-cage data root: grants/, capture/, policy-audit.jsonl, and
+    watcher logs live under it.
+    """
+    d = _DATA_DIR / name
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def grants_dir(name: str) -> Path:
     """Return (and create) ~/.local/share/agentcage/<name>/grants/."""
     d = _DATA_DIR / name / "grants"

--- a/src/agentcage/templates/egress.container.j2
+++ b/src/agentcage/templates/egress.container.j2
@@ -46,8 +46,11 @@ Environment="AGENTCAGE_CAPTURE=/var/log/agentcage/capture/capture.jsonl"
 # writes decided grants here) and the host-side grants watcher (which reads
 # them and promotes into the static baseline via the ``domain add`` chain).
 # RW + acproxy-owned so the addon can write; the cage is in a separate
-# netns and cannot read it. Same per-cage host dir the CLI's
-# state.grants_file(name) points at, so the two see one backing file.
+# netns and cannot read it. On container/apple backends this is the host
+# dir state.grants_file(name) points at; on the vm backend it is a
+# VM-LOCAL dir (quadlets.vm_local_grants_dir — Lima mounts can't be
+# trusted for host↔guest rewrites), round-tripped by the host watcher
+# via limactl (backends.vm.pull_grants / push_grants).
 Volume={{ grants_host_dir }}:/var/lib/agentcage:Z
 Environment="AGENTCAGE_GRANTS_DIR=/var/lib/agentcage"
 {% endif %}

--- a/src/agentcage/watcher.py
+++ b/src/agentcage/watcher.py
@@ -1,0 +1,114 @@
+"""Shared installers for the host-side grants watcher.
+
+The grants watcher is a host process (``agentcage cage <name> grants
+watch``) regardless of isolation backend — it writes the operator's
+``cage.yaml`` baseline and drives the backend-aware live-reload chain
+(``_apply_baseline_change``). Only its supervisor differs by platform:
+
+* Linux hosts: a systemd user unit (``quadlets._grants_service_unit``,
+  installed by ``cli._ensure_grants_watcher``).
+* macOS hosts: a launchd agent plist (this module) — used by BOTH the
+  apple-container backend and the vm backend (Lima/vz cages on macOS).
+
+Extracted from ``backends/apple_container.py`` so the vm backend can
+install the identical plist without importing macOS-backend code.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def _gui_domain_reachable(uid: int) -> bool:
+    """Probe whether the ``gui/<uid>`` launchd domain is reachable now.
+
+    ``~/Library/LaunchAgents/`` plists live in the per-user *GUI* domain.
+    That domain is only addressable from a session that owns the Aqua
+    console (a local Terminal.app window, or a GUI login). Over SSH the
+    user session runs in the non-GUI ``user/<uid>`` context:
+    ``launchctl bootstrap gui/<uid>`` exits 0 but silently no-ops, because
+    the GUI domain isn't actually reachable from the SSH context — so the
+    watcher would appear "installed" but never load. We probe
+    reachability and, when unavailable, leave the plist file on disk (the
+    FILE is the persistence — it loads at the next GUI login).
+    """
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"gui/{uid}"],
+            capture_output=True, text=True,
+        )
+        return result.returncode == 0
+    except OSError:
+        return False
+
+
+def grants_watcher_plist_path(name: str) -> Path:
+    """Host path of the per-cage grants-watcher launchd plist."""
+    return Path(
+        os.path.expanduser(f"~/Library/LaunchAgents/io.agentcage.{name}.grants.plist")
+    )
+
+
+def install_grants_watcher_plist(
+    name: str,
+    *,
+    log_dir: Path,
+    interval: int = 1,
+    plist_path: Path | None = None,
+) -> None:
+    """Write + load the per-cage grants-watcher launchd plist.
+
+    ``KeepAlive=true`` (unlike the cage autostart plist, which is
+    ``RunAtLoad`` only) so approved grants are promoted promptly and
+    expired ``--expires-in`` entries pruned, and the watcher restarts if
+    it dies. Idempotent (bootout before bootstrap reloads a changed
+    plist). Best-effort immediate-load (the SSH GUI-domain caveat in
+    :func:`_gui_domain_reachable`); the FILE is the persistence.
+
+    ``log_dir`` receives the watcher's stdout/stderr logs; callers own
+    creating it.
+    """
+    binary = shutil.which("agentcage") or "agentcage"
+    plist = plist_path or grants_watcher_plist_path(name)
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    label = f"io.agentcage.{name}.grants"
+    plist_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{binary}</string>
+        <string>cage</string>
+        <string>grants</string>
+        <string>{name}</string>
+        <string>watch</string>
+        <string>--interval</string>
+        <string>{interval}</string>
+    </array>
+    <key>StandardOutPath</key>
+    <string>{log_dir}/grants.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>{log_dir}/grants.err.log</string>
+</dict>
+</plist>
+"""
+    plist.write_text(plist_xml)
+    uid = os.getuid()
+    domain = f"gui/{uid}"
+    if not _gui_domain_reachable(uid):
+        return  # file is persistence; immediate-load not available over SSH
+    subprocess.run(["launchctl", "bootout", f"{domain}/{label}"],
+                   check=False, capture_output=True)
+    subprocess.run(["launchctl", "bootstrap", domain, str(plist)],
+                   check=False, capture_output=True)

--- a/tests/test_policy_api_ttl.py
+++ b/tests/test_policy_api_ttl.py
@@ -304,8 +304,10 @@ class TestWatchBlocklistModeSkipsPromotion:
 class TestEnsureGrantsWatcherBackendGate:
     """_ensure_grants_watcher must never write a systemd unit at the
     apple-container launchd .plist path — the apple backend installs its
-    own plist. And it must warn (not silently no-op) on the vm backend,
-    where the watcher is unsupported in v1."""
+    own plist. VM cages now get a real host-side watcher: launchd plist
+    on macOS hosts, the same systemd user unit as the container backend
+    on Linux hosts (with a 5s poll interval — each tick is a limactl SSH
+    round-trip)."""
 
     @patch("agentcage.cli.get_backend")
     def test_apple_delegates_to_install_plist(self, mock_backend):
@@ -329,17 +331,60 @@ class TestEnsureGrantsWatcherBackendGate:
         assert not Path("/tmp/io.agentcage.x.grants.plist").exists()
 
     @patch("agentcage.cli.get_backend")
-    def test_vm_warns_and_skips(self, mock_backend, capsys):
-        backend = MagicMock(spec=[])
+    def test_vm_linux_writes_unit_with_5s_interval(self, mock_backend, tmp_path):
+        # Linux host (qemu Lima): the watcher is the SAME systemd user
+        # unit the container backend installs — host-side path, 5s
+        # interval (limactl round-trips make 1 Hz chatty).
+        backend = MagicMock()
+        unit = tmp_path / "x-grants.service"
+        backend.grants_unit_path.return_value = unit
+        del backend._install_grants_plist
         mock_backend.return_value = backend
 
         from agentcage.cli import _ensure_grants_watcher
+        import agentcage.systemd as _systemd
         cfg = MagicMock()
         cfg.isolation = "vm"
-        _ensure_grants_watcher("x", cfg)
+        with patch.object(_systemd, "start_unit") as mock_start, \
+             patch.object(_systemd, "enable_unit") as mock_enable:
+            _ensure_grants_watcher("x", cfg)
 
-        out = capsys.readouterr().err
-        assert "not supported on the vm backend" in out
+        assert unit.exists()
+        assert "--interval 5" in unit.read_text()
+        mock_start.assert_called_once_with("x-grants.service")
+        mock_enable.assert_called_once_with("x-grants.service")
+
+    @patch("agentcage.cli.get_backend")
+    def test_vm_darwin_installs_plist(self, mock_backend, tmp_path, monkeypatch):
+        # macOS host (Lima/vz): launchd plist via the shared installer in
+        # agentcage.watcher (same one the apple-container backend uses),
+        # 5s interval.
+        backend = MagicMock()
+        backend.grants_unit_path.return_value = tmp_path / "x-grants.service"
+        del backend._install_grants_plist
+        mock_backend.return_value = backend
+
+        from agentcage import watcher as _watcher
+        calls = {}
+
+        def _fake_install(name, *, log_dir, interval=1, plist_path=None):
+            calls["name"] = name
+            calls["interval"] = interval
+
+        monkeypatch.setattr(_watcher, "install_grants_watcher_plist",
+                            _fake_install)
+        monkeypatch.setattr("agentcage.cli.sys.platform", "darwin")
+
+        from agentcage.cli import _ensure_grants_watcher
+        import agentcage.systemd as _systemd
+        cfg = MagicMock()
+        cfg.isolation = "vm"
+        with patch.object(_systemd, "start_unit") as mock_start:
+            _ensure_grants_watcher("x", cfg)
+
+        assert calls == {"name": "x", "interval": 5}
+        mock_start.assert_not_called()  # launchd, not systemd
+        assert not (tmp_path / "x-grants.service").exists()
 
     @patch("agentcage.cli.get_backend")
     def test_container_backend_still_writes_unit(self, mock_backend, tmp_path):
@@ -646,3 +691,107 @@ class TestSafeTickIsolation:
 
         with pytest.raises(KeyboardInterrupt):
             _safe_tick(kb, "x")
+
+
+# ── VM backend: isolation-aware overlay IO ──────────────────────────────
+
+
+class TestVmOverlayDispatch:
+    """_load_grants_overlay / _save_grants_overlay must route VM cages
+    through the limactl channel (backends.vm.pull_grants/push_grants) and
+    everything else through the host-side state file. A manual grants
+    command on an unreachable VM errors instead of treating the overlay
+    as empty."""
+
+    def test_load_dispatches_vm(self):
+        from agentcage.cli import _load_grants_overlay
+        cfg = MagicMock()
+        cfg.isolation = "vm"
+        with patch("agentcage.lima.instance.LimaInstance") as mock_li, \
+             patch("agentcage.backends.vm.pull_grants",
+                   return_value=[{"domain": "a.com"}]) as mock_pull:
+            assert _load_grants_overlay("x", cfg) == [{"domain": "a.com"}]
+        mock_pull.assert_called_once_with("x", mock_li.return_value)
+
+    def test_load_dispatches_container(self):
+        from agentcage.cli import _load_grants_overlay
+        cfg = MagicMock()
+        cfg.isolation = "container"
+        with patch("agentcage.cli.state") as mock_state:
+            mock_state.load_grants.return_value = []
+            assert _load_grants_overlay("x", cfg) == []
+            mock_state.load_grants.assert_called_once_with("x")
+
+    def test_save_dispatches_vm(self):
+        from agentcage.cli import _save_grants_overlay
+        cfg = MagicMock()
+        cfg.isolation = "vm"
+        with patch("agentcage.lima.instance.LimaInstance") as mock_li, \
+             patch("agentcage.backends.vm.push_grants") as mock_push:
+            _save_grants_overlay("x", cfg, [])
+        mock_push.assert_called_once_with("x", [], mock_li.return_value)
+
+    @patch("agentcage.cli.state")
+    def test_grants_list_errors_when_vm_unreachable(self, mock_state):
+        mock_state.load_raw_config.return_value = _raw()
+        mock_state.load_deployment_config.return_value = _make_cfg()
+        cfg = _make_cfg()
+        mock_state.load_deployment_config.return_value = cfg
+        with patch("agentcage.cli._load_grants_overlay", return_value=None):
+            result = _runner().invoke(
+                main, ["cage", "grants", "basic", "list"])
+        assert result.exit_code != 0
+        assert "could not reach the VM" in result.output
+
+    @patch("agentcage.cli.state")
+    @patch("agentcage.cli._apply_baseline_change")
+    def test_watch_tick_skips_quietly_when_vm_down(
+            self, mock_apply, mock_state):
+        """A stopped VM is a quiet no-op tick — not an error, not an
+        empty-overlay promotion storm. The watcher keeps running and picks
+        the overlay up again once the cage starts."""
+        mock_state.load_raw_config.return_value = _raw()
+        cfg = _make_cfg()
+        cfg.isolation = "vm"
+        mock_state.load_deployment_config.return_value = cfg
+        with patch("agentcage.lima.instance.LimaInstance") as mock_li, \
+             patch("agentcage.cli._load_grants_overlay", return_value=None) as lo:
+            mock_li.return_value.is_running.return_value = False
+            result = _runner().invoke(
+                main, ["cage", "grants", "basic", "watch", "--once"])
+        assert result.exit_code == 0
+        lo.assert_not_called()  # is_running gate short-circuits the pull
+        mock_apply.assert_not_called()
+
+    @patch("agentcage.cli.state")
+    @patch("agentcage.cli._apply_baseline_change")
+    def test_watch_tick_promotes_from_vm_overlay(
+            self, mock_apply, mock_state):
+        """End-to-end VM tick: pull the guest-local overlay, promote into
+        the baseline, push the shrunk overlay back through the same
+        channel."""
+        from agentcage.cli import _save_grants_overlay
+        mock_state.load_raw_config.return_value = _raw()
+        cfg = _make_cfg()
+        cfg.isolation = "vm"
+        mock_state.load_deployment_config.return_value = cfg
+        overlay = _overlay_entries()
+        saved = {}
+
+        def _save(name, cfg_, entries):
+            saved["entries"] = entries
+
+        with patch("agentcage.lima.instance.LimaInstance") as mock_li, \
+             patch("agentcage.cli._load_grants_overlay",
+                   side_effect=[overlay, overlay]) as lo, \
+             patch("agentcage.cli._save_grants_overlay",
+                   side_effect=_save) as sv:
+            mock_li.return_value.is_running.return_value = True
+            result = _runner().invoke(
+                main, ["cage", "grants", "basic", "watch", "--once"])
+        assert result.exit_code == 0, result.output
+        assert lo.call_count == 2  # tick snapshot + merge re-read
+        sv.assert_called_once()
+        # The promoted domain is gone from the pushed overlay.
+        assert all(e["domain"] != overlay[0]["domain"]
+                   for e in saved["entries"])

--- a/tests/test_quadlets.py
+++ b/tests/test_quadlets.py
@@ -1574,3 +1574,70 @@ class TestPassthroughSidecarFiles:
         state.save_deployment("test", str(p))
         body = open(state.save_dns_allowlist("test")).read()
         assert "server=/api.anthropic.com/100.100.100.100" in body
+
+
+class TestVmLocalGrantsOverlayPath:
+    """VM backend: the grants overlay dir must be VM-local (like the
+    proxy-config / dns-allowlist copies) — Lima's mounts can't be trusted
+    for host↔guest rewrites, and the host watcher round-trips the overlay
+    via limactl instead (backends.vm.pull_grants/push_grants)."""
+
+    def _vm_files(self, tmp_path, domains_extra=""):
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent(f"""\
+            name: test
+            isolation: vm
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+              auto:
+                enable: true
+        """) + domains_extra)
+        cfg = load_config(str(p))
+        return generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+
+    def test_egress_quadlet_uses_vm_local_grants_dir(self, tmp_path):
+        files = self._vm_files(tmp_path)
+        content = files["test-egress.container"]
+        assert (
+            "Volume=%h/.config/agentcage-vm/cages/test/grants:/var/lib/agentcage:Z"
+            in content
+        )
+        # NOT the host-side state dir (Lima-mount path).
+        assert "/grants:/var/lib/agentcage" in content
+        assert f"{os.path.expanduser('~/.local/share/agentcage')}" not in content
+
+    def test_container_backend_uses_host_grants_dir(self, tmp_path):
+        """Regression guard: container cages keep mounting the host dir the
+        watcher reads/writes directly."""
+        p = tmp_path / "config.yaml"
+        p.write_text(textwrap.dedent("""\
+            name: test
+            container:
+              image: test:latest
+            domains:
+              allow:
+                - example.com
+              auto:
+                enable: true
+        """))
+        cfg = load_config(str(p))
+        files = generate_quadlets(cfg, "/host/c.yaml", "/host/patches", "test")
+        content = files["test-egress.container"]
+        assert "Volume=" in content
+        assert ":/var/lib/agentcage:Z" in content
+        assert "%h/.config/agentcage-vm" not in content
+
+    def test_vm_does_not_emit_guest_grants_service(self, tmp_path):
+        """The watcher unit must NOT go into the guest quadlet set (it
+        runs on the HOST; a plain .service in the guest systemd dir never
+        loads)."""
+        files = self._vm_files(tmp_path)
+        assert "test-grants.service" not in files
+
+    def test_grants_service_unit_interval(self):
+        from agentcage.quadlets import _grants_service_unit
+        assert "--interval 1" in _grants_service_unit("test")
+        assert "--interval 5" in _grants_service_unit("test", interval=5)

--- a/tests/test_vm_backend.py
+++ b/tests/test_vm_backend.py
@@ -1284,3 +1284,100 @@ class TestGetBackend:
         config = Config()
         backend = get_backend(config)
         assert isinstance(backend, ContainerBackend)
+
+
+class TestGrantsOverlayRoundTrip:
+    """pull_grants / push_grants / ensure_grants_dir — the limactl channel
+    the host-side grants watcher uses for VM cages (the overlay lives
+    guest-side; see quadlets.vm_local_grants_dir)."""
+
+    def test_ensure_grants_dir_mkdirs_guest_local_dir(self):
+        from agentcage.backends.vm import ensure_grants_dir
+        inst = MagicMock()
+        inst.exec.side_effect = lambda cmd, **kw: MagicMock(
+            returncode=0, stdout="/home/acuser\n", stderr="")
+        ensure_grants_dir("test", inst)
+        calls = [c.args[0] for c in inst.exec.call_args_list]
+        assert ["bash", "-c", "echo ~"] in calls
+        assert ["mkdir", "-p",
+                "/home/acuser/.config/agentcage-vm/cages/test/grants"] in calls
+
+    def test_pull_grants_parses_yaml(self):
+        import yaml as _yaml
+        from agentcage.backends.vm import pull_grants
+        entries = [{"domain": "example.com", "reason": "need api"}]
+        payload = _yaml.safe_dump(entries)
+        inst = MagicMock()
+
+        def _exec(cmd, **kw):
+            if cmd[:2] == ["bash", "-c"] and "echo ~" in cmd[2]:
+                return MagicMock(returncode=0, stdout="/home/acuser\n", stderr="")
+            if cmd[0] == "cat":
+                assert cmd[1] == (
+                    "/home/acuser/.config/agentcage-vm/cages/test/grants/grants.yaml")
+                return MagicMock(returncode=0, stdout=payload, stderr="")
+            raise AssertionError(f"unexpected exec: {cmd}")
+
+        inst.exec.side_effect = _exec
+        assert pull_grants("test", inst) == entries
+
+    def test_pull_grants_missing_file_is_empty(self):
+        from agentcage.backends.vm import pull_grants
+        inst = MagicMock()
+
+        def _exec(cmd, **kw):
+            if cmd[0] == "cat":
+                return MagicMock(returncode=1, stdout="", stderr="no such file")
+            return MagicMock(returncode=0, stdout="/home/acuser\n", stderr="")
+
+        inst.exec.side_effect = _exec
+        assert pull_grants("test", inst) == []
+
+    def test_pull_grants_exec_failure_is_none(self):
+        """A failed round-trip (VM down) is None — NOT [] — so the
+        watcher can distinguish 'unreachable' from 'empty overlay'."""
+        from agentcage.backends.vm import pull_grants
+        inst = MagicMock()
+        inst.exec.side_effect = OSError("ssh: connect refused")
+        assert pull_grants("test", inst) is None
+
+    def test_pull_grants_malformed_yaml_is_empty(self):
+        from agentcage.backends.vm import pull_grants
+        inst = MagicMock()
+
+        def _exec(cmd, **kw):
+            if cmd[0] == "cat":
+                return MagicMock(returncode=0, stdout="::: not yaml [\n", stderr="")
+            return MagicMock(returncode=0, stdout="/home/acuser\n", stderr="")
+
+        inst.exec.side_effect = _exec
+        assert pull_grants("test", inst) == []
+
+    def test_push_grants_atomic_base64_write(self):
+        import base64 as _b64
+        import yaml as _yaml
+        from agentcage.backends.vm import push_grants
+        entries = [{"domain": "example.com"}]
+        inst = MagicMock()
+
+        def _exec(cmd, **kw):
+            if cmd[0] == "bash" and "echo ~" in cmd[2]:
+                return MagicMock(returncode=0, stdout="/home/acuser\n", stderr="")
+            if cmd[0] == "bash":
+                # Atomic: decode into a temp file, then mv over the target —
+                # the in-guest addon's mtime-poll never sees a truncated
+                # overlay mid-write.
+                script = cmd[2]
+                assert ".tmp " in script and "mv " in script
+                target = ("/home/acuser/.config/agentcage-vm/cages/test/"
+                          "grants/grants.yaml")
+                assert f"mv " in script and target in script
+                # The payload is base64 of the YAML dump.
+                b64 = script.split("echo '")[1].split("'")[0]
+                assert _b64.b64decode(b64) == _yaml.safe_dump(
+                    entries, default_flow_style=False, sort_keys=False).encode()
+                return MagicMock(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected exec: {cmd}")
+
+        inst.exec.side_effect = _exec
+        push_grants("test", entries, inst)


### PR DESCRIPTION
Stacked on #330 (`feat/policy-api`) — review/merge that first.

## What

Brings the Policy-API grants watcher to **vm-isolation cages** (Lima). Previously v1-unsupported: `domains.auto` grants were decided and L7-enforced inside the egress, but never promoted into the baseline/DNS, and `domain add --expires-in` entries were never pruned on vm cages.

## Design

The watcher stays **host-side** and reuses the entire existing promotion chain — `_apply_baseline_change` was already VM-aware (`push_config_files` over `limactl shell` + `podman exec` dnsmasq SIGHUP). Only the overlay transport changes:

| | container/apple | vm (this PR) |
|---|---|---|
| Overlay location | host `~/.local/share/agentcage/<name>/grants/` | **guest-local** `~/.config/agentcage-vm/cages/<name>/grants/` |
| Addon writes | via RW bind mount | guest-local (no Lima sshfs staleness, same `chgrp 200`+`0770` dual-writer perms via podman-in-guest) |
| Watcher reads/writes | host file | `limactl shell` — `cat` pull / base64 temp+`mv` push (atomic) |
| Watcher supervisor | systemd user unit / launchd plist | same systemd unit on Linux hosts (5s poll), same launchd plist on macOS hosts (extracted into the shared `agentcage.watcher` module) |

Rationale for the guest-local overlay: Lima's reverse-sshfs caches host→guest rewrites, so a host-written overlay would be invisible to the addon's mtime-poll — the same reason `proxy-config.yaml`/`dns-allowlist.conf` already use vm-local copies + the base64 push channel. Guest→host is reliable, but pulling via `limactl` keeps ONE transport and avoids trusting the mount in either direction. The host-side grants dir stays operator-only (the round-8 world-writable-dir fix's threat model is unaffected).

## Behavior details

- **VM down = quiet no-op tick.** `pull_grants` returns `None` on an unreachable VM (distinct from `[]`), the watcher skips without erroring, and grants decided while the cage is down are promoted when it next runs.
- **Manual commands** (`grants list/promote/revoke`) are isolation-aware via `_load_grants_overlay`/`_save_grants_overlay` and error clearly when the VM is unreachable.
- The guest quadlet set still excludes the watcher unit (it runs on the host); `VmBackend.grants_unit_path()` points at the host systemd user dir.
- The vm-local grants dir is created at deploy (`ensure_grants_dir`) because the egress unit's `ExecStartPre` chmods it before podman processes the Volume bind.

## Testing

+17 tests (2298 total, green): vm-local grants-dir rendering in the egress quadlet (`%h` specifier), guest-set exclusion, unit interval parameterization, pull/push round-trip semantics (`None`-vs-empty on unreachable VM, malformed YAML → `[]`, atomic base64 write), overlay dispatch routing, VM-down quiet tick, end-to-end VM promote, watcher install on Linux (systemd, 5s) and macOS (plist), apple-container plist delegation intact after the refactor.