### PR TITLE
feat(egress): validate the resolved peer address for granted domains

### DIFF
--- a/docs/reference/policy-api.md
+++ b/docs/reference/policy-api.md
@@ -381,6 +381,29 @@ decider. The safeguards:
   > these on its own (verified by red-teaming a live cage), but that made a
   > metadata bypass contingent on model judgement; the structural check makes
   > it contingent on nothing.
+
+- **Granted domains are checked against the address they resolve to.** Every
+  check above reasons about the *name*, and DNS answers the name — the answer
+  can change after the grant (rebinding), or be internal from the start with
+  nothing odd about the name at all (`localtest.me` is a real public domain
+  whose A record is `127.0.0.1`). Before the egress opens an upstream
+  connection for a **granted** host it resolves the name and refuses if *any*
+  answer is loopback, link-local, private or CGNAT — every answer, since a
+  rebinding payload commonly returns a public address alongside the internal
+  one.
+
+  This runs at mitmproxy's `server_connect` hook, which is the only point
+  that can abort: mitmproxy reads `connection.error` there and skips
+  connecting, but proceeds unconditionally after `server_connected`, so a
+  verdict reached later cannot stop the request already in flight. A host
+  caught rebinding between the lookup and the connect is refused at L7 on its
+  next request.
+
+  Scoped to **grant-derived** hosts only. A baseline domain is the operator's
+  own choice — an internal artifact mirror on `10.x` in `domains.allow` is a
+  legitimate configuration — and inbound port-forwarding connects to the
+  cage's private address by design. Neither is affected. Blocks are audited
+  as `private_peer_blocked`.
 - **Bounded blast radius.** Max 32 concurrent grants, per-cage request rate
   limit, full audit logging, and permanent grants that are explicitly
   removable via `agentcage domain rm`.

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import dataclasses
+import ipaddress
 import json
 import os
+import socket
 import sys
 import time
 from collections import defaultdict
@@ -127,6 +129,11 @@ class Agentcage:
         # data/proxy/policy_api.py.
         self.domain_requests = None
         self._policy_sweeper: Optional[asyncio.Task] = None
+        # Peer-address guard state (see server_connect). The cache is
+        # keyed by granted host; the poisoned set records hosts caught
+        # rebinding so the L7 gate refuses them on the next request.
+        self._peer_dns_cache: dict = {}
+        self._poisoned_peers: set = set()
         self._running = False
         self._init_domain_requests()
 
@@ -715,6 +722,36 @@ class Agentcage:
             self._log(flow, "blocked", "rate limit exceeded", [])
             return
 
+        # ── Rebind backstop ──────────────────────────────────────
+        # A granted host caught resolving to a non-global address in
+        # server_connected (too late to stop THAT request — mitmproxy does
+        # not re-read connection.error after connecting) is poisoned here,
+        # so every subsequent request to it is refused at L7. The normal
+        # path is server_connect, which aborts before any socket opens;
+        # this only fires when the answer changed underneath us.
+        # getattr: tests and hot-reload paths construct the addon without
+        # running __init__, and this gate must never be the thing that
+        # breaks the request path.
+        _poisoned = getattr(self, "_poisoned_peers", None)
+        if _poisoned:
+            _pk = (flow.request.host or "").lower().rstrip(".")
+            if _pk in _poisoned:
+                reason = (
+                    f"granted domain {_pk} was observed resolving to a "
+                    f"non-global address; refusing further requests"
+                )
+                flow.response = http.Response.make(
+                    403,
+                    json.dumps(
+                        {"blocked": True, "reason": reason,
+                         "host": flow.request.host, "by": "agentcage"}
+                    ).encode(),
+                    {"Content-Type": "application/json"},
+                )
+                flow.metadata["agentcage_blocked"] = True
+                self._log(flow, "blocked", reason, [])
+                return
+
         # Check for placeholder-to-unauthorized-domain violations first
         # (this does NOT modify the flow — only checks domain restrictions)
         inject_result = self.injector.check_injection_policy(flow)
