### PR TITLE
fix(proxy): hot reload no longer resets inspectors:-section configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Hot reload no longer resets `inspectors:`-section configs to defaults.** `_maybe_reload` reconfigured built-in inspectors from the legacy top-level key map only, so a builtin configured exclusively via the explicit `inspectors:` section — the documented style — was silently reset to defaults on every proxy-config mtime bump. For a cage whose content-type `host_exempt_content_types` live in that section, the first `domain add`/`domain rm` or domains.auto grant after egress start wiped the exemptions in place, and legitimate multipart uploads started 403ing on body entropy; hit in production on 2026-09-01 as "ElevenLabs audio transcription failed (HTTP 403): content-type mismatch: multipart/form-data declared but body entropy is 7.80" — a voice-note STT upload whose exemption had been erased by the previous day's domain churn, reproduced live as pass→reload→block. The reload now re-applies the `inspectors:` section after the legacy map, mirroring the initial-load precedence (legacy first, explicit section wins), and `_load_custom_inspectors` is reload-safe: builtin and path-based entries alike are reconfigured in place, never appended twice (a duplicate would have run the inspector twice per request). Two documented limits: a path-based inspector's *file* is not re-imported on reload (a changed implementation needs an egress restart), and an entry removed from the section keeps its last config until restart — consistent with the other sections, where removal is not a live-reload operation.
+
 ## [0.35.0] - 2026-08-30
 
 ### Added

--- a/src/agentcage/data/proxy/addon.py
+++ b/src/agentcage/data/proxy/addon.py
@@ -504,7 +504,26 @@ class Agentcage:
                     continue
                 inspector = _BUILTIN_INSPECTORS[name]()
             elif path:
+                # Reconfigure-in-place when an inspector of this name is
+                # already loaded (the hot-reload path calls this method on
+                # every config change — appending again would run the
+                # inspector twice per request). Matched by the entry's
+                # declared name falling back to the loaded class's name on
+                # the append below; the file itself is NOT re-imported on
+                # reload — a changed implementation needs an egress restart.
+                existing = next(
+                    (i for i in self.inspectors
+                     if name and i.name == name), None)
+                if existing is not None:
+                    existing.configure(cfg)
+                    continue
                 inspector = load_inspector_from_file(path)
+                existing = next(
+                    (i for i in self.inspectors
+                     if i.name == inspector.name), None)
+                if existing is not None:
+                    existing.configure(cfg)
+                    continue
             else:
                 ctx.log.warn(f"skipping unknown inspector: {name}")
                 continue
@@ -552,6 +571,22 @@ class Agentcage:
         for inspector in self.inspectors:
             if inspector.name in legacy_map and legacy_map[inspector.name] is not None:
                 inspector.configure(legacy_map[inspector.name])
+
+        # Re-apply the explicit ``inspectors:`` section AFTER the legacy
+        # map, mirroring the initial-load precedence (legacy first, the
+        # explicit section wins). Without this, every hot reload silently
+        # RESET any builtin configured only via ``inspectors:`` back to
+        # legacy/default config — for a cage whose content-type exemptions
+        # live in that section, the first ``domain add``/``domain rm`` or
+        # domains.auto grant after egress start wiped
+        # ``host_exempt_content_types`` in place and multipart uploads
+        # started 403ing on body entropy (hit in production 2026-09-01:
+        # ElevenLabs STT voice-note uploads). ``_load_custom_inspectors``
+        # is reload-safe: it reconfigures in place and never appends a
+        # duplicate. An entry REMOVED from the section keeps its last
+        # config until restart — acceptable; removal is not a live-reload
+        # operation for any other section either.
+        self._load_custom_inspectors()
 
         # Reconfigure the secret injector too — it is NOT part of the
         # inspector chain (inspectors must see placeholders, injection

