### PR TITLE
fix(cli): restore the host terminal after cage exec/shell sessions end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`cage exec` / `cage shell` now restore the host terminal after the session ends — however it ends.** A full-screen program inside the cage (pi, claude, vim, less) switches the operator's terminal into modes it undoes on exit: raw input, bracketed paste, the Kitty keyboard protocol, xterm `modifyOtherKeys`, hidden cursor. It can't undo any of that when the cage is stopped, destroyed, or rebuilt underneath it — the microVM/container is gone before the program can write its restore sequence, and the exec client just closes. The visible result, reported with pi on apple-container: after `cage stop`/`cage update` with a pi session open, every keystroke in iTerm2 echoes an escape sequence (pi pushes Kitty flags that include key-*release* reporting, and `reset` doesn't clear them). The CLI is the only party still alive to clean up, so interactive sessions now run as a child of `agentcage` instead of replacing it via `os.execvp`; when the child exits the CLI restores the saved termios state and writes a fixed restore sequence (Kitty pop + flags-to-zero, `modifyOtherKeys` off, bracketed paste/focus/mouse reporting off, cursor visible, SGR reset — each a no-op on a clean terminal). Ctrl-C is diverted in the parent for the duration so it still reaches the program in the cage. Non-interactive invocations (no tty on stdin) keep the previous exec/subprocess semantics; signal deaths now surface as shell-style `128+N` exit codes on every backend. Recovery on an already-mangled terminal, without upgrading: `printf '\e[<u\e[=0;1u\e[?2004l\e[>4;0m'`.
+
 ## [0.40.0] - 2026-09-07
 
 ### Changed

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -94,6 +94,20 @@ agentcage cage audit myapp --decision blocked --inspector secrets --since 7d
 
 Full filter set in [CLI — cage audit](../reference/cli.md#cage-audit).
 
+## The terminal is garbled after a cage session
+
+Symptom: after `cage exec` or `cage shell` ends, the shell prompt is back but every keystroke echoes stray characters (typically `[97;1:3u`-style sequences), pasted text arrives wrapped in `[200~ ... [201~`, or the cursor is gone.
+
+Cause: a full-screen program inside the cage (pi, claude, vim, less) had switched your terminal into modes it undoes on exit — raw input, bracketed paste, the Kitty keyboard protocol with key-release reporting — and the cage was stopped, destroyed, or rebuilt underneath it, so it never got the chance. `reset` does not clear the Kitty keyboard modes.
+
+Since the release after 0.40.0, `cage exec` and `cage shell` restore the terminal themselves once the session ends, whatever ended it. On an older version, or for a terminal that is already garbled, run:
+
+```bash
+printf '\e[<u\e[=0;1u\e[?2004l\e[>4;0m\e[?25h'
+```
+
+or use your terminal's reset action (iTerm2: **Session → Reset**).
+
 ## Backend-specific quirks
 
 Full list in [Isolation modes](../explain/isolation-modes.md#known-limitations).

--- a/src/agentcage/cli.py
+++ b/src/agentcage/cli.py
@@ -32,7 +32,7 @@ from agentcage.audit import (
 from agentcage.config import load_config, validate_config, _LEVEL_ORDER
 from agentcage.podman import Podman
 from agentcage.backends import get_backend
-from agentcage import state, systemd
+from agentcage import state, systemd, terminal
 from agentcage.scaffold_brief import stage_scaffold_assets
 from agentcage.lima.instance import LimaInstance
 from agentcage.services import (
@@ -2594,16 +2594,18 @@ def cage_exec(name: str, service: str, command: tuple[str, ...], as_root: bool):
         click.echo(f"error: {e}", err=True)
         sys.exit(1)
 
-    # vm and apple-container backends want exec semantics (replace the
-    # current process); container backend's `podman exec` we run as a
-    # subprocess and propagate the exit code. Distinguishing here keeps
-    # the existing UX for both shapes — limactl shell + container exec
-    # benefit from os.execvp's tty handling, while podman exec on Linux
-    # has historically been run via subprocess.run.
+    # Interactive sessions run as a child of the CLI (not an exec hand-off) so
+    # the CLI is still around to restore the host terminal afterwards —
+    # a full-screen program (pi, claude, vim) that dies with the cage
+    # never gets to undo raw mode / Kitty keyboard / bracketed paste
+    # itself. See agentcage.terminal. Non-interactive invocations keep
+    # exec semantics on vm / apple-container and subprocess semantics
+    # on the container backend, exactly as before.
     if cfg.isolation in ("vm", "apple-container"):
-        os.execvp(argv[0], argv)
-    result = subprocess.run(argv)
-    sys.exit(result.returncode)
+        terminal.run_interactive(argv)
+    with terminal.restored_terminal():
+        result = subprocess.run(argv)
+    sys.exit(terminal.exit_status(result.returncode))
 
 
 @cage.command("shell")
@@ -2644,13 +2646,13 @@ def cage_shell(name: str, service: str, as_root: bool):
             )
             if result.returncode == 0:
                 exec_flags = ["-it"] if sys.stdin.isatty() else []
-                os.execvp("limactl", ["limactl", "shell", "--workdir", "/",
-                          inst.name, "--",
-                          "podman", "exec", "-u", spec, *exec_flags, container, shell])
+                terminal.run_interactive(
+                    ["limactl", "shell", "--workdir", "/", inst.name, "--",
+                     "podman", "exec", "-u", spec, *exec_flags, container, shell])
         exec_flags = ["-it"] if sys.stdin.isatty() else []
-        os.execvp("limactl", ["limactl", "shell", "--workdir", "/",
-                  inst.name, "--",
-                  "podman", "exec", "-u", spec, *exec_flags, container, "/bin/sh"])
+        terminal.run_interactive(
+            ["limactl", "shell", "--workdir", "/", inst.name, "--",
+             "podman", "exec", "-u", spec, *exec_flags, container, "/bin/sh"])
 
     if _is_apple_container(cfg):
         _require_cage_service_on_apple_container(service, "shell")
@@ -2679,7 +2681,8 @@ def cage_shell(name: str, service: str, as_root: bool):
         if as_root:
             # Operator debug path — image's USER (root on wrapper),
             # full cap set, NoNewPrivs=0. For apt-get install etc.
-            os.execvp(binary, [binary, "exec", *exec_flags, name, chosen_shell])
+            terminal.run_interactive(
+                [binary, "exec", *exec_flags, name, chosen_shell])
         # Secure default — wrap in capsh exactly like the supervisor's
         # stage-90 privilege drop: NoNewPrivs=1 + drop=all (CapBnd=0)
         # + setuid to the uid-1000 user (resolved by name via getent;
@@ -2695,7 +2698,7 @@ def cage_shell(name: str, service: str, as_root: bool):
             "--user=\"$CAGE_USER\" --shell=/bin/sh "
             f"-- -c 'exec {chosen_shell}'"
         )
-        os.execvp(binary, [
+        terminal.run_interactive([
             binary, "exec", "-u", "0", *exec_flags, name,
             "/bin/sh", "-c", inner,
         ])
@@ -2715,10 +2718,12 @@ def cage_shell(name: str, service: str, as_root: bool):
         )
         if result.returncode == 0:
             exec_flags = ["-it"] if sys.stdin.isatty() else []
-            os.execvp("podman", ["podman", "exec", "-u", spec, *exec_flags, container, shell])
+            terminal.run_interactive(
+                ["podman", "exec", "-u", spec, *exec_flags, container, shell])
     # Fallback
     exec_flags = ["-it"] if sys.stdin.isatty() else []
-    os.execvp("podman", ["podman", "exec", "-u", spec, *exec_flags, container, "/bin/sh"])
+    terminal.run_interactive(
+        ["podman", "exec", "-u", spec, *exec_flags, container, "/bin/sh"])
 
 
 # ── cage audit ─────────────────────────────────────────────

--- a/src/agentcage/terminal.py
+++ b/src/agentcage/terminal.py
@@ -1,0 +1,163 @@
+"""Host terminal hygiene around interactive cage sessions.
+
+``cage exec`` / ``cage shell`` hand the operator's terminal to a program
+running *inside* the cage (``container exec -it``, ``podman exec -it``,
+``limactl shell``). Full-screen programs in there — pi, claude, vim, less —
+switch the host terminal into modes they promise to undo on exit: raw
+input, bracketed paste, the Kitty keyboard protocol (whose key-*release*
+reporting makes every later keystroke echo an escape sequence), xterm
+``modifyOtherKeys``, focus/mouse reporting, hidden cursor.
+
+They keep that promise when they exit on their own terms. They cannot when
+the cage is stopped, destroyed, or rebuilt underneath them: the microVM /
+container vanishes, the program is gone before it can write its restore
+sequence, and the exec client simply closes. The operator is left with a
+mangled terminal and no idea why (``reset`` usually doesn't fix Kitty mode).
+
+The program inside the cage can't help — it's dead. The exec client doesn't
+know what modes the program pushed. The only party that can reliably clean
+up is the agentcage CLI on the host, *after* the session ends. Hence this
+module: :func:`run_interactive` replaces the former ``os.execvp`` hand-off
+with a child process plus an unconditional post-session restore.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from contextlib import contextmanager
+from typing import Iterator, NoReturn
+
+# Written to the terminal after every interactive session. Each item is a
+# no-op on a terminal that's already in that state, so it's safe to send
+# unconditionally — including to terminals that don't implement the
+# corresponding protocol (unknown CSI sequences are ignored).
+RESTORE_SEQUENCE = (
+    b"\x1b[<u"        # Kitty keyboard protocol: pop one flags entry
+    b"\x1b[=0;1u"     # Kitty keyboard protocol: force current flags to 0
+    b"\x1b[>4;0m"     # xterm modifyOtherKeys off
+    b"\x1b[?2004l"    # bracketed paste off
+    b"\x1b[?1004l"    # focus reporting off
+    b"\x1b[?1000l"    # mouse tracking off (all variants)
+    b"\x1b[?1002l"
+    b"\x1b[?1003l"
+    b"\x1b[?1006l"
+    b"\x1b[?2026l"    # synchronized output: end any open frame
+    b"\x1b[?25h"      # cursor visible
+    b"\x1b[0m"        # SGR reset
+)
+
+
+def is_interactive() -> bool:
+    """True when stdin is a terminal.
+
+    This is the same test the backends use to decide whether to allocate a
+    pty (``-it``) — and therefore whether the program inside the cage can
+    have touched the host terminal at all. It is deliberately ``sys.stdin``
+    rather than fd 0: test harnesses (click's ``CliRunner``, pytest) swap
+    ``sys.stdin`` for a non-tty object while leaving fd 0 attached to the
+    developer's terminal.
+    """
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def controlling_tty_fd() -> int | None:
+    """Return a file descriptor on the controlling terminal, or ``None``.
+
+    Prefers stdout (where the session's output went), then stderr, then
+    stdin — the last covers ``cage exec ... | tee`` style invocations where
+    only stdin is still the terminal.
+    """
+    for fd in (1, 2, 0):
+        try:
+            if os.isatty(fd):
+                return fd
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _ignore_sigint(signum, frame) -> None:  # pragma: no cover - trivial
+    # A Python-level handler (rather than SIG_IGN) so that the disposition
+    # is NOT inherited across exec: children start with SIG_DFL. SIG_IGN
+    # *would* survive exec and silently make Ctrl-C a no-op inside the cage.
+    return None
+
+
+@contextmanager
+def restored_terminal() -> Iterator[None]:
+    """Snapshot the controlling terminal; put it back when the block ends.
+
+    Restores the termios attributes (raw mode, echo, ...) and writes
+    :data:`RESTORE_SEQUENCE` to undo terminal-application modes, whether
+    the block exits normally or via an exception. SIGINT is diverted to a
+    no-op in the *parent* for the duration, so Ctrl-C reaches the session's
+    child process instead of unwinding the CLI mid-session (children still
+    get the default disposition — see :func:`_ignore_sigint`).
+
+    A no-op when the session isn't interactive or no terminal is attached.
+    """
+    if not is_interactive():
+        yield
+        return
+    fd = controlling_tty_fd()
+    if fd is None:
+        yield
+        return
+
+    import termios  # POSIX only; agentcage doesn't run on Windows.
+
+    try:
+        saved = termios.tcgetattr(fd)
+    except termios.error:
+        saved = None
+
+    previous = signal.signal(signal.SIGINT, _ignore_sigint)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, previous)
+        if saved is not None:
+            try:
+                termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+            except termios.error:
+                pass
+        try:
+            os.write(fd, RESTORE_SEQUENCE)
+        except OSError:
+            pass
+
+
+def exit_status(returncode: int) -> int:
+    """Map a ``subprocess`` return code to a shell-style exit status.
+
+    ``subprocess`` reports a signal death as ``-signum``; shells report it
+    as ``128 + signum``. Callers that scripted around the old ``os.execvp``
+    hand-off saw the latter, so keep it.
+    """
+    if returncode < 0:
+        return 128 + (-returncode)
+    return returncode
+
+
+def run_interactive(argv: list[str]) -> NoReturn:
+    """Run ``argv`` as the operator's session and exit with its status,
+    restoring the host terminal afterwards.
+
+    Without a terminal on stdin there is nothing to restore, so this keeps
+    the historical ``os.execvp`` semantics (agentcage is replaced by the
+    exec client; the exit status is the client's). With a terminal, the
+    client runs as a child so that the CLI is still alive to clean up once
+    the session ends — however it ends.
+    """
+    if not is_interactive():
+        os.execvp(argv[0], argv)
+        raise AssertionError("unreachable")  # pragma: no cover
+    with restored_terminal():
+        proc = subprocess.run(argv)
+    sys.exit(exit_status(proc.returncode))

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,167 @@
+"""Tests for agentcage.terminal — host terminal restore around cage sessions."""
+
+import os
+import pty
+import select
+import signal
+import sys
+import termios
+from unittest.mock import patch
+
+import pytest
+
+from agentcage import terminal
+
+
+def _drain(fd: int, timeout: float = 0.5) -> bytes:
+    out = b""
+    while True:
+        r, _, _ = select.select([fd], [], [], timeout)
+        if not r:
+            return out
+        chunk = os.read(fd, 4096)
+        if not chunk:
+            return out
+        out += chunk
+
+
+@pytest.fixture
+def fake_tty():
+    """A pty pair, with the module convinced the slave is the controlling tty."""
+    master, slave = pty.openpty()
+    with patch.object(terminal, "is_interactive", return_value=True), \
+         patch.object(terminal, "controlling_tty_fd", return_value=slave):
+        yield master, slave
+    os.close(master)
+    os.close(slave)
+
+
+class TestRestoreSequence:
+    def test_pops_kitty_and_clears_flags(self):
+        # Pop one level *and* zero the current flags — either alone leaves
+        # some terminals with key-release reporting on.
+        assert b"\x1b[<u" in terminal.RESTORE_SEQUENCE
+        assert b"\x1b[=0;1u" in terminal.RESTORE_SEQUENCE
+
+    def test_undoes_paste_modifyotherkeys_cursor(self):
+        assert b"\x1b[?2004l" in terminal.RESTORE_SEQUENCE
+        assert b"\x1b[>4;0m" in terminal.RESTORE_SEQUENCE
+        assert b"\x1b[?25h" in terminal.RESTORE_SEQUENCE
+
+    def test_never_touches_the_alternate_screen(self):
+        # DECRST 1049 on a terminal that isn't in the alternate screen also
+        # performs DECRC, which on some emulators homes the cursor over the
+        # prompt. Not worth it for a mode our own sessions don't leak.
+        assert b"1049" not in terminal.RESTORE_SEQUENCE
+
+
+class TestRestoredTerminal:
+    def test_writes_restore_sequence_on_normal_exit(self, fake_tty):
+        master, _ = fake_tty
+        with terminal.restored_terminal():
+            pass
+        assert _drain(master) == terminal.RESTORE_SEQUENCE
+
+    def test_writes_restore_sequence_on_exception(self, fake_tty):
+        master, _ = fake_tty
+        with pytest.raises(RuntimeError):
+            with terminal.restored_terminal():
+                raise RuntimeError("cage vanished")
+        assert _drain(master) == terminal.RESTORE_SEQUENCE
+
+    def test_restores_termios_after_block_left_raw_mode(self, fake_tty):
+        _, slave = fake_tty
+        before = termios.tcgetattr(slave)
+        assert before[3] & termios.ECHO
+        with terminal.restored_terminal():
+            # Simulate the exec client (or a dead program) leaving raw mode on.
+            attrs = termios.tcgetattr(slave)
+            attrs[3] &= ~(termios.ECHO | termios.ICANON)
+            termios.tcsetattr(slave, termios.TCSANOW, attrs)
+            assert not termios.tcgetattr(slave)[3] & termios.ECHO
+        after = termios.tcgetattr(slave)
+        assert after[3] & termios.ECHO
+        assert after[3] & termios.ICANON
+
+    def test_sigint_diverted_only_for_the_duration(self, fake_tty):
+        previous = signal.getsignal(signal.SIGINT)
+        with terminal.restored_terminal():
+            handler = signal.getsignal(signal.SIGINT)
+            assert handler is not previous
+            assert handler is not signal.SIG_IGN, (
+                "SIG_IGN would be inherited across exec and make Ctrl-C a "
+                "no-op inside the cage; use a Python handler instead"
+            )
+        assert signal.getsignal(signal.SIGINT) is previous
+
+    def test_noop_when_not_interactive(self):
+        with patch.object(terminal, "is_interactive", return_value=False), \
+             patch("os.write") as mock_write:
+            with terminal.restored_terminal():
+                pass
+        mock_write.assert_not_called()
+
+    def test_noop_when_no_tty_fd(self):
+        with patch.object(terminal, "is_interactive", return_value=True), \
+             patch.object(terminal, "controlling_tty_fd", return_value=None), \
+             patch("os.write") as mock_write:
+            with terminal.restored_terminal():
+                pass
+        mock_write.assert_not_called()
+
+
+class TestExitStatus:
+    @pytest.mark.parametrize("rc,expected", [
+        (0, 0), (1, 1), (129, 129), (137, 137),
+        (-signal.SIGINT, 130), (-signal.SIGKILL, 137), (-signal.SIGHUP, 129),
+    ])
+    def test_shell_style(self, rc, expected):
+        assert terminal.exit_status(rc) == expected
+
+
+class TestRunInteractive:
+    def test_non_interactive_keeps_exec_semantics(self):
+        with patch.object(terminal, "is_interactive", return_value=False), \
+             patch("os.execvp", side_effect=SystemExit(0)) as mock_execvp:
+            with pytest.raises(SystemExit):
+                terminal.run_interactive(["container", "exec", "-it", "x", "sh"])
+        mock_execvp.assert_called_once_with(
+            "container", ["container", "exec", "-it", "x", "sh"])
+
+    def test_interactive_runs_child_and_restores(self, fake_tty):
+        master, _ = fake_tty
+        # The child leaves the terminal dirty and dies by signal, the way a
+        # program does when its cage is destroyed underneath it.
+        argv = [sys.executable, "-c",
+                "import os, signal; os.kill(os.getpid(), signal.SIGKILL)"]
+        with pytest.raises(SystemExit) as exc:
+            terminal.run_interactive(argv)
+        assert exc.value.code == 128 + signal.SIGKILL
+        assert _drain(master) == terminal.RESTORE_SEQUENCE
+
+    def test_interactive_propagates_exit_code(self, fake_tty):
+        with pytest.raises(SystemExit) as exc:
+            terminal.run_interactive([sys.executable, "-c", "raise SystemExit(7)"])
+        assert exc.value.code == 7
+
+    def test_child_starts_with_default_sigint(self, fake_tty):
+        # The parent's SIGINT diversion must not leak into the session.
+        probe = ("import signal, sys; "
+                 "sys.exit(0 if signal.getsignal(signal.SIGINT) "
+                 "is signal.default_int_handler else 9)")
+        with pytest.raises(SystemExit) as exc:
+            terminal.run_interactive([sys.executable, "-c", probe])
+        assert exc.value.code == 0
+
+
+class TestCliWiring:
+    """cage exec / cage shell must go through the restore path."""
+
+    def test_cli_has_no_direct_exec_handoff_for_sessions(self):
+        import inspect
+        from agentcage import cli
+        for fn in (cli.cage_exec, cli.cage_shell):
+            src = inspect.getsource(fn.callback)
+            assert "os.execvp(" not in src, f"{fn.name} bypasses terminal restore"
+            assert "terminal.run_interactive" in src or \
+                   "terminal.restored_terminal" in src


### PR DESCRIPTION
## Problem

A full-screen program inside the cage (pi, claude, vim, less) switches the operator's terminal into modes it undoes on exit: raw input, bracketed paste, the Kitty keyboard protocol, xterm `modifyOtherKeys`, hidden cursor. It cannot undo any of that when the cage is stopped, destroyed, or rebuilt underneath it: the microVM/container is gone before the restore sequence is written, and the exec client simply closes.

Reported with pi on apple-container: after `cage stop` / `cage update` with a pi session open, every keystroke in iTerm2 echoes an escape sequence. pi pushes Kitty flags 7, which include key-*release* reporting, and `reset` does not clear it. Reproduced by SIGKILLing the `container exec` client under a pty: the host receives the Kitty push and never a pop.

## Fix

`cage exec` and `cage shell` used `os.execvp`, so nothing on the host survived the session to clean up. They now run the session as a child process when stdin is a TTY, via the new `agentcage.terminal` module:

- snapshot termios before the session, restore it after, whatever ended the session;
- write a fixed restore sequence: Kitty pop + flags-to-zero, `modifyOtherKeys` off, bracketed paste / focus / mouse reporting off, synchronized-output end, cursor visible, SGR reset. Each is a no-op on a clean terminal and ignored by terminals that lack the protocol;
- divert SIGINT in the parent with a Python handler (not `SIG_IGN`, which would be inherited across exec and make Ctrl-C a no-op inside the cage);
- map signal deaths to shell-style `128+N` exit codes on every backend.

Non-interactive invocations (no TTY on stdin) keep the previous exec / subprocess semantics, so scripts and existing tests are unchanged. The alternate-screen mode is deliberately not touched: `DECRST 1049` on a terminal that is not in the alternate screen also performs `DECRC`, which homes the cursor over the prompt on some emulators.

Also adds a troubleshooting entry with the one-liner recovery for an already-mangled terminal, and a changelog entry under Unreleased.

Verified end to end on apple-container with pi running through this branch's CLI under a pty and the exec client killed from outside: the host received the full restore sequence and exit status 137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