@@ -1018,6 +1055,205 @@ class Agentcage:
                 if isinstance(host, str) and host:
                     return f"{host}:{port}" if port is not None else host
         return "<unknown>"
+
+    # ── Peer-address validation for granted hosts ───────────
+    # Every name-based check — never_grant, the IP-encoding guard, the
+    # decider itself — reasons about the NAME. DNS answers the name, and the
+    # answer can change after the grant. A domain granted while it resolved
+    # somewhere harmless can have its A record repointed at 169.254.169.254
+    # a second later (classic DNS rebinding), and nothing keyed on the name
+    # would notice. `localtest.me` needs no rebinding at all: it is a real
+    # public domain whose A record is 127.0.0.1.
+    #
+    # So this is the one check that looks at the ADDRESS, at the moment it
+    # matters — when mitmproxy is about to talk to it.
+    #
+    # Scoped deliberately to GRANT-ONLY hosts. Baseline domains are the
+    # operator's own choice: an internal artifact mirror on 10.x in
+    # `domains.allow` is a legitimate, deliberate configuration, and this
+    # must not break it. Inbound port-forwards are the same story from the
+    # other direction — mitmproxy runs `--mode reverse:http://<cage-ip>` and
+    # connects to the cage's private address on purpose. Neither is a
+    # granted domain, so neither is affected.
+
+    def _domain_inspector(self) -> Optional[DomainInspector]:
+        return next((i for i in self.inspectors
+                     if isinstance(i, DomainInspector)), None)
+
+    @staticmethod
+    def _non_global_ip(value) -> Optional[str]:
+        """Return *value* as a string when it is a non-global IP address.
+
+        ``None`` when it is not an IP at all (a hostname, at the point in
+        the connection where mitmproxy has not resolved it yet) or when it
+        is globally routable.
+        """
+        if not value:
+            return None
+        host = value[0] if isinstance(value, (tuple, list)) else value
+        if not isinstance(host, str):
+            return None
+        # IPv6 scope suffix (fe80::1%eth0) is not part of the address.
+        host = host.split("%", 1)[0].strip("[]")
+        try:
+            ip = ipaddress.ip_address(host)
+        except ValueError:
+            return None  # a hostname; nothing to judge yet
+        # Unwrap ::ffff:169.254.169.254 — an IPv4 target reached over a
+        # v6 socket must not launder itself past this check.
+        if getattr(ip, "ipv4_mapped", None):
+            ip = ip.ipv4_mapped
+        return None if ip.is_global else str(ip)
+
+    def _guard_peer(self, data, phase: str) -> None:
+        """Refuse a granted host that resolves to a non-global address."""
+        server = getattr(data, "server", None)
+        if server is None:
+            return
+        dom = self._domain_inspector()
+        if dom is None or not getattr(dom, "granted", None):
+            return  # no grants in play; nothing this check applies to
+        host = ""
+        addr = getattr(server, "address", None)
+        if addr:
+            host = str(addr[0] if isinstance(addr, (tuple, list)) else addr)
+        # `sni` is set for TLS flows before the upstream connect and is the
+        # name the allowlist was evaluated against.
+        sni = getattr(server, "sni", None)
+        candidates = [h for h in (host, sni) if h]
+        if not any(dom.is_grant_only(h) for h in candidates):
+            return
+        for value in (getattr(server, "peername", None), addr):
+            bad = self._non_global_ip(value)
+            if not bad:
+                continue
+            target = next(
+                (h for h in candidates if dom.is_grant_only(h)), host or "?"
+            )
+            self._refuse_peer(server, target, bad, phase)
+            return
+
+    def _log_peer_block(self, host: str, ip: str, phase: str,
+                        reason: str) -> None:
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "kind": "private_peer_blocked",
+            "direction": "outbound",
+            "decision": "blocked",
+            "reason": reason,
+            "host": host,
+            "peer_ip": ip,
+            "phase": phase,
+        }
+        line = json.dumps(entry)
+        print(line, file=sys.stderr, flush=True)
+        if self._audit_file:
+            try:
+                self._audit_file.write(line + "\n")
+                self._audit_file.flush()
+            except Exception:
+                pass
+
+    def _resolve_all(self, host: str) -> list:
+        """Every address *host* resolves to, cached briefly.
+
+        Called only for grant-only hosts, and only from ``server_connect``.
+        That placement is what makes the lookup safe: the host is ALREADY
+        granted, so the cage can already resolve it through the egress's
+        dnsmasq — this adds no DNS the cage could not trigger itself. (The
+        same lookup at *request* time, against an arbitrary not-yet-granted
+        string, would be a DNS exfiltration channel: non-allowlisted names
+        are sinkholed locally today and never leave the host.)
+
+        The cache keeps a burst of requests to one granted host from
+        re-resolving on every connection; the window is deliberately short
+        so a rebind is caught on the next connect rather than after a
+        normal DNS TTL.
+        """
+        now = time.time()
+        hit = self._peer_dns_cache.get(host)
+        if hit and now - hit[0] < 5.0:
+            return hit[1]
+        try:
+            infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+            addrs = [i[4][0] for i in infos]
+        except OSError:
+            addrs = []
+        self._peer_dns_cache[host] = (now, addrs)
+        if len(self._peer_dns_cache) > 256:      # bound the cache
+            self._peer_dns_cache.clear()
+        return addrs
+
+    def server_connect(self, data) -> None:
+        """Refuse before the socket opens — the only hook that can.
+
+        mitmproxy reads ``connection.error`` after this hook and aborts
+        without connecting. It does NOT re-check after
+        ``ServerConnectedHook``, so a verdict reached later cannot stop the
+        request that is already in flight — which is why the resolution
+        happens here rather than reusing mitmproxy's own.
+
+        EVERY answer is checked, not just the first: a rebinding payload
+        commonly returns a public address alongside the internal one and
+        relies on the client picking either.
+        """
+        try:
+            server = getattr(data, "server", None)
+            if server is None:
+                return
+            dom = self._domain_inspector()
+            if dom is None or not getattr(dom, "granted", None):
+                return
+            addr = getattr(server, "address", None)
+            host = ""
+            if addr:
+                host = str(addr[0] if isinstance(addr, (tuple, list)) else addr)
+            sni = getattr(server, "sni", None)
+            target = next(
+                (h for h in (host, sni) if h and dom.is_grant_only(h)), ""
+            )
+            if not target:
+                return
+            # The address itself may already be an IP (transparent mode).
+            candidates = [host] if host else []
+            candidates += self._resolve_all(target)
+            for value in candidates:
+                bad = self._non_global_ip(value)
+                if bad:
+                    self._refuse_peer(server, target, bad, "server_connect")
+                    return
+        except Exception as e:  # never break the proxy over this check
+            print(f"agentcage: peer guard error: {e!r}", file=sys.stderr,
+                  flush=True)
+
+    def server_connected(self, data) -> None:
+        """Backstop: catch a rebind between our lookup and mitmproxy's.
+
+        This CANNOT stop the request already in flight — mitmproxy does not
+        re-read ``connection.error`` after this hook. It audits the event and
+        poisons the host so the next request to it is refused at the L7
+        ``request()`` gate, which can still return a 403.
+        """
+        try:
+            self._guard_peer(data, "server_connected")
+        except Exception as e:
+            print(f"agentcage: peer guard error: {e!r}", file=sys.stderr,
+                  flush=True)
+
+    def _refuse_peer(self, server, host: str, ip: str, phase: str) -> None:
+        reason = (
+            f"granted domain {host} resolves to non-global address {ip}; "
+            f"refusing the upstream connection. A grant is a NAME, and DNS "
+            f"can point that name at an internal address after the fact "
+            f"(rebinding) or by design (localtest.me). Operator-configured "
+            f"baseline domains are unaffected."
+        )
+        try:
+            server.error = reason
+        except Exception:
+            pass
+        self._poisoned_peers.add(host.lower().rstrip("."))
+        self._log_peer_block(host, ip, phase, reason)
 
     def tcp_start(self, flow) -> None:
         """Block raw TCP / non-HTTP flows that bypass the L7 hooks.

--- a/src/agentcage/data/proxy/inspectors/domain.py
+++ b/src/agentcage/data/proxy/inspectors/domain.py
@@ -256,6 +256,21 @@ class DomainInspector(Inspector):
     def is_granted(self, domain: str) -> bool:
         return domain.lower().rstrip(".") in self.granted
 
+    def is_grant_only(self, host: str) -> bool:
+        """True if *host* is reachable ONLY because of a policy-API grant.
+
+        A grant for ``example.com`` covers ``sub.example.com``, so this
+        suffix-matches rather than looking the host up exactly. A host that
+        also matches the operator's static baseline is NOT grant-only: the
+        operator vetted it, and extra restrictions keyed on "the cage asked
+        for this" must not apply to what the operator chose themselves.
+        """
+        parts = host.lower().rstrip(".").split(".")
+        suffixes = [".".join(parts[i:]) for i in range(len(parts))]
+        if any(sfx in self._baseline for sfx in suffixes):
+            return False
+        return any(sfx in self.granted for sfx in suffixes)
+
     def drop_expired(self, now_iso: str = "") -> list[str]:
         """Remove & return domains whose ``expires_at`` has passed.
 