--- a/tests/test_addon_reload_inspector_config.py
+++ b/tests/test_addon_reload_inspector_config.py
@@ -1,0 +1,177 @@
+"""Hot-reload must not reset ``inspectors:``-section configs (2026-09-01).
+
+Regression: ``_maybe_reload`` reconfigured built-in inspectors from the
+LEGACY key map only, so a builtin configured via the explicit
+``inspectors:`` section was silently reset to defaults on every
+proxy-config mtime bump. For a cage whose content-type
+``host_exempt_content_types`` lives in that section, the first
+``domain add``/``domain rm`` or domains.auto grant after egress start
+wiped the exemptions in place, and multipart uploads started 403ing on
+body entropy — hit in production as "ElevenLabs audio transcription
+failed (HTTP 403): content-type mismatch ... body entropy is 7.80".
+
+Reload now re-applies the ``inspectors:`` section after the legacy map
+(same precedence as initial load), and ``_load_custom_inspectors`` is
+reload-safe: reconfigure-in-place, never a duplicate append.
+"""
+
+import os
+import textwrap
+
+import pytest
+import yaml
+
+
+ELEVENLABS_EXEMPT = {
+    "host_exempt_content_types": {"elevenlabs.io": ["multipart/form-data"]}
+}
+
+
+def _write_cfg(path, extra=None, domains=("a.com",)):
+    cfg = {
+        "domains": {"allow": list(domains)},
+        "inspectors": [
+            {"name": "content-type", "config": dict(ELEVENLABS_EXEMPT)},
+        ],
+    }
+    if extra:
+        cfg.update(extra)
+    path.write_text(yaml.safe_dump(cfg))
+
+
+def _bump_mtime(path):
+    os.utime(path, (0, os.stat(path).st_mtime + 5))
+
+
+def _make_addon(tmp_path, monkeypatch, extra=None):
+    from agentcage.data.proxy import addon as addon_mod
+
+    cfg_path = tmp_path / "config.yaml"
+    _write_cfg(cfg_path, extra=extra)
+    monkeypatch.setattr(addon_mod, "CONFIG_PATH", str(cfg_path))
+    addon = addon_mod.Agentcage()
+    addon.load(loader=None)
+    return addon, cfg_path
+
+
+def _content_type_inspector(addon):
+    matches = [i for i in addon.inspectors if i.name == "content-type"]
+    assert len(matches) == 1, f"expected exactly one, got {len(matches)}"
+    return matches[0]
+
+
+class TestReloadKeepsInspectorSectionConfig:
+    def test_exemptions_survive_reload(self, tmp_path, monkeypatch):
+        """THE production regression: a domain change bumps the config
+        mtime; the content-type exemptions must survive the reload."""
+        addon, cfg_path = _make_addon(tmp_path, monkeypatch)
+        ct = _content_type_inspector(addon)
+        assert ct.host_exempt_content_types == {
+            "elevenlabs.io": ["multipart/form-data"]}
+
+        # The realistic trigger: a domain add rewrites the config file.
+        _write_cfg(cfg_path, domains=("a.com", "b.com"))
+        _bump_mtime(cfg_path)
+        addon._maybe_reload()
+
+        ct = _content_type_inspector(addon)
+        assert ct.host_exempt_content_types == {
+            "elevenlabs.io": ["multipart/form-data"]}, (
+            "hot reload reset the inspectors:-section config to defaults")
+
+    def test_reload_applies_changed_section_config(self, tmp_path,
+                                                   monkeypatch):
+        """The section is live config: an EDITED exemption list must be
+        picked up by the reload, not just preserved from initial load."""
+        addon, cfg_path = _make_addon(tmp_path, monkeypatch)
+
+        cfg = {
+            "domains": {"allow": ["a.com"]},
+            "inspectors": [
+                {"name": "content-type",
+                 "config": {"host_exempt_content_types": {
+                     "example.org": ["multipart/form-data"]}}},
+            ],
+        }
+        cfg_path.write_text(yaml.safe_dump(cfg))
+        _bump_mtime(cfg_path)
+        addon._maybe_reload()
+
+        ct = _content_type_inspector(addon)
+        assert ct.host_exempt_content_types == {
+            "example.org": ["multipart/form-data"]}
+
+    def test_no_duplicate_inspectors_after_reloads(self, tmp_path,
+                                                   monkeypatch):
+        addon, cfg_path = _make_addon(tmp_path, monkeypatch)
+        names_before = sorted(i.name for i in addon.inspectors)
+        for n in range(3):
+            _write_cfg(cfg_path, domains=("a.com", f"x{n}.com"))
+            _bump_mtime(cfg_path)
+            addon._maybe_reload()
+        assert sorted(i.name for i in addon.inspectors) == names_before
+
+    def test_section_wins_over_legacy_key_on_reload(self, tmp_path,
+                                                    monkeypatch):
+        """Initial-load precedence is legacy first, explicit section wins.
+        The reload must keep that ordering, not invert it."""
+        extra = {"content_type": {"entropy_ceiling": 7.0}}
+        addon, cfg_path = _make_addon(tmp_path, monkeypatch, extra=extra)
+        cfg = {
+            "domains": {"allow": ["a.com"]},
+            "content_type": {"entropy_ceiling": 7.0},
+            "inspectors": [
+                {"name": "content-type",
+                 "config": {"entropy_ceiling": 8.0}},
+            ],
+        }
+        cfg_path.write_text(yaml.safe_dump(cfg))
+        _bump_mtime(cfg_path)
+        addon._maybe_reload()
+        assert _content_type_inspector(addon).entropy_ceiling == 8.0
+
+
+class TestPathInspectorNotDuplicatedOnReload:
+    def test_path_entry_reconfigured_in_place(self, tmp_path, monkeypatch):
+        insp_dir = tmp_path / "inspectors"
+        insp_dir.mkdir()
+        (insp_dir / "my_check.py").write_text(textwrap.dedent("""\
+            from inspectors.base import Inspector
+
+            class MyCheck(Inspector):
+                name = "my-check"
+
+                def configure(self, config):
+                    self.marker = config.get("marker", "")
+
+                def inspect_request(self, ctx):
+                    return None
+        """))
+        monkeypatch.setenv("AGENTCAGE_INSPECTOR_DIRS", str(insp_dir))
+
+        from agentcage.data.proxy import addon as addon_mod
+        cfg_path = tmp_path / "config.yaml"
+
+        def _cfg(marker, domains):
+            return yaml.safe_dump({
+                "domains": {"allow": list(domains)},
+                "inspectors": [
+                    {"name": "my-check",
+                     "path": str(insp_dir / "my_check.py"),
+                     "config": {"marker": marker}},
+                ],
+            })
+
+        cfg_path.write_text(_cfg("v1", ["a.com"]))
+        monkeypatch.setattr(addon_mod, "CONFIG_PATH", str(cfg_path))
+        addon = addon_mod.Agentcage()
+        addon.load(loader=None)
+        assert [i.name for i in addon.inspectors].count("my-check") == 1
+
+        cfg_path.write_text(_cfg("v2", ["a.com", "b.com"]))
+        _bump_mtime(cfg_path)
+        addon._maybe_reload()
+
+        mine = [i for i in addon.inspectors if i.name == "my-check"]
+        assert len(mine) == 1, "path-based inspector duplicated on reload"
+        assert mine[0].marker == "v2"


