### PR TITLE
fix(config): accept single-label LAN hostnames in operator-owned domains lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Single-label LAN hostnames in `domains.allow` no longer fail config validation.** 0.34.0's new per-entry domain-syntax validation (part of the `domains.auto` hardening) required a dotted name in every domains list, so a cage whose allowlist names a LAN/mDNS/tailnet host by its bare hostname (`fcos-vm-home-01`) — an entry that rendered into dnsmasq and suffix-matched in the `DomainInspector` without issue in every release before 0.34.0 — was rejected at `cage create`/`update` with `invalid domain syntax`, bricking previously valid configs on upgrade. `valid_domain()` gained an `allow_single_label` keyword: the operator-owned paths — the static `domains.allow`/`block`/`passthrough`/`expires` lists and the `domain add` command, strings that come from the same person who could edit `cage.yaml` anyway — accept a bare label matching the same charset/length rules as a dotted-name label, so none of the dnsmasq-injection guards (whitespace, slashes, the `\Z` anchor), the IP-literal rejection, or the ≥2-char rule are weakened. The runtime grant paths deliberately stay strict-dotted: the addon's request endpoint, the grants reconcile, and `grants promote` all validate strings that cross the cage trust boundary, where "syntactically valid public hostname" is part of the Policy API threat model — a single-label name is exactly what an internal service looks like, and the decider must never be asked about one.
+
 ## [0.34.0] - 2026-08-30
 
 ### Added

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -4420,7 +4420,10 @@ def domain_add(name: str, domain_names: tuple[str, ...], passthrough: bool,
     # nothing is written.
     for domain_name in domain_names:
         dn = domain_name.rstrip(".").lower()
-        if not state.valid_domain(dn):
+        # allow_single_label: `domain add` is the operator speaking — same
+        # trust as editing cage.yaml, where a bare LAN hostname is valid.
+        # The runtime-grant paths (reconcile / promote) stay strict-dotted.
+        if not state.valid_domain(dn, allow_single_label=True):
             click.echo(f"error: invalid domain: {domain_name!r}", err=True)
             sys.exit(1)
 

--- a/src/agentcage/config.py
+++ b/src/agentcage/config.py
@@ -54,6 +54,12 @@ DOMAIN_RE = re.compile(
     r"(\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+\Z"
 )
 
+# One bare DNS label — the shape of a LAN/mDNS/tailnet hostname
+# (``fcos-vm-home-01``). Same charset and length rules as one DOMAIN_RE
+# label; used only by ``valid_domain(allow_single_label=True)`` (see its
+# docstring for why the runtime-grant paths never take this branch).
+SINGLE_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z")
+
 
 # Wildcard-DNS services (nip.io, sslip.io, xip.io, traefik.me, localtest.me
 # and clones) encode an IP in the hostname and resolve to it, so
@@ -92,12 +98,26 @@ def encoded_private_ip(domain: str) -> str | None:
     return None if ip.is_global else str(ip)
 
 
-def valid_domain(domain: str) -> bool:
+def valid_domain(domain: str, *, allow_single_label: bool = False) -> bool:
     """True if *domain* is a syntactically valid lowercase DNS domain.
 
     Rejects anything that is not a plain dotted hostname — in particular
     strings containing newlines, slashes, or other characters that would
     inject additional directives when interpolated into dnsmasq config.
+
+    ``allow_single_label=True`` additionally accepts a bare hostname with
+    no dot (``fcos-vm-home-01``, ``nas``) — the shape a LAN/mDNS/tailnet
+    host legitimately takes in an OPERATOR-owned list. Only the static
+    ``domains.allow``/``block``/``passthrough``/``expires`` entries and the
+    operator's ``domain add`` pass it: those strings come from the same
+    person who could edit cage.yaml anyway, and single-label hosts worked
+    there in every release before the 0.34.0 validator (dnsmasq renders
+    ``server=/name/`` and the DomainInspector suffix-matches it just fine).
+    The RUNTIME grant paths — the addon's request endpoint, the grants
+    reconcile, ``grants promote`` — deliberately stay strict-dotted: a
+    grant crosses the cage trust boundary, and "syntactically valid PUBLIC
+    hostname" is part of that threat model (a single-label name is exactly
+    what an internal service looks like).
 
     Mirrors the in-container addon's ``_valid_domain`` (data/proxy/
     policy_api.py) so a domain the host accepts at parse time is the same
@@ -125,12 +145,15 @@ def valid_domain(domain: str) -> bool:
     exclude it mid-string, but make it explicit so a future regex tweak
     can't silently re-open the injection).
     """
-    if (
-        not isinstance(domain, str)
-        or any(c.isspace() for c in domain)
-        or not DOMAIN_RE.match(domain)
-    ):
+    if not isinstance(domain, str) or any(c.isspace() for c in domain):
         return False
+    if not DOMAIN_RE.match(domain):
+        # A single label never matches DOMAIN_RE (its dotted-suffix group is
+        # ``+``). Accept it only on operator-owned paths, and only when it is
+        # a well-formed label by the same charset/length rules — the
+        # injection properties (no whitespace, no ``/``) are identical.
+        if not (allow_single_label and SINGLE_LABEL_RE.match(domain)):
+            return False
     # Reject IP literals (v4/v6). IPv6 literals already fail the regex
     # (``:`` is not in the char classes), but IPv4 literals like ``1.2.3.4``
     # match the dotted-label shape, so reject them explicitly — mirroring
@@ -1525,13 +1548,27 @@ def validate_config(config: Config) -> list[str]:
     # wildcard form is accepted at the config layer; a ``.example.com`` or
     # bare ``com`` entry would be escaped verbatim and silently fail to
     # match the intended hosts. ``valid_domain`` therefore applies directly.
-    _bad_allow = [d for d in config.domains.allow if not valid_domain(d)]
-    _bad_block = [d for d in config.domains.block if not valid_domain(d)]
+    # ``allow_single_label=True`` on every static list: these entries are
+    # operator-owned (same trust as editing cage.yaml itself), and a bare
+    # LAN/tailnet hostname (``fcos-vm-home-01``) is a legitimate, previously
+    # working entry — 0.34.0's strict-dotted validator broke real configs.
+    # The runtime-grant validators (addon request endpoint, reconcile,
+    # promote) stay strict-dotted; see valid_domain's docstring.
+    _bad_allow = [
+        d for d in config.domains.allow
+        if not valid_domain(d, allow_single_label=True)
+    ]
+    _bad_block = [
+        d for d in config.domains.block
+        if not valid_domain(d, allow_single_label=True)
+    ]
     _bad_passthrough = [
-        d for d in config.domains.passthrough if not valid_domain(d)
+        d for d in config.domains.passthrough
+        if not valid_domain(d, allow_single_label=True)
     ]
     _bad_expires = [
-        k for k in config.domains.expires if not valid_domain(k)
+        k for k in config.domains.expires
+        if not valid_domain(k, allow_single_label=True)
     ]
     if _bad_allow or _bad_block or _bad_passthrough or _bad_expires:
         offenders = ", ".join(
@@ -1540,7 +1577,8 @@ def validate_config(config: Config) -> list[str]:
         )
         raise ValueError(
             f"invalid domain syntax: {offenders} — expected a plain "
-            f"lowercase dotted hostname (e.g. 'api.example.com')"
+            f"lowercase hostname (e.g. 'api.example.com', or a bare LAN "
+            f"name like 'fcos-vm-home-01')"
         )
 
     warnings = []

--- a/tests/test_policy_api_config.py
+++ b/tests/test_policy_api_config.py
@@ -726,3 +726,62 @@ class TestValidDomainTightening:
         cfg = load_config(_write(tmp_path, body))
         with pytest.raises(ValueError, match="invalid domain syntax"):
             validate_config(cfg)
+
+
+# ── Single-label LAN hostnames in operator-owned lists ───────────────────
+
+
+class TestSingleLabelHostnames:
+    """0.34.0's validator required a dotted name everywhere, breaking real
+    configs whose ``domains.allow`` names a LAN/tailnet host by its bare
+    hostname (``fcos-vm-home-01``) — entries that rendered and matched fine
+    in every prior release. Operator-owned lists (the static domains lists
+    and ``domain add``) now pass ``allow_single_label=True``; the runtime
+    grant paths (addon request endpoint, reconcile, promote) stay
+    strict-dotted per the Policy API threat model."""
+
+    def test_valid_domain_rejects_single_label_by_default(self):
+        # The strict default is what every runtime-grant path calls.
+        assert valid_domain("fcos-vm-home-01") is False
+
+    def test_valid_domain_accepts_single_label_when_allowed(self):
+        assert valid_domain("fcos-vm-home-01", allow_single_label=True) is True
+        assert valid_domain("nas", allow_single_label=True) is True
+
+    def test_single_label_still_rejects_injection_shapes(self):
+        # The relaxation must not weaken the dnsmasq-injection guards.
+        for bad in ("bad\nline", "bad/path", "bad name", "UPPER",
+                    "-leading", "trailing-", "host\n"):
+            assert valid_domain(bad, allow_single_label=True) is False
+
+    def test_single_label_still_rejects_short_and_ip(self):
+        # The >=2-char last-label rule and IP-literal rejection apply to the
+        # single-label branch too.
+        assert valid_domain("x", allow_single_label=True) is False
+        assert valid_domain("1.2.3.4", allow_single_label=True) is False
+
+    def test_single_label_allow_entry_validates_clean(self, tmp_path):
+        body = "domains:\n  allow:\n    - fcos-vm-home-01\n    - github.com\n"
+        cfg = load_config(_write(tmp_path, body))
+        validate_config(cfg)  # must not raise
+
+    def test_single_label_passthrough_and_expires_validate_clean(
+        self, tmp_path
+    ):
+        body = (
+            "domains:\n"
+            "  allow:\n"
+            "    - fcos-vm-home-01\n"
+            "  passthrough:\n"
+            "    - fcos-vm-home-01\n"
+            "  expires:\n"
+            "    fcos-vm-home-01: \"2099-01-01T00:00:00+00:00\"\n"
+        )
+        cfg = load_config(_write(tmp_path, body))
+        validate_config(cfg)  # must not raise
+
+    def test_newline_bearing_single_label_still_rejected(self, tmp_path):
+        body = 'domains:\n  allow:\n    - "badhost\n"\n'
+        cfg = load_config(_write(tmp_path, body))
+        with pytest.raises(ValueError, match="invalid domain syntax"):
+            validate_config(cfg)


### PR DESCRIPTION
## Problem

0.34.0's new per-entry domain-syntax validation (part of the `domains.auto` hardening) requires a dotted name in every domains list. A cage whose `domains.allow` names a LAN/mDNS/tailnet host by its bare hostname (e.g. `fcos-vm-home-01`) — valid and functional in every release before 0.34.0 — now fails `cage create`/`update` with `invalid domain syntax`, bricking previously valid configs on upgrade. Hit in production on the first 0.34.0 rollout.

## Fix

`valid_domain()` gains an `allow_single_label` keyword (default `False`):

- **Relaxed** (operator-owned strings, same trust as editing cage.yaml): the static `domains.allow`/`block`/`passthrough`/`expires` validation in `validate_config`, and the `domain add` command.
- **Strict-dotted, unchanged** (strings crossing the cage trust boundary): the addon's request endpoint (`policy_api._valid_domain`), the grants reconcile, and `grants promote` — "syntactically valid public hostname" is part of the Policy API threat model there.

The single-label branch matches one `DOMAIN_RE` label (`SINGLE_LABEL_RE`), so the dnsmasq-injection guards (whitespace, slashes, `\Z` anchor), IP-literal rejection and the ≥2-char rule are not weakened.

## Tests

New `TestSingleLabelHostnames` in `tests/test_policy_api_config.py`: strict default, relaxed acceptance, injection shapes still rejected, static-list round-trips, newline-bearing single label still rejected. Full suite passes locally (962 passed; `test_egress_image.py::test_image_builds` fails pre-existing on this host's podman, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRngq6vZGXxBMQKnhD7CxX