--- a/tests/test_peer_ip_guard.py
+++ b/tests/test_peer_ip_guard.py
@@ -1,0 +1,271 @@
+"""Connect-time peer-address validation for policy-API grants.
+
+Every other check in the feature reasons about the NAME: `never_grant`, the
+IP-encoding guard, the decider's own judgement. DNS answers the name, and the
+answer can change after the grant — so a name-based check cannot close this.
+
+Two concrete cases motivate it:
+
+* **Rebinding.** A domain granted while it resolved somewhere harmless has
+  its A record repointed at 169.254.169.254 a second later.
+* **No rebinding needed.** `localtest.me` is a real, public, ordinary-looking
+  domain whose A record is simply 127.0.0.1. The IP-encoding guard added in
+  the previous change does not fire on it — nothing about the *name* is
+  suspicious.
+
+Scope matters as much as the check: only GRANT-ONLY hosts are subject to it.
+An operator who allowlists an internal mirror on 10.x meant to, and
+mitmproxy's own inbound forwarding runs `--mode reverse:http://<cage-ip>`
+straight at a private address.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── Stub mitmproxy before importing the addon (same bootstrap the other
+# addon tests use: the shipped addon imports mitmproxy, which is not a
+# dependency of the CLI package). ────────────────────────
+_mitmproxy = types.ModuleType("mitmproxy")
+_mitmproxy.__path__ = []
+_mitmproxy.ctx = MagicMock()
+_mitmproxy.http = MagicMock()
+_proxy = types.ModuleType("mitmproxy.proxy")
+_proxy.__path__ = []
+_mode_specs = types.ModuleType("mitmproxy.proxy.mode_specs")
+_mitmproxy.proxy = _proxy
+_proxy.mode_specs = _mode_specs
+sys.modules.setdefault("mitmproxy", _mitmproxy)
+sys.modules.setdefault("mitmproxy.ctx", _mitmproxy.ctx)
+sys.modules.setdefault("mitmproxy.http", _mitmproxy.http)
+sys.modules.setdefault("mitmproxy.proxy", _proxy)
+sys.modules.setdefault("mitmproxy.proxy.mode_specs", _mode_specs)
+sys.modules["mitmproxy.proxy.mode_specs"].ReverseMode = type("ReverseMode", (), {})
+
+_PROXY_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "agentcage" / "data" / "proxy"
+)
+if str(_PROXY_DIR) not in sys.path:
+    sys.path.insert(0, str(_PROXY_DIR))
+
+from addon import Agentcage  # noqa: E402
+from inspectors.domain import DomainInspector  # noqa: E402
+
+
+@pytest.fixture
+def inspector():
+    dom = DomainInspector()
+    dom.configure({"allow": ["registry.npmjs.org", "mirror.corp.example"]})
+    dom.granted = {"granted.example.com": {}, "evil.example.org": {}}
+    return dom
+
+
+class TestGrantOnlyScoping:
+    """The check must fire for grants and only for grants."""
+
+    def test_granted_host_is_grant_only(self, inspector):
+        assert inspector.is_grant_only("granted.example.com")
+
+    def test_subdomain_of_a_grant_is_covered(self, inspector):
+        # A grant for example.com covers sub.example.com at L7, so the peer
+        # check has to follow the same matching or it is trivially evaded.
+        assert inspector.is_grant_only("api.granted.example.com")
+
+    def test_baseline_domain_is_not_grant_only(self, inspector):
+        # The operator chose this one; an internal mirror here is legitimate.
+        assert not inspector.is_grant_only("mirror.corp.example")
+        assert not inspector.is_grant_only("registry.npmjs.org")
+
+    def test_unrelated_host_is_not_grant_only(self, inspector):
+        assert not inspector.is_grant_only("example.net")
+
+    def test_baseline_wins_when_a_host_matches_both(self, inspector):
+        """Operator intent beats an auto-grant for the same name."""
+        inspector.granted["mirror.corp.example"] = {}
+        assert not inspector.is_grant_only("mirror.corp.example")
+
+
+class TestNonGlobalDetection:
+    def _fn(self):
+        return Agentcage._non_global_ip
+
+    @pytest.mark.parametrize("addr", [
+        "169.254.169.254",          # cloud metadata
+        "127.0.0.1",                # loopback — localtest.me
+        "10.0.0.5", "192.168.1.1", "172.16.0.1",   # RFC1918
+        "100.64.0.1",               # CGNAT
+        "::1",                      # v6 loopback
+        "fd00::1",                  # v6 ULA
+        "fe80::1%eth0",             # v6 link-local with scope
+        "::ffff:169.254.169.254",   # v4-mapped metadata
+    ])
+    def test_non_global_detected(self, addr):
+        assert self._fn()(addr) is not None, addr
+
+    @pytest.mark.parametrize("addr", [
+        "93.184.216.34", "1.1.1.1", "2606:4700:4700::1111",
+    ])
+    def test_global_allowed(self, addr):
+        assert self._fn()(addr) is None, addr
+
+    def test_hostname_is_not_judged(self):
+        # Before mitmproxy resolves, address[0] is a name. Nothing to say yet.
+        assert self._fn()("registry.npmjs.org") is None
+
+    def test_accepts_the_peername_tuple_shape(self):
+        assert self._fn()(("169.254.169.254", 443)) == "169.254.169.254"
+
+    def test_v4_mapped_is_unwrapped_not_laundered(self):
+        """An IPv4 target over a v6 socket must not slip past."""
+        assert self._fn()("::ffff:127.0.0.1") == "127.0.0.1"
+
+
+class TestGuardBehaviour:
+    def _addon(self, inspector):
+        a = Agentcage.__new__(Agentcage)
+        a.inspectors = [inspector]
+        a._audit_file = None
+        a._peer_dns_cache = {}
+        a._poisoned_peers = set()
+        return a
+
+    def _data(self, host, peer):
+        server = MagicMock()
+        server.address = (host, 443)
+        server.peername = (peer, 443) if peer else None
+        server.sni = None
+        server.error = None
+        return types.SimpleNamespace(server=server, client=MagicMock())
+
+    def test_granted_host_on_metadata_ip_is_refused(self, inspector):
+        a = self._addon(inspector)
+        d = self._data("granted.example.com", "169.254.169.254")
+        a.server_connected(d)
+        assert d.server.error and "169.254.169.254" in d.server.error
+
+    def test_granted_host_on_loopback_is_refused(self, inspector):
+        """The localtest.me case — an ordinary name, a loopback answer."""
+        a = self._addon(inspector)
+        d = self._data("granted.example.com", "127.0.0.1")
+        a.server_connected(d)
+        assert d.server.error
+
+    def test_baseline_host_on_private_ip_is_allowed(self, inspector):
+        """An operator's internal mirror must keep working."""
+        a = self._addon(inspector)
+        d = self._data("mirror.corp.example", "10.0.0.5")
+        a.server_connected(d)
+        assert d.server.error is None
+
+    def test_inbound_reverse_mode_to_the_cage_is_allowed(self, inspector):
+        """mitmproxy connects to the cage's private IP on purpose."""
+        a = self._addon(inspector)
+        d = self._data("10.89.0.20", "10.89.0.20")
+        a.server_connected(d)
+        assert d.server.error is None
+
+    def test_granted_host_on_public_ip_is_allowed(self, inspector):
+        a = self._addon(inspector)
+        d = self._data("granted.example.com", "93.184.216.34")
+        a.server_connected(d)
+        assert d.server.error is None
+
+    def test_sni_is_considered_for_tls_flows(self, inspector):
+        a = self._addon(inspector)
+        d = self._data("93.184.216.34", "127.0.0.1")
+        d.server.sni = "granted.example.com"
+        a.server_connected(d)
+        assert d.server.error
+
+    def test_no_grants_means_no_work(self, inspector):
+        inspector.granted = {}
+        a = self._addon(inspector)
+        d = self._data("anything.example.com", "127.0.0.1")
+        a.server_connected(d)
+        assert d.server.error is None
+
+    def test_server_connect_catches_a_literal_address(self, inspector):
+        """Refuse before the socket opens when the target is already an IP."""
+        a = self._addon(inspector)
+        a._resolve_all = lambda host: []   # no real DNS in tests
+        server = MagicMock()
+        server.address = ("169.254.169.254", 80)
+        server.peername = None
+        server.sni = "granted.example.com"
+        server.error = None
+        a.server_connect(types.SimpleNamespace(server=server, client=MagicMock()))
+        assert server.error
+
+    def test_guard_never_raises_into_the_proxy(self, inspector):
+        """A bug here must not take the proxy down with it."""
+        a = self._addon(inspector)
+        a.server_connected(types.SimpleNamespace(server=None, client=None))
+        a.server_connected(object())  # no .server at all
+
+
+class TestServerConnectIsTheEnforcementPoint:
+    """`server_connect` is the ONLY hook that can abort the connection.
+
+    mitmproxy reads `connection.error` after it and skips connecting; after
+    `ServerConnectedHook` it proceeds unconditionally, so a verdict reached
+    there cannot stop the in-flight request. Verified against mitmproxy
+    12.2.1's proxy/server.py — and observed live: a guard that only ran at
+    server_connected audited the block while curl still got a 200.
+    """
+
+    def _addon(self, inspector, answers):
+        a = Agentcage.__new__(Agentcage)
+        a.inspectors = [inspector]
+        a._audit_file = None
+        a._peer_dns_cache = {}
+        a._poisoned_peers = set()
+        a._resolve_all = lambda host: answers
+        return a
+
+    def _data(self, host):
+        server = MagicMock()
+        server.address = (host, 443)
+        server.peername = None
+        server.sni = None
+        server.error = None
+        return types.SimpleNamespace(server=server, client=MagicMock())
+
+    def test_refuses_before_connecting_when_resolution_is_private(self, inspector):
+        a = self._addon(inspector, ["127.0.0.1"])
+        d = self._data("granted.example.com")
+        a.server_connect(d)
+        assert d.server.error and "127.0.0.1" in d.server.error
+
+    def test_every_answer_is_checked_not_just_the_first(self, inspector):
+        """Rebinding payloads return a public answer beside the internal one."""
+        a = self._addon(inspector, ["93.184.216.34", "169.254.169.254"])
+        d = self._data("granted.example.com")
+        a.server_connect(d)
+        assert d.server.error and "169.254.169.254" in d.server.error
+
+    def test_public_resolution_connects_normally(self, inspector):
+        a = self._addon(inspector, ["93.184.216.34"])
+        d = self._data("granted.example.com")
+        a.server_connect(d)
+        assert d.server.error is None
+
+    def test_baseline_host_is_never_resolved_or_refused(self, inspector):
+        """No lookup at all for operator-chosen domains."""
+        called = []
+        a = self._addon(inspector, [])
+        a._resolve_all = lambda h: called.append(h) or ["10.0.0.5"]
+        d = self._data("mirror.corp.example")
+        a.server_connect(d)
+        assert d.server.error is None
+        assert called == [], "baseline hosts must not trigger a lookup"
+
+    def test_a_caught_host_is_poisoned_for_later_requests(self, inspector):
+        a = self._addon(inspector, ["127.0.0.1"])
+        a.server_connect(self._data("granted.example.com"))
+        assert "granted.example.com" in a._poisoned_peers