### PR DESCRIPTION
## Bug

`_maybe_reload` reconfigures built-in inspectors from the **legacy** top-level key map only. A builtin configured exclusively via the explicit `inspectors:` section (the documented style) is silently reset to defaults on every proxy-config mtime bump — for content-type that's `cfg.get("content_type", {})` → `{}`, wiping `host_exempt_content_types`, and resetting ceiling/action.

**Production hit (2026-09-01):** ElevenLabs STT voice-note uploads 403'd with "content-type mismatch: multipart/form-data declared but body entropy is 7.80" despite the configured `elevenlabs.io: [multipart/form-data]` exemption. domains.auto made this acute: grants and `domain add`/`rm` rewrite proxy-config.yaml frequently, so the exemption now dies minutes after every egress start. Reproduced live on the affected cage as a clean three-point cycle: blocked → egress restart → passes (401 from origin) → one domain add/rm reload → blocked again.

## Fix

- `_maybe_reload` re-applies the `inspectors:` section **after** the legacy map — the same precedence as initial load (legacy first, explicit section wins).
- `_load_custom_inspectors` is now reload-safe: builtin **and path-based** entries are reconfigured in place, never appended twice (a duplicate append would run the inspector twice per request).
- Documented limits: path-based inspector *files* are not re-imported on reload (changed implementation needs an egress restart); an entry removed from the section keeps its last config until restart (consistent with other sections).

## Tests

New `tests/test_addon_reload_inspector_config.py` (5 tests): exemptions survive reload (the production scenario), edited section config is picked up live, no duplicates across repeated reloads, section-wins-over-legacy precedence preserved on reload, path-based entry reconfigured in place. Verified 4/5 fail against the unfixed addon. Full suite: 2511 passed.

Stacked on #337 (→ #336) — retarget as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRngq6vZGXxBMQKnhD7CxX