### PR DESCRIPTION
**Stacked on #334**, which is stacked on #330. Merge those first; review only the one commit here.

This is the check the other two can't be. #334 refuses hostnames that *encode* an address (`169-254-169-254.nip.io`). This one looks at the address a name actually **resolves to**.

## Why a name-based check cannot close this

Every check the policy API has reasons about the NAME — `never_grant`, the IP-encoding guard, the decider's judgement. DNS answers the name, and the answer can change after the grant.

- **Rebinding.** A domain granted while it resolved somewhere harmless has its A record repointed at 169.254.169.254 a second later.
- **No rebinding needed.** `localtest.me` is a real, public, entirely ordinary-looking domain whose A record is `127.0.0.1`. #334's guard does not fire on it — nothing about the *name* is suspicious:

```
encoded_private_ip("localtest.me") = None   <- name looks innocent
```

## What it does

Before opening an upstream connection for a **grant-derived** host, the egress resolves the name and refuses if *any* answer is loopback, link-local, private or CGNAT. Every answer, not the first — a rebinding payload commonly returns a public address alongside the internal one and relies on the client picking either.

## Why `server_connect` and not `server_connected`

`server_connect` is the only hook that can abort: mitmproxy reads `connection.error` there and skips connecting, but after `ServerConnectedHook` it proceeds unconditionally.

That is not a reading of the docs. A first cut of this change checked at `server_connected` and, against a live cage, dutifully audited `private_peer_blocked` **while curl still received a 200**. `server_connected` survives as an honest backstop for a rebind landing between our lookup and mitmproxy's — it cannot stop *that* request, so it poisons the host and the L7 gate refuses the next one.

## Why resolving here is safe (and at request time would not be)

The host is **already granted**, so the cage can already resolve it through the egress's dnsmasq — this adds no lookup the cage could not trigger itself.

The same lookup against an arbitrary, not-yet-granted string would be a DNS exfiltration channel (`<secret>.attacker.com` leaks on the *denial*). Verified that channel doesn't exist today — inside the cage, both a real non-allowlisted domain and a made-up one answer the sinkhole:

```
registry.npmjs.org                  -> 104.16.4.34    (allowlisted, real)
example.org                         -> 198.51.100.1   (sinkholed)
leak-payload.attacker-example.com   -> 198.51.100.1   (sinkholed)
```

## Scope

**Grant-derived hosts only.** A baseline domain is the operator's own choice — an internal artifact mirror on `10.x` in `domains.allow` is a legitimate configuration — and inbound forwarding runs `--mode reverse:http://<cage-ip>` at a private address by design. Neither is a granted domain; both are covered by tests.

## Verified live

On an apple-container cage, with a grant injected into the overlay to simulate one whose DNS turned internal:

| target | before | after |
|---|---|---|
| granted + private (`localtest.me`) | **200** | 502 at connect, then 403 |
| granted + public (`codecov.io`) | 301 | 301 (connects normally) |
| baseline (`registry.npmjs.org`) | 200 | 200 (untouched) |

```json
{"kind":"private_peer_blocked","host":"localtest.me","peer_ip":"::1","phase":"server_connect"}
```

Note `::1` — caught because every answer is checked, not just the first.

35 new tests. Suite: 2417 passed, 13 failed — the same 13 pre-existing macOS-env failures as the base. shellcheck clean.

## Note for review

The guard reads `_poisoned_peers` via `getattr` in the request path. That is deliberate: tests and the hot-reload path construct the addon without `__init__`, and an 18-test breakage during development showed this gate must never be the thing that breaks request handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)